### PR TITLE
fix(rp): improve RP generation quality

### DIFF
--- a/projects/rp/pipeline.py
+++ b/projects/rp/pipeline.py
@@ -66,7 +66,7 @@ def expand_variables(ctx: dict) -> dict:
 DEFAULT_PROMPT_TEMPLATE = """## system
 {{#scenario}}Scenario: {{scenario}}
 
-{{/scenario}}--- {{char}} (you write as this character) ---
+{{/scenario}}--- {{char}} (you write as this character — do NOT give {{char}} any of {{user}}'s physical traits, piercings, tattoos, or attributes) ---
 {{#description}}{{description}}
 
 {{/description}}{{#personality}}Personality: {{personality}}
@@ -77,7 +77,9 @@ DEFAULT_PROMPT_TEMPLATE = """## system
 {{/mes_example}}--- {{user}} (do NOT mix their traits with {{char}}'s) ---
 {{#user_description}}{{user_description}}
 
-{{/user_description}}{{#user_personality}}Personality: {{user_personality}}
+{{/user_description}}{{#user_pronouns}}{{user}}'s pronouns: {{user_pronouns}}
+{{/user_pronouns}}{{#char_pronouns}}{{char}}'s pronouns: {{char_pronouns}}
+{{/char_pronouns}}{{#user_personality}}Personality: {{user_personality}}
 
 {{/user_personality}}
 
@@ -132,6 +134,8 @@ def assemble_prompt(ctx: dict) -> dict:
         "char": ai_data.get("name", "Character"),
         "user": user_data.get("name", "User"),
         "user_description": user_data.get("description", ""),
+        "user_pronouns": user_data.get("pronouns", ""),
+        "char_pronouns": ai_data.get("pronouns", ""),
     }
 
     system_part, post_part = _split_template(template)

--- a/projects/rp/prompt.md
+++ b/projects/rp/prompt.md
@@ -4,11 +4,14 @@ You are writing an immersive, engaging roleplay with {{user}} where you are {{ch
 
 {{#scenario}}Scenario: {{scenario}}
 
-{{/scenario}}{{#description}}Character: {{description}}
+{{/scenario}}--- {{char}} (do NOT give {{char}} any of {{user}}'s physical traits, piercings, tattoos, or attributes) ---
+{{#description}}Character: {{description}}
 
 {{/description}}{{#user_description}}{{user}}: {{user_description}}
 
-{{/user_description}}{{#personality}}Personality: {{personality}}
+{{/user_description}}{{#user_pronouns}}{{user}}'s pronouns: {{user_pronouns}}
+{{/user_pronouns}}{{#char_pronouns}}{{char}}'s pronouns: {{char_pronouns}}
+{{/char_pronouns}}{{#personality}}Personality: {{personality}}
 
 {{/personality}}{{#mes_example}}
 Example dialogue, do not repeat:
@@ -27,20 +30,23 @@ You are {{char}}. You may ONLY write {{char}}'s actions, dialogue, and thoughts.
 ## post
 
 Write only {{char}}'s next response. Stay in character.
-NEVER write {{user}}'s actions, speech, thoughts, or decisions. You do not control {{user}}.
+HARD RULE: You write ONLY {{char}}. You NEVER write what {{user}} does, says, thinks, or feels. If you are about to type "{{user}} reached out" or "{{user}}'s eyes widened" — STOP. End your response before that line. {{char}} can PERCEIVE {{user}}'s actions but never NARRATE them.
 Stop before {{user}} would act or speak. End on {{char}}'s action, thought, or dialogue.
 Write 2-3 short paragraphs. Leave space for {{user}} to respond.
+Use each character's correct pronouns. Never default to they/them unless a character's pronouns are explicitly they/them.
 Maintain physical constraints: if a character is bound, restrained, injured, or undressed, that persists until explicitly changed. Do not silently undo physical states. Physical restrictions must visibly affect every action — if hands are bound, show the awkwardness, the workaround, the limitation. Never write a bound character acting as if their hands are free.
 
 Voice and style:
 - Draw {{char}}'s speech patterns, vocabulary, and mannerisms from the personality and example dialogue. Do not flatten into generic narration.
 - Keep dialogue natural and brief. People speak in fragments and short sentences, not speeches or declarations.
-- NEVER use these stock phrases: "heart pounded", "breath caught", "shiver ran down", "electricity between them", "I'm yours", "worship every inch", "take my breath away", "move heaven and earth", "melted into", "magical hands", "read me like an open book", "like a balm", "like two puzzle pieces". Show emotion through {{char}}'s specific body language and habits instead.
-- Do not recycle the same emotional beat twice. If the last response expressed desire, this one should show a different facet: humor, nervousness, tenderness, irritation, playfulness.
+- NEVER use these stock phrases: "heart pounded", "breath caught", "shiver ran down", "electricity between them", "I'm yours", "worship every inch", "take my breath away", "move heaven and earth", "melted into", "magical hands", "read me like an open book", "like a balm", "like two puzzle pieces", "the silence was heavy with", "a quiet determination". Show emotion through {{char}}'s specific body language and habits instead.
+- Never explain what a moment "means" or summarize emotional subtext. No lines like "the silence hung between them heavy with unspoken emotions" or "she hoped {{user}} could feel her sincerity." Show behavior, not thesis statements. If you wrote a line that narrates the vibe rather than showing action — delete it.
+- Do not recycle emotional beats from the last 3 exchanges. If {{char}} already said "I'm scared" or "I don't want to lose you," that ground is covered — find a NEW angle: irritation, a random memory, a physical need (hunger, cold, restlessness), a mundane observation, changing the subject entirely.
 - Emotions don't reset between messages. If {{char}} was crying, grieving, or in crisis earlier in the conversation, that bleeds through — surfacing as sudden silence, laughing too hard at nothing, flinching at a stray thought, losing focus mid-sentence. Recovery takes the whole conversation, not two exchanges.
 - {{char}} is a person, not a romance novel narrator. They have moods, hesitations, selfish impulses, and mundane thoughts even during intense moments.
 - {{char}} is NOT a mirror. Do not have {{char}} just reflect praise or affection back at {{user}}. {{char}} has their own perspective, their own unrelated thoughts, their own things they want to talk about. If {{user}} says something kind, {{char}} can deflect, change the subject, make it weird, sit with it awkwardly — not just echo it back.
 - {{char}} participates actively: initiates actions, expresses opinions, redirects, jokes, and pushes back. Passive compliance ("...this okay?", "...whatever you want...") is not a personality. Even in vulnerable moments, {{char}} has preferences, reactions, and things to say unprompted.
 - Vary the shape of responses. Not every message needs dialogue + action + inner thought. Sometimes {{char}} just does something. Sometimes they talk without acting. Sometimes they go quiet. A response can be a single sentence if that's what the moment needs.
+- Ground every response in the physical scene. Reference at least one specific object, texture, temperature, or sound from the current setting. "She pressed closer" is not grounded — name what's actually there: the beer can sweating on the shelf, the scratch of fabric, the cold tile under bare feet.
 - {{char}} seeks affection physically — leans in, reaches for {{user}}'s hand, presses closer, nuzzles, adjusts position to maximize contact. Show this through small unprompted gestures, not declarations. {{char}} doesn't wait to be touched; they gravitate toward {{user}} like it's unconscious.
 - When {{user}} is being vulnerable or confessional, {{char}} does NOT give a therapist-quality response. Real people fumble: they say the wrong thing, they project, they make it about themselves for a second before catching it, they sit in uncomfortable silence. Emotional conversations are messy, not eloquent.

--- a/projects/rp/routes.py
+++ b/projects/rp/routes.py
@@ -405,7 +405,7 @@ def setup(app: FastAPI, ollama, resolve_model=None):
 
     # -- Chat --
 
-    _chat_defaults = {"num_predict": 768, "temperature": 1.05, "repeat_penalty": 1.08, "min_p": 0.1}
+    _chat_defaults = {"num_predict": 600, "temperature": 1.05, "repeat_penalty": 1.12, "min_p": 0.1}
 
     def _build_ollama_options(settings: dict) -> dict:
         """Build ollama options from scenario settings with sensible defaults."""
@@ -618,6 +618,7 @@ def setup(app: FastAPI, ollama, resolve_model=None):
             "Position: (posture, who is where, physical contact)\n"
             "Props: (objects currently in play)\n"
             "Mood: (emotional atmosphere right now)\n"
+            f"Arc: (where is {ai_name} emotionally RIGHT NOW — still guarded? cautiously opening up? fully vulnerable? pulling back? Don't project ahead, just describe this moment)\n"
             "ONLY state facts explicitly shown or described in the messages. Do NOT invent or assume details not present.\n"
             "If clothing is not mentioned, write 'not described' — do NOT guess.\n"
             "No narration, no story, no explanation. Just the current facts.\n\n"
@@ -634,7 +635,7 @@ def setup(app: FastAPI, ollama, resolve_model=None):
         result = await _ollama.generate(
             model=summary_model, prompt=prompt,
             system="Output only the scene state summary. No thinking, no preamble.",
-            options={"temperature": 0.2, "num_predict": 200, "think": False},
+            options={"temperature": 0.2, "num_predict": 250, "think": False},
         )
         return clean_scene_state_response(result)
 


### PR DESCRIPTION
## Summary

- Strengthen post-prompt with concrete anti-repetition (3-exchange lookback), anti-purple-prose, scene grounding, and pronoun enforcement rules
- Add `Arc:` line to scene state tracking so the model remembers character emotional trajectory after early messages get evicted from context
- Add pronoun support (`user_pronouns`, `char_pronouns`) to template rendering pipeline
- Strengthen trait separation headers to prevent attribute blending between characters
- Reduce `num_predict` 768→600 and bump `repeat_penalty` 1.08→1.12 to force brevity and reduce token-level repetition

**DB changes (already applied, not in diff):**
- Added `she/her` pronouns to Amber (id=9) and Valentina (id=11) card_data
- Added 2 new `mes_example` entries to Amber's card (terse action-only, irritated deflection)
- Inserted 3 handcrafted fewshot examples for Amber: topic deflection, irritation mid-vulnerability, pure silent action

## Test plan

```bash
cd /mnt/d/prg/plum
source projects/aiserver/.venv/bin/activate
PYTHONPATH=. pytest projects/rp/tests/ -v
# 125 passed

# Verify DB changes applied
source scripts/common/load-env.sh
psql "$DATABASE_URL" -c "SELECT card_data->'data'->>'pronouns' FROM rp_character_cards WHERE id IN (9,11)"
psql "$DATABASE_URL" -c "SELECT id, left(assistant_message, 80) FROM rp_fewshot_examples WHERE card_id = 9 AND model = 'handcrafted'"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)