### PR TITLE
feat(rp): implement conversation summary generation

### DIFF
--- a/projects/rp/db.py
+++ b/projects/rp/db.py
@@ -461,6 +461,42 @@ async def get_metrics(
     return [dict(r) for r in rows]
 
 
+# -- Summaries --
+
+async def save_summary(conv_id: int, summary: str, through_msg_id: int,
+                       through_sequence: int, msg_count: int,
+                       token_estimate: int) -> dict:
+    pool = await get_pool()
+    row = await pool.fetchrow(
+        "INSERT INTO rp_conversation_summaries "
+        "(conversation_id, summary, through_msg_id, through_sequence, "
+        "msg_count, token_estimate) "
+        "VALUES ($1, $2, $3, $4, $5, $6) "
+        "RETURNING id, conversation_id, summary, through_msg_id, "
+        "through_sequence, msg_count, token_estimate, created_at::text",
+        conv_id, summary, through_msg_id, through_sequence,
+        msg_count, token_estimate,
+    )
+    await pool.execute(
+        "UPDATE rp_conversations SET summary_msg_id = $1 WHERE id = $2",
+        through_msg_id, conv_id,
+    )
+    return dict(row)
+
+
+async def get_latest_summary(conv_id: int) -> dict | None:
+    pool = await get_pool()
+    row = await pool.fetchrow(
+        "SELECT id, conversation_id, summary, through_msg_id, through_sequence, "
+        "msg_count, token_estimate, created_at::text "
+        "FROM rp_conversation_summaries "
+        "WHERE conversation_id = $1 "
+        "ORDER BY through_sequence DESC LIMIT 1",
+        conv_id,
+    )
+    return dict(row) if row else None
+
+
 async def get_latest_metrics(
     target_type: str, target_id: str, domain: str,
     pool: "asyncpg.Pool | None" = None,

--- a/projects/rp/routes.py
+++ b/projects/rp/routes.py
@@ -17,6 +17,7 @@ from .pipeline import create_default_pipeline
 from .mcp_client import get_router as get_mcp_router
 from .research import research_dispatch
 from .fewshot import get_fewshot_messages
+from .summarize import maybe_generate_summary
 from . import conv_log
 
 # Priority levels from aiserver's inference queue (lower = higher priority).
@@ -436,22 +437,48 @@ def setup(app: FastAPI, ollama, resolve_model=None):
         if _template_path.exists():
             prompt_template = _template_path.read_text()
 
+        # Attach _sequence to each message so SummaryBuffer can filter
+        msg_dicts = []
+        for m in messages:
+            d = {"role": m["role"], "content": m["content"]}
+            d["_sequence"] = m.get("sequence", 0)
+            msg_dicts.append(d)
+
         ctx = {
             "user_card": user_card,
             "ai_card": ai_card,
             "scenario": scenario,
-            "messages": [{"role": m["role"], "content": m["content"]} for m in messages],
+            "messages": msg_dicts,
             "system_prompt": "",
             "post_prompt": "",
             "scene_state": conv.get("scene_state", ""),
             "prompt_template": prompt_template,
         }
+
+        # Load latest summary for SummaryBuffer context strategy
+        summary_row = await db.get_latest_summary(conv["id"])
+        if summary_row:
+            ctx["_summary"] = summary_row["summary"]
+            ctx["_summary_through_sequence"] = summary_row["through_sequence"]
+
         return await _pipeline.run_pre(ctx)
 
     def _get_ai_name(ctx):
         """Extract AI character name for response prefixing."""
         ai_data = ctx.get("ai_card", {}).get("card_data", {}).get("data", ctx.get("ai_card", {}).get("card_data", {}))
         return ai_data.get("name", "Character")
+
+    async def _maybe_summarize(conv_id: int, model: str,
+                               ai_name: str, user_name: str, ai_personality: str):
+        """Fire-and-forget summary generation if enough messages accumulated."""
+        try:
+            await maybe_generate_summary(
+                conv_id, _ollama, model,
+                char_name=ai_name, user_name=user_name,
+                ai_personality=ai_personality,
+            )
+        except Exception as e:
+            _log.warning("Summary generation failed for conv %d: %s", conv_id, e)
 
     async def _get_or_generate_first_message(conv, ai_card, user_card, scenario, model):
         """Check cache, return if fresh, otherwise generate and cache."""
@@ -777,8 +804,10 @@ def setup(app: FastAPI, ollama, resolve_model=None):
                 post_ctx = await _pipeline.run_post(post_ctx)
                 await db.add_message(conv_id, "assistant", post_ctx["response"], raw_response=raw)
                 conv_log.log_response(conv_id, "assistant", post_ctx["response"], raw)
-                # Update scene state in background
+                # Update scene state and maybe generate summary in background
                 asyncio.create_task(_auto_update_scene_state(conv_id, model,
+                                                _get_ai_name(ctx), _get_user_name(ctx), _get_ai_personality(ctx)))
+                asyncio.create_task(_maybe_summarize(conv_id, model,
                                                 _get_ai_name(ctx), _get_user_name(ctx), _get_ai_personality(ctx)))
             except Exception as e:
                 yield json.dumps({"error": f"Failed to save response: {e}", "done": True}) + "\n"
@@ -863,8 +892,10 @@ def setup(app: FastAPI, ollama, resolve_model=None):
                 post_ctx = await _pipeline.run_post(post_ctx)
                 await db.add_message(conv_id, "assistant", post_ctx["response"], raw_response=raw)
                 conv_log.log_response(conv_id, "assistant", post_ctx["response"], raw)
-                # Update scene state in background
+                # Update scene state and maybe generate summary in background
                 asyncio.create_task(_auto_update_scene_state(conv_id, model,
+                                                _get_ai_name(ctx), _get_user_name(ctx), _get_ai_personality(ctx)))
+                asyncio.create_task(_maybe_summarize(conv_id, model,
                                                 _get_ai_name(ctx), _get_user_name(ctx), _get_ai_personality(ctx)))
             except Exception as e:
                 yield json.dumps({"error": f"Failed to save response: {e}", "done": True}) + "\n"
@@ -919,8 +950,10 @@ def setup(app: FastAPI, ollama, resolve_model=None):
                 post_ctx = await _pipeline.run_post(post_ctx)
                 await db.add_message(conv_id, "assistant", post_ctx["response"], raw_response=raw)
                 conv_log.log_response(conv_id, "assistant", post_ctx["response"], raw)
-                # Update scene state in background
+                # Update scene state and maybe generate summary in background
                 asyncio.create_task(_auto_update_scene_state(conv_id, model,
+                                                _get_ai_name(ctx), _get_user_name(ctx), _get_ai_personality(ctx)))
+                asyncio.create_task(_maybe_summarize(conv_id, model,
                                                 _get_ai_name(ctx), _get_user_name(ctx), _get_ai_personality(ctx)))
             except Exception as e:
                 yield json.dumps({"error": f"Failed to save response: {e}", "done": True}) + "\n"
@@ -1024,8 +1057,10 @@ def setup(app: FastAPI, ollama, resolve_model=None):
                 post_ctx = await _pipeline.run_post(post_ctx)
                 await db.add_message(conv_id, save_role, post_ctx["response"], raw_response=raw)
                 conv_log.log_response(conv_id, save_role, post_ctx["response"], raw)
-                # Update scene state in background
+                # Update scene state and maybe generate summary in background
                 asyncio.create_task(_auto_update_scene_state(conv_id, model,
+                                                _get_ai_name(ctx), _get_user_name(ctx), _get_ai_personality(ctx)))
+                asyncio.create_task(_maybe_summarize(conv_id, model,
                                                 _get_ai_name(ctx), _get_user_name(ctx), _get_ai_personality(ctx)))
             except Exception as e:
                 yield json.dumps({"error": f"Failed to save response: {e}", "done": True}) + "\n"

--- a/projects/rp/summarize.py
+++ b/projects/rp/summarize.py
@@ -1,4 +1,16 @@
-"""Conversation summary prompt building and response cleaning."""
+"""Conversation summary generation, prompt building, and response cleaning.
+
+Generates rolling summaries of conversation history so the SummaryBuffer
+context strategy can inject them instead of losing older messages entirely.
+"""
+
+import logging
+
+from . import db
+
+_log = logging.getLogger("rp.summarize")
+
+SUMMARY_THRESHOLD = 10  # unsummarized messages before triggering
 
 
 def build_summary_prompt(messages: list[dict], previous_summary: str = "",
@@ -44,3 +56,66 @@ def clean_summary_response(raw: str) -> str:
     if "<think>" in clean:
         clean = clean.split("</think>")[-1].strip()
     return clean
+
+
+async def maybe_generate_summary(
+    conv_id: int,
+    ollama,
+    model: str,
+    char_name: str = "Character",
+    user_name: str = "User",
+    ai_personality: str = "",
+) -> dict | None:
+    """Generate a summary if enough unsummarized messages have accumulated.
+
+    Returns the saved summary row, or None if no summary was needed.
+    """
+    messages = await db.get_messages(conv_id)
+    if not messages:
+        return None
+
+    existing = await db.get_latest_summary(conv_id)
+    prev_summary = ""
+    prev_through_seq = 0
+
+    if existing:
+        prev_summary = existing["summary"]
+        prev_through_seq = existing["through_sequence"]
+
+    # Filter to messages after the last summary
+    new_msgs = [m for m in messages if m["sequence"] > prev_through_seq]
+    if len(new_msgs) < SUMMARY_THRESHOLD:
+        return None
+
+    prompt = build_summary_prompt(
+        [{"role": m["role"], "content": m["content"]} for m in new_msgs],
+        previous_summary=prev_summary,
+        char_name=char_name,
+        user_name=user_name,
+        ai_personality=ai_personality,
+    )
+
+    raw = await ollama.generate(
+        model=model, prompt=prompt,
+        system="Output only the summary. No thinking, no preamble.",
+        options={"temperature": 0.3, "num_predict": 600, "think": False},
+    )
+    summary = clean_summary_response(raw)
+    if not summary:
+        _log.warning("Empty summary generated for conv %d", conv_id)
+        return None
+
+    last_msg = new_msgs[-1]
+    token_estimate = len(summary) // 4
+
+    saved = await db.save_summary(
+        conv_id,
+        summary=summary,
+        through_msg_id=last_msg["id"],
+        through_sequence=last_msg["sequence"],
+        msg_count=len(new_msgs),
+        token_estimate=token_estimate,
+    )
+    _log.info("Generated summary for conv %d (through seq %d, %d msgs, ~%d tokens)",
+              conv_id, last_msg["sequence"], len(new_msgs), token_estimate)
+    return saved

--- a/projects/rp/tests/test_summarize.py
+++ b/projects/rp/tests/test_summarize.py
@@ -1,6 +1,5 @@
+import asyncio
 from unittest.mock import AsyncMock, patch
-
-import pytest
 
 from projects.rp.summarize import (
     build_summary_prompt,
@@ -119,111 +118,117 @@ def _make_messages(n):
 
 
 class TestMaybeGenerateSummary:
-    @pytest.mark.asyncio
-    async def test_skips_when_below_threshold(self):
+    def test_skips_when_below_threshold(self):
         """No summary generated when fewer than SUMMARY_THRESHOLD messages."""
-        few_msgs = _make_messages(3)  # 6 messages, below threshold of 10
-        with patch("projects.rp.summarize.db") as mock_db:
-            mock_db.get_messages = AsyncMock(return_value=few_msgs)
-            mock_db.get_latest_summary = AsyncMock(return_value=None)
+        async def run():
+            few_msgs = _make_messages(3)  # 6 messages, below threshold of 10
+            with patch("projects.rp.summarize.db") as mock_db:
+                mock_db.get_messages = AsyncMock(return_value=few_msgs)
+                mock_db.get_latest_summary = AsyncMock(return_value=None)
 
-            ollama = AsyncMock()
-            result = await maybe_generate_summary(1, ollama, "test-model")
+                ollama = AsyncMock()
+                result = await maybe_generate_summary(1, ollama, "test-model")
 
-            assert result is None
-            ollama.generate.assert_not_called()
+                assert result is None
+                ollama.generate.assert_not_called()
+        asyncio.run(run())
 
-    @pytest.mark.asyncio
-    async def test_generates_when_above_threshold(self):
+    def test_generates_when_above_threshold(self):
         """Summary generated when enough unsummarized messages exist."""
-        msgs = _make_messages(6)  # 12 messages, above threshold
-        with patch("projects.rp.summarize.db") as mock_db:
-            mock_db.get_messages = AsyncMock(return_value=msgs)
-            mock_db.get_latest_summary = AsyncMock(return_value=None)
-            mock_db.save_summary = AsyncMock(return_value={
-                "id": 1, "conversation_id": 1, "summary": "test summary",
-                "through_msg_id": 12, "through_sequence": 12,
-                "msg_count": 12, "token_estimate": 3,
-            })
+        async def run():
+            msgs = _make_messages(6)  # 12 messages, above threshold
+            with patch("projects.rp.summarize.db") as mock_db:
+                mock_db.get_messages = AsyncMock(return_value=msgs)
+                mock_db.get_latest_summary = AsyncMock(return_value=None)
+                mock_db.save_summary = AsyncMock(return_value={
+                    "id": 1, "conversation_id": 1, "summary": "test summary",
+                    "through_msg_id": 12, "through_sequence": 12,
+                    "msg_count": 12, "token_estimate": 3,
+                })
 
-            ollama = AsyncMock()
-            ollama.generate = AsyncMock(return_value="Test summary of conversation.")
+                ollama = AsyncMock()
+                ollama.generate = AsyncMock(return_value="Test summary of conversation.")
 
-            result = await maybe_generate_summary(1, ollama, "test-model",
-                                                  char_name="Amber", user_name="Val")
+                result = await maybe_generate_summary(1, ollama, "test-model",
+                                                      char_name="Amber", user_name="Val")
 
-            assert result is not None
-            ollama.generate.assert_called_once()
-            mock_db.save_summary.assert_called_once()
-            call_args = mock_db.save_summary.call_args
-            assert call_args[1]["through_msg_id"] == 12
-            assert call_args[1]["through_sequence"] == 12
-            assert call_args[1]["msg_count"] == 12
+                assert result is not None
+                ollama.generate.assert_called_once()
+                mock_db.save_summary.assert_called_once()
+                call_args = mock_db.save_summary.call_args
+                assert call_args[1]["through_msg_id"] == 12
+                assert call_args[1]["through_sequence"] == 12
+                assert call_args[1]["msg_count"] == 12
+        asyncio.run(run())
 
-    @pytest.mark.asyncio
-    async def test_only_counts_unsummarized_messages(self):
+    def test_only_counts_unsummarized_messages(self):
         """Only messages after the last summary count toward the threshold."""
-        msgs = _make_messages(8)  # 16 messages total
-        existing_summary = {
-            "summary": "Previous summary text.",
-            "through_sequence": 10,  # summary covers through sequence 10
-            "through_msg_id": 10,
-        }
-        with patch("projects.rp.summarize.db") as mock_db:
-            mock_db.get_messages = AsyncMock(return_value=msgs)
-            mock_db.get_latest_summary = AsyncMock(return_value=existing_summary)
+        async def run():
+            msgs = _make_messages(8)  # 16 messages total
+            existing_summary = {
+                "summary": "Previous summary text.",
+                "through_sequence": 10,  # summary covers through sequence 10
+                "through_msg_id": 10,
+            }
+            with patch("projects.rp.summarize.db") as mock_db:
+                mock_db.get_messages = AsyncMock(return_value=msgs)
+                mock_db.get_latest_summary = AsyncMock(return_value=existing_summary)
 
-            ollama = AsyncMock()
-            # 6 messages after sequence 10 (seqs 11-16), below threshold of 10
-            result = await maybe_generate_summary(1, ollama, "test-model")
+                ollama = AsyncMock()
+                # 6 messages after sequence 10 (seqs 11-16), below threshold of 10
+                result = await maybe_generate_summary(1, ollama, "test-model")
 
-            assert result is None
-            ollama.generate.assert_not_called()
+                assert result is None
+                ollama.generate.assert_not_called()
+        asyncio.run(run())
 
-    @pytest.mark.asyncio
-    async def test_includes_previous_summary_in_prompt(self):
+    def test_includes_previous_summary_in_prompt(self):
         """When extending a summary, the previous summary text is passed to the prompt."""
-        msgs = _make_messages(10)  # 20 messages
-        existing_summary = {
-            "summary": "They met at the park.",
-            "through_sequence": 4,  # only covers first 4
-            "through_msg_id": 4,
-        }
-        with patch("projects.rp.summarize.db") as mock_db:
-            mock_db.get_messages = AsyncMock(return_value=msgs)
-            mock_db.get_latest_summary = AsyncMock(return_value=existing_summary)
-            mock_db.save_summary = AsyncMock(return_value={"id": 2})
+        async def run():
+            msgs = _make_messages(10)  # 20 messages
+            existing_summary = {
+                "summary": "They met at the park.",
+                "through_sequence": 4,  # only covers first 4
+                "through_msg_id": 4,
+            }
+            with patch("projects.rp.summarize.db") as mock_db:
+                mock_db.get_messages = AsyncMock(return_value=msgs)
+                mock_db.get_latest_summary = AsyncMock(return_value=existing_summary)
+                mock_db.save_summary = AsyncMock(return_value={"id": 2})
 
-            ollama = AsyncMock()
-            ollama.generate = AsyncMock(return_value="Extended summary.")
+                ollama = AsyncMock()
+                ollama.generate = AsyncMock(return_value="Extended summary.")
 
-            await maybe_generate_summary(1, ollama, "test-model")
+                await maybe_generate_summary(1, ollama, "test-model")
 
-            # Check that the prompt included the previous summary
-            call_args = ollama.generate.call_args
-            assert "They met at the park" in call_args[1]["prompt"]
+                # Check that the prompt included the previous summary
+                call_args = ollama.generate.call_args
+                assert "They met at the park" in call_args[1]["prompt"]
+        asyncio.run(run())
 
-    @pytest.mark.asyncio
-    async def test_skips_on_empty_llm_response(self):
+    def test_skips_on_empty_llm_response(self):
         """Don't save if the LLM returns empty."""
-        msgs = _make_messages(6)
-        with patch("projects.rp.summarize.db") as mock_db:
-            mock_db.get_messages = AsyncMock(return_value=msgs)
-            mock_db.get_latest_summary = AsyncMock(return_value=None)
+        async def run():
+            msgs = _make_messages(6)
+            with patch("projects.rp.summarize.db") as mock_db:
+                mock_db.get_messages = AsyncMock(return_value=msgs)
+                mock_db.get_latest_summary = AsyncMock(return_value=None)
 
-            ollama = AsyncMock()
-            ollama.generate = AsyncMock(return_value="<think>reasoning</think>")
+                ollama = AsyncMock()
+                ollama.generate = AsyncMock(return_value="<think>reasoning</think>")
 
-            result = await maybe_generate_summary(1, ollama, "test-model")
+                result = await maybe_generate_summary(1, ollama, "test-model")
 
-            assert result is None
-            mock_db.save_summary.assert_not_called()
+                assert result is None
+                mock_db.save_summary.assert_not_called()
+        asyncio.run(run())
 
-    @pytest.mark.asyncio
-    async def test_empty_conversation(self):
+    def test_empty_conversation(self):
         """No crash on empty conversation."""
-        with patch("projects.rp.summarize.db") as mock_db:
-            mock_db.get_messages = AsyncMock(return_value=[])
+        async def run():
+            with patch("projects.rp.summarize.db") as mock_db:
+                mock_db.get_messages = AsyncMock(return_value=[])
 
-            result = await maybe_generate_summary(1, AsyncMock(), "test-model")
-            assert result is None
+                result = await maybe_generate_summary(1, AsyncMock(), "test-model")
+                assert result is None
+        asyncio.run(run())

--- a/projects/rp/tests/test_summarize.py
+++ b/projects/rp/tests/test_summarize.py
@@ -1,4 +1,12 @@
-from projects.rp.summarize import build_summary_prompt, clean_summary_response
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from projects.rp.summarize import (
+    build_summary_prompt,
+    clean_summary_response,
+    maybe_generate_summary,
+)
 
 
 def _msgs(*pairs):
@@ -94,3 +102,128 @@ class TestCleanSummaryResponse:
         raw = "<think>outer<think>inner</think>still thinking</think>Actual summary."
         result = clean_summary_response(raw)
         assert result == "Actual summary."
+
+
+def _db_msg(role, content, msg_id, sequence):
+    return {"role": role, "content": content, "id": msg_id, "sequence": sequence,
+            "conversation_id": 1, "raw_response": None, "created_at": "2026-01-01"}
+
+
+def _make_messages(n):
+    """Generate n user/assistant message pairs with sequential ids."""
+    msgs = []
+    for i in range(n):
+        msgs.append(_db_msg("user", f"user msg {i}", i * 2 + 1, i * 2 + 1))
+        msgs.append(_db_msg("assistant", f"assistant msg {i}", i * 2 + 2, i * 2 + 2))
+    return msgs
+
+
+class TestMaybeGenerateSummary:
+    @pytest.mark.asyncio
+    async def test_skips_when_below_threshold(self):
+        """No summary generated when fewer than SUMMARY_THRESHOLD messages."""
+        few_msgs = _make_messages(3)  # 6 messages, below threshold of 10
+        with patch("projects.rp.summarize.db") as mock_db:
+            mock_db.get_messages = AsyncMock(return_value=few_msgs)
+            mock_db.get_latest_summary = AsyncMock(return_value=None)
+
+            ollama = AsyncMock()
+            result = await maybe_generate_summary(1, ollama, "test-model")
+
+            assert result is None
+            ollama.generate.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_generates_when_above_threshold(self):
+        """Summary generated when enough unsummarized messages exist."""
+        msgs = _make_messages(6)  # 12 messages, above threshold
+        with patch("projects.rp.summarize.db") as mock_db:
+            mock_db.get_messages = AsyncMock(return_value=msgs)
+            mock_db.get_latest_summary = AsyncMock(return_value=None)
+            mock_db.save_summary = AsyncMock(return_value={
+                "id": 1, "conversation_id": 1, "summary": "test summary",
+                "through_msg_id": 12, "through_sequence": 12,
+                "msg_count": 12, "token_estimate": 3,
+            })
+
+            ollama = AsyncMock()
+            ollama.generate = AsyncMock(return_value="Test summary of conversation.")
+
+            result = await maybe_generate_summary(1, ollama, "test-model",
+                                                  char_name="Amber", user_name="Val")
+
+            assert result is not None
+            ollama.generate.assert_called_once()
+            mock_db.save_summary.assert_called_once()
+            call_args = mock_db.save_summary.call_args
+            assert call_args[1]["through_msg_id"] == 12
+            assert call_args[1]["through_sequence"] == 12
+            assert call_args[1]["msg_count"] == 12
+
+    @pytest.mark.asyncio
+    async def test_only_counts_unsummarized_messages(self):
+        """Only messages after the last summary count toward the threshold."""
+        msgs = _make_messages(8)  # 16 messages total
+        existing_summary = {
+            "summary": "Previous summary text.",
+            "through_sequence": 10,  # summary covers through sequence 10
+            "through_msg_id": 10,
+        }
+        with patch("projects.rp.summarize.db") as mock_db:
+            mock_db.get_messages = AsyncMock(return_value=msgs)
+            mock_db.get_latest_summary = AsyncMock(return_value=existing_summary)
+
+            ollama = AsyncMock()
+            # 6 messages after sequence 10 (seqs 11-16), below threshold of 10
+            result = await maybe_generate_summary(1, ollama, "test-model")
+
+            assert result is None
+            ollama.generate.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_includes_previous_summary_in_prompt(self):
+        """When extending a summary, the previous summary text is passed to the prompt."""
+        msgs = _make_messages(10)  # 20 messages
+        existing_summary = {
+            "summary": "They met at the park.",
+            "through_sequence": 4,  # only covers first 4
+            "through_msg_id": 4,
+        }
+        with patch("projects.rp.summarize.db") as mock_db:
+            mock_db.get_messages = AsyncMock(return_value=msgs)
+            mock_db.get_latest_summary = AsyncMock(return_value=existing_summary)
+            mock_db.save_summary = AsyncMock(return_value={"id": 2})
+
+            ollama = AsyncMock()
+            ollama.generate = AsyncMock(return_value="Extended summary.")
+
+            await maybe_generate_summary(1, ollama, "test-model")
+
+            # Check that the prompt included the previous summary
+            call_args = ollama.generate.call_args
+            assert "They met at the park" in call_args[1]["prompt"]
+
+    @pytest.mark.asyncio
+    async def test_skips_on_empty_llm_response(self):
+        """Don't save if the LLM returns empty."""
+        msgs = _make_messages(6)
+        with patch("projects.rp.summarize.db") as mock_db:
+            mock_db.get_messages = AsyncMock(return_value=msgs)
+            mock_db.get_latest_summary = AsyncMock(return_value=None)
+
+            ollama = AsyncMock()
+            ollama.generate = AsyncMock(return_value="<think>reasoning</think>")
+
+            result = await maybe_generate_summary(1, ollama, "test-model")
+
+            assert result is None
+            mock_db.save_summary.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_empty_conversation(self):
+        """No crash on empty conversation."""
+        with patch("projects.rp.summarize.db") as mock_db:
+            mock_db.get_messages = AsyncMock(return_value=[])
+
+            result = await maybe_generate_summary(1, AsyncMock(), "test-model")
+            assert result is None


### PR DESCRIPTION
## Summary

- Wires up the existing `SummaryBuffer` context strategy which was dead code — the table and strategy existed but nothing generated summaries
- Adds `save_summary()` / `get_latest_summary()` to `db.py`
- Adds `maybe_generate_summary()` orchestration: checks if 10+ unsummarized messages have accumulated, calls LLM to generate/extend a rolling summary, saves to `rp_conversation_summaries`
- `_build_pipeline_ctx` now loads the latest summary into `ctx["_summary"]` and attaches `_sequence` to messages so `SummaryBuffer` can filter already-summarized ones
- Fires as background task after every assistant message save (send, regenerate, continue, auto-reply)

## Test plan

```bash
cd /mnt/d/prg/plum/.worktrees/rp-summary
source /mnt/d/prg/plum/projects/aiserver/.venv/bin/activate

# Unit tests (20 tests for summarize, 156 total)
python3 -m pytest projects/rp/tests/test_summarize.py -v
python3 -m pytest projects/rp/tests/ -q

# Manual: start a conversation with 10+ turns, check DB for summary
psql $DATABASE_URL -c "SELECT id, conversation_id, through_sequence, msg_count, token_estimate FROM rp_conversation_summaries ORDER BY id DESC LIMIT 5"
```

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)