### PR TITLE
feat: block direct commits and pushes to master

### DIFF
--- a/.claude/hooks/block-master-commits.sh
+++ b/.claude/hooks/block-master-commits.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# PreToolUse hook: block git commit and git push on master/main branch
+# Forces Claude to work in worktrees with feature branches and PRs.
+input=$(cat)
+command=$(echo "$input" | jq -r '.tool_input.command // empty')
+
+if [[ -z "$command" ]]; then
+  exit 0
+fi
+
+# Only check git commit and git push commands
+if ! echo "$command" | grep -qE 'git\s+(commit|push)'; then
+  exit 0
+fi
+
+# Check current branch
+current_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
+if [[ "$current_branch" == "master" || "$current_branch" == "main" ]]; then
+  cat <<EOF
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "deny",
+    "permissionDecisionReason": "BLOCKED: git commit/push on $current_branch is not allowed. Use a worktree with a feature branch and create a PR."
+  }
+}
+EOF
+  exit 0
+fi

--- a/scripts/common/pre-push
+++ b/scripts/common/pre-push
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Pre-push hook: block direct pushes to master and pushes from worktrees
+
+# Block pushes from worktree directories
+cwd=$(pwd)
+if [[ "$cwd" == */.claude/worktrees/* ]]; then
+  echo "BLOCKED: Push not allowed from worktree directory."
+  echo "Worktree branches must be reviewed before pushing."
+  echo "Review the branch, then push from the main working directory."
+  exit 1
+fi
+
+# Block direct pushes to master — use PRs instead
+while read -r local_ref local_sha remote_ref remote_sha; do
+  if [[ "$remote_ref" == "refs/heads/master" || "$remote_ref" == "refs/heads/main" ]]; then
+    echo "BLOCKED: Direct push to master is not allowed."
+    echo "Create a feature branch and open a PR instead."
+    echo "(Use --no-verify to override in exceptional cases.)"
+    exit 1
+  fi
+done
+
+exit 0

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -12,4 +12,11 @@ exec "$(git rev-parse --show-toplevel)/scripts/common/pre-commit"
 EOF
 chmod +x "$HOOKS_DIR/pre-commit"
 
+echo "Installing pre-push hook..."
+cat > "$HOOKS_DIR/pre-push" << 'EOF'
+#!/bin/bash
+exec "$(git rev-parse --show-toplevel)/scripts/common/pre-push"
+EOF
+chmod +x "$HOOKS_DIR/pre-push"
+
 echo "Done. Hooks installed."


### PR DESCRIPTION
## Summary
- Add pre-push git hook (`scripts/common/pre-push`) that blocks pushes to master/main
- Add Claude Code hook (`block-master-commits.sh`) that blocks `git commit`/`git push` on master branch
- Wire pre-push hook into `setup-hooks.sh` for fresh clones

Enforces the worktree + feature branch + PR workflow.

## Test plan
- [ ] Run `echo "refs/heads/master x refs/heads/master y" | bash scripts/common/pre-push` — should block
- [ ] Run `echo "refs/heads/feature x refs/heads/feature y" | bash scripts/common/pre-push` — should pass
- [ ] Verify Claude Code blocks `git commit` on master via hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)