### PR TITLE
feat(rp): rewrite card generator to functional approach

### DIFF
--- a/projects/rp/routes.py
+++ b/projects/rp/routes.py
@@ -117,59 +117,107 @@ def setup(app: FastAPI, ollama, resolve_model=None):
 
     _card_gen_model = "q25"
 
+    _card_fields = {
+        "name": "A unique, memorable character name",
+        "description": "Physical appearance, background, key traits (2-3 paragraphs, vivid detail)",
+        "personality": "Personality traits, mannerisms, speech patterns (1-2 paragraphs)",
+        "first_mes": "Character's opening message in a scene, third person with dialogue (1-2 paragraphs)",
+        "mes_example": "2-3 example exchanges showing how the character speaks and acts",
+        "scenario": "A default scenario/setting for this character (1 paragraph)",
+        "tags": "Comma-separated genre/trait tags",
+    }
+
     @app.post("/rp/cards/generate")
     async def generate_card(request: Request):
-        """Generate or refine a character card via LLM conversation."""
+        """Generate a full character card from a description."""
         req = await request.json()
-        messages = req.get("messages", [])
-        if not messages:
-            raise HTTPException(400, "No messages provided")
+        description = req.get("description", "")
+        if not description:
+            raise HTTPException(400, "No description provided")
 
         system = (
-            "You are a character card designer for roleplay. "
-            "The user will describe a character and you will create a detailed character card.\n\n"
-            "Always respond with a JSON object containing these fields:\n"
-            "- name: character's name\n"
+            "You are a character card designer for roleplay.\n"
+            "Given a character concept, create a detailed card as a JSON object with these fields:\n"
+            "- name: character name\n"
             "- description: physical appearance, background, key traits (2-3 paragraphs)\n"
             "- personality: personality traits, mannerisms, speech patterns (1-2 paragraphs)\n"
-            "- first_mes: the character's opening message in a scene, written in third person with dialogue (1-2 paragraphs)\n"
-            "- mes_example: 2-3 example exchanges showing how the character speaks and acts\n"
-            "- scenario: a default scenario/setting for the character (1 paragraph)\n"
-            "- tags: array of genre/trait tags\n\n"
-            "Write vivid, specific descriptions. Give the character depth and quirks.\n"
-            "If the user asks for changes, return the COMPLETE updated card, not just the changes.\n\n"
-            "Respond with ONLY the JSON object, no markdown fences, no explanation."
+            "- first_mes: opening message in third person with dialogue (1-2 paragraphs)\n"
+            "- mes_example: 2-3 example exchanges as a single string\n"
+            "- scenario: default scenario (1 paragraph)\n"
+            "- tags: array of string tags\n\n"
+            "Write vivid, specific descriptions with depth and quirks.\n"
+            "Respond with ONLY the JSON object. No markdown fences, no explanation."
         )
-
-        # Build conversation for the LLM
-        llm_messages = [{"role": "system", "content": system}]
-        for m in messages:
-            llm_messages.append({"role": m["role"], "content": m["content"]})
 
         model = _resolve_model(_card_gen_model) if _resolve_model else _card_gen_model
         result = await _ollama.generate(
-            model=model,
-            prompt="\n".join(f"{m['role']}: {m['content']}" for m in llm_messages),
-            system=system,
-            options={"temperature": 0.7, "num_predict": 1024, "think": False},
+            model=model, prompt=description, system=system,
+            options={"temperature": 0.7, "num_predict": 2048, "think": False},
         )
+        card_data = _parse_card_json(result)
+        if card_data is None:
+            return {"error": "LLM returned invalid JSON", "raw": result.strip()}
+        return {"card": card_data}
 
+    @app.post("/rp/cards/generate-field")
+    async def generate_field(request: Request):
+        """Regenerate a single field of a character card."""
+        req = await request.json()
+        card = req.get("card", {})
+        field = req.get("field", "")
+        instructions = req.get("instructions", "")
+
+        if field not in _card_fields:
+            raise HTTPException(400, f"Unknown field: {field}")
+
+        field_desc = _card_fields[field]
+        prompt = (
+            f"Here is a character card:\n{json.dumps(card, indent=2)}\n\n"
+            f"Regenerate ONLY the '{field}' field.\n"
+            f"Field description: {field_desc}\n"
+        )
+        if instructions:
+            prompt += f"User instructions: {instructions}\n"
+        prompt += f"\nRespond with ONLY the new value for '{field}'. No JSON, no field name, just the content."
+
+        model = _resolve_model(_card_gen_model) if _resolve_model else _card_gen_model
+        result = await _ollama.generate(
+            model=model, prompt=prompt,
+            system="Output only the requested field content. No thinking, no preamble, no quotes around the value.",
+            options={"temperature": 0.7, "num_predict": 512, "think": False},
+        )
         clean = result.strip()
         if "<think>" in clean:
             clean = clean.split("</think>")[-1].strip()
-        # Strip markdown fences if present
+        # For tags field, try to parse as array
+        if field == "tags":
+            clean = [t.strip().strip('"') for t in clean.split(",")]
+        return {"field": field, "value": clean}
+
+    def _parse_card_json(raw: str):
+        """Parse LLM output as card JSON, handling common issues."""
+        clean = raw.strip()
+        if "<think>" in clean:
+            clean = clean.split("</think>")[-1].strip()
         if clean.startswith("```"):
             clean = clean.split("\n", 1)[1] if "\n" in clean else clean[3:]
         if clean.endswith("```"):
             clean = clean[:-3]
         clean = clean.strip()
-
         try:
-            card_data = json.loads(clean)
+            data = json.loads(clean)
         except json.JSONDecodeError:
-            return {"error": "LLM returned invalid JSON", "raw": clean}
-
-        return {"card": card_data}
+            return None
+        # Unwrap {card: ...} wrapper if present
+        if "card" in data and isinstance(data["card"], dict):
+            data = data["card"]
+        # Normalize mes_example: array -> joined string
+        if isinstance(data.get("mes_example"), list):
+            data["mes_example"] = "\n\n".join(data["mes_example"])
+        # Normalize tags: string -> array
+        if isinstance(data.get("tags"), str):
+            data["tags"] = [t.strip() for t in data["tags"].split(",")]
+        return data
 
     # -- Scenarios --
 

--- a/projects/rp/static/app.js
+++ b/projects/rp/static/app.js
@@ -949,85 +949,197 @@
   });
 
   // ---------------------------------------------------------------------------
-  // Card Generator (AI-assisted)
+  // Card Generator (AI-assisted, functional approach)
   // ---------------------------------------------------------------------------
-  var cardGenMessages = [];
   var cardGenCard = null;
 
+  var cardGenFieldDefs = [
+    { key: "name", label: "Name", rows: 1 },
+    { key: "description", label: "Description", rows: 4 },
+    { key: "personality", label: "Personality", rows: 3 },
+    { key: "first_mes", label: "First Message", rows: 3 },
+    { key: "mes_example", label: "Example Messages", rows: 3 },
+    { key: "scenario", label: "Scenario", rows: 2 },
+    { key: "tags", label: "Tags", rows: 1 },
+  ];
+
   $("generateCardBtn").addEventListener("click", () => {
-    cardGenMessages = [];
     cardGenCard = null;
-    $("cardGenChat").textContent = "";
-    $("cardGenInput").value = "";
-    $("cardGenPreview").style.display = "none";
+    $("cardGenDescription").value = "";
+    $("cardGenStatus").textContent = "";
+    $("cardGenStep1").style.display = "";
+    $("cardGenStep2").style.display = "none";
     $("cardGenerator").classList.add("open");
     $("cardEditor").classList.remove("open");
-    $("cardGenInput").focus();
+    $("cardGenDescription").focus();
   });
 
   $("cardGenCancel").addEventListener("click", () => {
     $("cardGenerator").classList.remove("open");
   });
+  $("cardGenCancelPreview").addEventListener("click", () => {
+    $("cardGenerator").classList.remove("open");
+  });
+  $("cardGenBack").addEventListener("click", () => {
+    $("cardGenStep1").style.display = "";
+    $("cardGenStep2").style.display = "none";
+  });
 
-  $("cardGenSend").addEventListener("click", cardGenSendMessage);
-  $("cardGenInput").addEventListener("keydown", (e) => {
+  $("cardGenGenerate").addEventListener("click", cardGenFullGenerate);
+  $("cardGenDescription").addEventListener("keydown", (e) => {
     if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
-      cardGenSendMessage();
+      cardGenFullGenerate();
     }
   });
 
-  async function cardGenSendMessage() {
-    var input = $("cardGenInput").value.trim();
-    if (!input) return;
+  async function cardGenFullGenerate() {
+    var desc = $("cardGenDescription").value.trim();
+    if (!desc) return;
 
-    cardGenMessages.push({ role: "user", content: input });
-    cardGenAppendMsg("user", input);
-    $("cardGenInput").value = "";
-    $("cardGenSend").disabled = true;
-    $("cardGenSend").textContent = "Thinking...";
+    $("cardGenGenerate").disabled = true;
+    $("cardGenStatus").textContent = "Generating...";
 
     try {
-      var resp = await api("POST", "/rp/cards/generate", { messages: cardGenMessages });
+      var resp = await api("POST", "/rp/cards/generate", { description: desc });
       if (resp.error) {
-        cardGenAppendMsg("assistant", "Error: " + resp.error + "\n\nRaw:\n" + (resp.raw || ""));
+        $("cardGenStatus").textContent = "Error: " + resp.error;
       } else {
         cardGenCard = resp.card;
-        cardGenMessages.push({ role: "assistant", content: JSON.stringify(cardGenCard) });
-        cardGenAppendMsg("assistant", "Card generated! See preview below. Send feedback to refine.");
-        cardGenShowPreview(cardGenCard);
+        cardGenRenderFields();
+        $("cardGenStep1").style.display = "none";
+        $("cardGenStep2").style.display = "";
+        $("cardGenStatus").textContent = "";
       }
     } catch (e) {
-      cardGenAppendMsg("assistant", "Request failed: " + e.message);
+      $("cardGenStatus").textContent = "Failed: " + e.message;
     }
 
-    $("cardGenSend").disabled = false;
-    $("cardGenSend").textContent = "Send";
+    $("cardGenGenerate").disabled = false;
   }
 
-  function cardGenAppendMsg(role, text) {
-    var div = document.createElement("div");
-    div.className = "gen-msg " + role;
-    div.textContent = text;
-    $("cardGenChat").appendChild(div);
-    $("cardGenChat").scrollTop = $("cardGenChat").scrollHeight;
+  function cardGenRenderFields() {
+    var container = $("cardGenFields");
+    container.innerHTML = "";
+    for (var def of cardGenFieldDefs) {
+      var val = cardGenCard[def.key] || "";
+      if (def.key === "tags" && Array.isArray(val)) val = val.join(", ");
+
+      var fieldDiv = document.createElement("div");
+      fieldDiv.className = "card-gen-field";
+
+      var header = document.createElement("div");
+      header.className = "card-gen-field-header";
+      var label = document.createElement("label");
+      label.textContent = def.label;
+      var regenBtn = document.createElement("button");
+      regenBtn.textContent = "Regenerate";
+      regenBtn.dataset.field = def.key;
+      regenBtn.addEventListener("click", cardGenToggleInstructions);
+      header.appendChild(label);
+      header.appendChild(regenBtn);
+
+      var textarea = document.createElement("textarea");
+      textarea.id = "cardGen_" + def.key;
+      textarea.rows = def.rows;
+      textarea.value = val;
+      textarea.addEventListener("input", cardGenFieldEdited);
+      textarea.dataset.field = def.key;
+
+      var instrDiv = document.createElement("div");
+      instrDiv.className = "card-gen-field-instructions";
+      instrDiv.id = "cardGenInstr_" + def.key;
+      var instrInput = document.createElement("input");
+      instrInput.type = "text";
+      instrInput.placeholder = "Instructions (optional)";
+      instrInput.id = "cardGenInstrInput_" + def.key;
+      var instrGo = document.createElement("button");
+      instrGo.textContent = "Go";
+      instrGo.dataset.field = def.key;
+      instrGo.addEventListener("click", cardGenRegenField);
+      instrDiv.appendChild(instrInput);
+      instrDiv.appendChild(instrGo);
+
+      fieldDiv.appendChild(header);
+      fieldDiv.appendChild(textarea);
+      fieldDiv.appendChild(instrDiv);
+      container.appendChild(fieldDiv);
+    }
   }
 
-  function cardGenShowPreview(card) {
-    var lines = [];
-    lines.push("Name: " + (card.name || ""));
-    lines.push("\nDescription:\n" + (card.description || ""));
-    lines.push("\nPersonality:\n" + (card.personality || ""));
-    lines.push("\nFirst Message:\n" + (card.first_mes || ""));
-    lines.push("\nScenario:\n" + (card.scenario || ""));
-    lines.push("\nExample Messages:\n" + (card.mes_example || ""));
-    lines.push("\nTags: " + (card.tags || []).join(", "));
-    $("cardGenPreviewContent").textContent = lines.join("\n");
-    $("cardGenPreview").style.display = "";
+  function cardGenToggleInstructions(e) {
+    var field = e.target.dataset.field;
+    var instrDiv = $("cardGenInstr_" + field);
+    instrDiv.classList.toggle("open");
+    if (instrDiv.classList.contains("open")) {
+      $("cardGenInstrInput_" + field).focus();
+    }
+  }
+
+  function cardGenFieldEdited(e) {
+    var field = e.target.dataset.field;
+    var val = e.target.value;
+    if (field === "tags") {
+      cardGenCard[field] = val.split(",").map(function(t) { return t.trim(); });
+    } else {
+      cardGenCard[field] = val;
+    }
+  }
+
+  async function cardGenRegenField(e) {
+    var field = e.target.dataset.field;
+    var instructions = $("cardGenInstrInput_" + field).value.trim();
+    var btn = e.target;
+    var regenBtn = btn.closest(".card-gen-field").querySelector(".card-gen-field-header button");
+
+    btn.disabled = true;
+    regenBtn.disabled = true;
+    regenBtn.textContent = "...";
+
+    // Sync current field values into cardGenCard before sending
+    for (var def of cardGenFieldDefs) {
+      var ta = $("cardGen_" + def.key);
+      if (ta) {
+        if (def.key === "tags") {
+          cardGenCard[def.key] = ta.value.split(",").map(function(t) { return t.trim(); });
+        } else {
+          cardGenCard[def.key] = ta.value;
+        }
+      }
+    }
+
+    try {
+      var resp = await api("POST", "/rp/cards/generate-field", {
+        card: cardGenCard,
+        field: field,
+        instructions: instructions,
+      });
+      cardGenCard[field] = resp.value;
+      var ta = $("cardGen_" + field);
+      ta.value = Array.isArray(resp.value) ? resp.value.join(", ") : resp.value;
+    } catch (err) {
+      regenBtn.textContent = "Failed";
+      regenBtn.style.color = "#f85149";
+      setTimeout(function() { regenBtn.style.color = ""; regenBtn.textContent = "Regenerate"; }, 2000);
+    }
+
+    btn.disabled = false;
+    regenBtn.disabled = false;
   }
 
   $("cardGenCreate").addEventListener("click", async () => {
     if (!cardGenCard) return;
+    // Sync final field values
+    for (var def of cardGenFieldDefs) {
+      var ta = $("cardGen_" + def.key);
+      if (ta) {
+        if (def.key === "tags") {
+          cardGenCard[def.key] = ta.value.split(",").map(function(t) { return t.trim(); });
+        } else {
+          cardGenCard[def.key] = ta.value;
+        }
+      }
+    }
     var card = cardGenCard;
     var data = {
       name: card.name || "Untitled",

--- a/projects/rp/static/index.html
+++ b/projects/rp/static/index.html
@@ -496,19 +496,76 @@
   }
   .card-generator.open { display: block; }
   .card-generator h3 { font-size: 0.95em; color: #f0f6fc; margin-bottom: 12px; }
-  .card-gen-chat {
-    max-height: 200px;
-    overflow-y: auto;
-    font-size: 0.82em;
-    color: #c9d1d9;
-  }
-  .card-gen-chat .gen-msg {
-    margin-bottom: 8px;
-    padding: 6px 10px;
+  .card-gen-field {
+    margin-bottom: 10px;
+    border: 1px solid #30363d;
     border-radius: 6px;
+    padding: 10px;
+    background: #0d1117;
   }
-  .card-gen-chat .gen-msg.user { background: #1c2333; color: #58a6ff; }
-  .card-gen-chat .gen-msg.assistant { background: #1c2d1c; color: #8b949e; }
+  .card-gen-field-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 4px;
+  }
+  .card-gen-field-header label {
+    font-size: 0.7em;
+    color: #8b949e;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+  }
+  .card-gen-field-header button {
+    font-size: 0.7em;
+    background: #21262d;
+    border: 1px solid #30363d;
+    color: #8b949e;
+    border-radius: 4px;
+    padding: 2px 8px;
+    cursor: pointer;
+    font-family: inherit;
+  }
+  .card-gen-field-header button:hover { color: #8957e5; border-color: #8957e5; }
+  .card-gen-field-header button:disabled { opacity: 0.5; cursor: not-allowed; }
+  .card-gen-field textarea {
+    width: 100%;
+    background: #161b22;
+    border: 1px solid #30363d;
+    border-radius: 4px;
+    color: #c9d1d9;
+    padding: 6px 8px;
+    font-family: inherit;
+    font-size: 0.82em;
+    resize: vertical;
+    min-height: 40px;
+  }
+  .card-gen-field textarea:focus { outline: none; border-color: #58a6ff; }
+  .card-gen-field-instructions {
+    display: none;
+    margin-top: 4px;
+  }
+  .card-gen-field-instructions.open { display: flex; gap: 4px; }
+  .card-gen-field-instructions input {
+    flex: 1;
+    background: #161b22;
+    border: 1px solid #30363d;
+    border-radius: 4px;
+    color: #c9d1d9;
+    padding: 4px 6px;
+    font-family: inherit;
+    font-size: 0.78em;
+  }
+  .card-gen-field-instructions input:focus { outline: none; border-color: #8957e5; }
+  .card-gen-field-instructions button {
+    font-size: 0.75em;
+    background: #8957e5;
+    border: none;
+    color: #fff;
+    border-radius: 4px;
+    padding: 4px 10px;
+    cursor: pointer;
+    font-family: inherit;
+  }
   .card-editor h3 {
     font-size: 0.95em;
     color: #f0f6fc;
@@ -876,17 +933,23 @@
         </div>
         <div class="card-generator" id="cardGenerator">
           <h3>Generate Character Card</h3>
-          <div class="card-gen-chat" id="cardGenChat"></div>
-          <div style="display:flex;gap:8px;margin-top:8px">
-            <textarea id="cardGenInput" rows="2" placeholder="Describe a character... or request changes" style="flex:1"></textarea>
-            <button id="cardGenSend" style="align-self:flex-end">Send</button>
-          </div>
-          <div id="cardGenPreview" style="display:none;margin-top:12px">
-            <h4 style="color:#f0f6fc;font-size:0.85em;margin-bottom:8px">Preview</h4>
-            <div id="cardGenPreviewContent" style="background:#0d1117;border:1px solid #30363d;border-radius:8px;padding:12px;font-size:0.82em;color:#c9d1d9;max-height:300px;overflow-y:auto;white-space:pre-wrap"></div>
-            <div style="display:flex;gap:8px;margin-top:8px">
-              <button id="cardGenCreate" style="background:#238636">Create Card</button>
+          <div id="cardGenStep1">
+            <div class="form-group">
+              <label for="cardGenDescription">Describe your character</label>
+              <textarea id="cardGenDescription" rows="3" placeholder="A cheerful elven bard who travels from town to town..."></textarea>
+            </div>
+            <div style="display:flex;gap:8px;align-items:center">
+              <button id="cardGenGenerate" class="btn-primary" style="background:#8957e5">Generate</button>
               <button id="cardGenCancel" class="btn-secondary">Cancel</button>
+              <span id="cardGenStatus" style="font-size:0.8em;color:#8b949e"></span>
+            </div>
+          </div>
+          <div id="cardGenStep2" style="display:none">
+            <div id="cardGenFields"></div>
+            <div style="display:flex;gap:8px;margin-top:12px">
+              <button id="cardGenCreate" class="btn-primary">Create Card</button>
+              <button id="cardGenBack" class="btn-secondary">Back</button>
+              <button id="cardGenCancelPreview" class="btn-secondary">Cancel</button>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Replace chat-based card generation (broken with 7B models) with two-step functional flow
- Step 1: enter description, generate full card via `POST /rp/cards/generate`
- Step 2: editable preview with per-field regeneration via `POST /rp/cards/generate-field`
- Backend: add `generate-field` endpoint, extract `_parse_card_json` helper, increase `num_predict` to 2048
- Frontend: replace chat UI with description input + editable field cards with inline regenerate buttons

## Test plan
```bash
cd /mnt/d/prg/plum-worktrees/rp-card-gen-functional
# Start the server and open the UI
# Navigate to Cards view, click "Generate"
# Enter a character description, click Generate
# Verify card fields appear as editable textareas
# Edit a field manually, verify it persists
# Click "Regenerate" on a field, optionally add instructions, click "Go"
# Verify the field updates with new content
# Click "Create Card" to save
# Verify the card appears in the cards list
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)