### PR TITLE
feat(rp): prompt budgeting for runtime + lora_generate

### DIFF
--- a/docs/superpowers/plans/2026-04-07-rp-prompt-budgeting.md
+++ b/docs/superpowers/plans/2026-04-07-rp-prompt-budgeting.md
@@ -1,0 +1,2383 @@
+# Prompt Budgeting Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Guarantee every prompt sent to Ollama by the rp runtime pipeline and `lora_generate.py` fits within the model's real context window, with a deterministic shrink policy and a ground-truth token count.
+
+**Architecture:** New module `projects/rp/budget.py` with a single async entry point `fit_prompt(ctx, ...)` (plus `fit_raw_prompt` for single-shot prompts). Called explicitly from `routes.py` after pipeline pre-hooks and from `lora_generate.py` before each Ollama call. The pipeline itself stays pure. `OllamaClient` gets one new method `get_num_ctx` that reads `/api/show` once per model and caches the result.
+
+**Tech Stack:** Python 3.11+, `httpx`, `asyncpg`, `asyncio`, `pytest`, `pytest-asyncio`, `fastapi`, Ollama local server.
+
+**Spec:** `docs/superpowers/specs/2026-04-07-rp-prompt-budgeting-design.md`
+
+**Branch / worktree:** work must happen on branch `prompt-budgeting` in worktree `/mnt/d/prg/plum-prompt-budgeting`. All `cd` paths in this plan assume that worktree.
+
+---
+
+## Preflight
+
+- [ ] **Step 0: Switch to the correct worktree**
+
+```bash
+cd /mnt/d/prg/plum-prompt-budgeting
+git status
+git branch --show-current
+```
+
+Expected: clean working tree, branch `prompt-budgeting`.
+
+---
+
+## Task 1: Add `OllamaClient.get_num_ctx`
+
+**Why:** Budgeting needs the model's real context window. Ollama exposes it via `/api/show`. This method is general enough to belong on the shared client, not inside `budget.py`.
+
+**Files:**
+- Modify: `projects/aiserver/ollama.py` (add method after `list_models_detail`, around line 254)
+- Test: `projects/aiserver/tests/test_ollama_chat.py` (add a new test class at the end)
+
+- [ ] **Step 1.1: Write the failing tests**
+
+Append to `projects/aiserver/tests/test_ollama_chat.py`:
+
+```python
+import pytest
+from unittest.mock import AsyncMock, patch
+from aiserver.ollama import OllamaClient, OllamaError
+
+
+class TestGetNumCtx:
+    @pytest.mark.asyncio
+    async def test_prefers_parameters_num_ctx(self):
+        client = OllamaClient("http://localhost:11434")
+        show_response = {
+            "parameters": "num_ctx                        32768\ntemperature                    0.8",
+            "model_info": {"llama.context_length": 131072},
+        }
+        with patch("httpx.AsyncClient.post") as mock_post:
+            mock_post.return_value.status_code = 200
+            mock_post.return_value.json = lambda: show_response
+            result = await client.get_num_ctx("mymodel")
+        assert result == 32768
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_model_info_context_length(self):
+        client = OllamaClient("http://localhost:11434")
+        show_response = {
+            "parameters": "temperature                    0.8",
+            "model_info": {"llama.context_length": 8192},
+        }
+        with patch("httpx.AsyncClient.post") as mock_post:
+            mock_post.return_value.status_code = 200
+            mock_post.return_value.json = lambda: show_response
+            result = await client.get_num_ctx("mymodel")
+        assert result == 8192
+
+    @pytest.mark.asyncio
+    async def test_tries_any_arch_context_length(self):
+        """model_info keys look like <arch>.context_length — e.g. qwen2.context_length."""
+        client = OllamaClient("http://localhost:11434")
+        show_response = {
+            "parameters": "",
+            "model_info": {"qwen2.context_length": 4096, "general.architecture": "qwen2"},
+        }
+        with patch("httpx.AsyncClient.post") as mock_post:
+            mock_post.return_value.status_code = 200
+            mock_post.return_value.json = lambda: show_response
+            result = await client.get_num_ctx("mymodel")
+        assert result == 4096
+
+    @pytest.mark.asyncio
+    async def test_raises_when_neither_present(self):
+        client = OllamaClient("http://localhost:11434")
+        show_response = {"parameters": "temperature 0.8", "model_info": {}}
+        with patch("httpx.AsyncClient.post") as mock_post:
+            mock_post.return_value.status_code = 200
+            mock_post.return_value.json = lambda: show_response
+            with pytest.raises(OllamaError, match="context length"):
+                await client.get_num_ctx("mymodel")
+
+    @pytest.mark.asyncio
+    async def test_raises_on_show_http_error(self):
+        client = OllamaClient("http://localhost:11434")
+        with patch("httpx.AsyncClient.post") as mock_post:
+            mock_post.return_value.status_code = 404
+            mock_post.return_value.text = "model not found"
+            with pytest.raises(OllamaError):
+                await client.get_num_ctx("nope")
+```
+
+- [ ] **Step 1.2: Run tests and verify they fail**
+
+```bash
+cd /mnt/d/prg/plum-prompt-budgeting
+cd projects/aiserver && source .venv/bin/activate && cd ../..
+pytest projects/aiserver/tests/test_ollama_chat.py::TestGetNumCtx -v
+```
+
+Expected: FAIL — `AttributeError: 'OllamaClient' object has no attribute 'get_num_ctx'`.
+
+- [ ] **Step 1.3: Implement `get_num_ctx`**
+
+In `projects/aiserver/ollama.py`, add this method to `OllamaClient` after `list_models_detail` (around line 254):
+
+```python
+    async def get_num_ctx(self, model: str) -> int:
+        """Return effective context length for a model via /api/show.
+
+        Prefers the runtime-loaded num_ctx from the parameters field (a
+        whitespace-formatted string). Falls back to any <arch>.context_length
+        entry in model_info (the architectural max from the GGUF file).
+        Raises OllamaError if neither is present or the request fails.
+        """
+        try:
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                resp = await client.post(
+                    f"{self.base_url}/api/show", json={"model": model}
+                )
+                if resp.status_code != 200:
+                    raise OllamaError(
+                        f"Ollama /api/show returned {resp.status_code}: {resp.text}"
+                    )
+                data = resp.json()
+        except httpx.ConnectError:
+            raise OllamaError(f"Cannot connect to Ollama at {self.base_url}")
+        except httpx.HTTPError as e:
+            raise OllamaError(f"HTTP error from /api/show: {e}") from e
+
+        # Parse parameters for "num_ctx <value>"
+        params_str = data.get("parameters", "") or ""
+        for line in params_str.splitlines():
+            parts = line.split()
+            if len(parts) >= 2 and parts[0] == "num_ctx":
+                try:
+                    return int(parts[1])
+                except ValueError:
+                    pass
+
+        # Fall back to model_info[<arch>.context_length]
+        model_info = data.get("model_info", {}) or {}
+        for key, value in model_info.items():
+            if key.endswith(".context_length") and isinstance(value, int):
+                return value
+
+        raise OllamaError(
+            f"Could not determine context length for model {model!r}: "
+            f"no num_ctx in parameters and no <arch>.context_length in model_info"
+        )
+```
+
+- [ ] **Step 1.4: Run tests and verify they pass**
+
+```bash
+pytest projects/aiserver/tests/test_ollama_chat.py::TestGetNumCtx -v
+```
+
+Expected: all 5 tests PASS.
+
+- [ ] **Step 1.5: Run the full aiserver test suite to check nothing regressed**
+
+```bash
+pytest projects/aiserver/tests/ -v
+```
+
+Expected: all tests pass (or same baseline as before this change).
+
+- [ ] **Step 1.6: Commit**
+
+```bash
+cd /mnt/d/prg/plum-prompt-budgeting
+git add projects/aiserver/ollama.py projects/aiserver/tests/test_ollama_chat.py
+git commit --author="Claude <noreply@anthropic.com>" -m "feat(ollama): add get_num_ctx to read model context length
+
+Reads /api/show and returns the effective num_ctx, preferring
+parameters.num_ctx (runtime) and falling back to model_info
+<arch>.context_length (architectural max).
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: `budget.py` foundations — exceptions, report, model-ctx cache
+
+**Why:** The shared module needs its types and caching layer before any budgeting logic can land.
+
+**Files:**
+- Create: `projects/rp/budget.py`
+- Create: `projects/rp/tests/test_budget.py`
+- Create: `projects/rp/tests/conftest.py` (test helpers — a stub Ollama client)
+
+- [ ] **Step 2.1: Create the test stub for Ollama**
+
+Create `projects/rp/tests/conftest.py`:
+
+```python
+"""Shared test fixtures for the rp test suite."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class StubOllama:
+    """Stand-in for OllamaClient in unit tests.
+
+    - `num_ctx_map` is what get_num_ctx returns per model.
+    - `count_map` lets tests stub the ground-truth count helper by
+      registering a dict of {prompt_key: token_count}. Tests that don't
+      care about ground-truth counting can leave it empty.
+    - `show_calls` records how many times get_num_ctx was called per
+      model (for cache-hit tests).
+    - `chat_calls` records how many times chat() was called (for the
+      ground-truth call counter).
+    """
+
+    num_ctx_map: dict[str, int] = field(default_factory=dict)
+    count_map: dict[str, int] = field(default_factory=dict)
+    show_calls: dict[str, int] = field(default_factory=dict)
+    chat_calls: int = 0
+    default_count: int = 0
+
+    async def get_num_ctx(self, model: str) -> int:
+        self.show_calls[model] = self.show_calls.get(model, 0) + 1
+        if model not in self.num_ctx_map:
+            from aiserver.ollama import OllamaError
+            raise OllamaError(f"stub has no num_ctx for model {model!r}")
+        return self.num_ctx_map[model]
+
+    async def chat(self, model: str, messages, tools=None, think=False):
+        """Stub /api/chat that returns a prompt_eval_count.
+
+        Ground-truth counting calls this with num_predict=0 in options;
+        our stub returns count_map[model] or default_count.
+        """
+        self.chat_calls += 1
+        count = self.count_map.get(model, self.default_count)
+        return {
+            "message": {"role": "assistant", "content": ""},
+            "done": True,
+            "prompt_eval_count": count,
+        }
+```
+
+- [ ] **Step 2.2: Write the failing tests for `_get_model_ctx` caching and data classes**
+
+Create `projects/rp/tests/test_budget.py`:
+
+```python
+"""Unit tests for projects/rp/budget.py."""
+
+import asyncio
+import pytest
+
+from projects.rp import budget
+from projects.rp.budget import BudgetError, BudgetReport, _get_model_ctx
+
+
+@pytest.fixture(autouse=True)
+def _clear_budget_cache():
+    """Ensure each test sees a fresh module-level cache."""
+    budget._ctx_cache.clear()
+    budget._ctx_locks.clear()
+    yield
+    budget._ctx_cache.clear()
+    budget._ctx_locks.clear()
+
+
+class TestBudgetReport:
+    def test_fields_have_sensible_defaults(self):
+        report = BudgetReport(
+            model="m", model_ctx=8192, response_reserve=1024,
+            available=7168, overhead=500, messages_budget=6668,
+            messages_kept=10, messages_dropped=0,
+            summary_dropped=False, mes_example_truncated=False,
+            estimator_tokens=5000, actual_tokens=None, warnings=[],
+        )
+        assert report.model == "m"
+        assert report.warnings == []
+
+    def test_budget_error_carries_report(self):
+        report = BudgetReport(
+            model="m", model_ctx=1024, response_reserve=1024,
+            available=0, overhead=0, messages_budget=0,
+            messages_kept=0, messages_dropped=0,
+            summary_dropped=False, mes_example_truncated=False,
+            estimator_tokens=0, actual_tokens=None, warnings=[],
+        )
+        err = BudgetError("doesn't fit", report)
+        assert err.report is report
+        assert str(err) == "doesn't fit"
+
+
+class TestGetModelCtx:
+    @pytest.mark.asyncio
+    async def test_first_call_fetches_from_ollama(self, stub_ollama_factory):
+        stub = stub_ollama_factory(num_ctx_map={"modelA": 8192})
+        result = await _get_model_ctx("modelA", stub)
+        assert result == 8192
+        assert stub.show_calls["modelA"] == 1
+
+    @pytest.mark.asyncio
+    async def test_second_call_uses_cache(self, stub_ollama_factory):
+        stub = stub_ollama_factory(num_ctx_map={"modelA": 8192})
+        await _get_model_ctx("modelA", stub)
+        await _get_model_ctx("modelA", stub)
+        assert stub.show_calls["modelA"] == 1
+
+    @pytest.mark.asyncio
+    async def test_concurrent_first_calls_only_fetch_once(self, stub_ollama_factory):
+        stub = stub_ollama_factory(num_ctx_map={"modelA": 8192})
+        results = await asyncio.gather(*[
+            _get_model_ctx("modelA", stub) for _ in range(10)
+        ])
+        assert all(r == 8192 for r in results)
+        assert stub.show_calls["modelA"] == 1
+
+    @pytest.mark.asyncio
+    async def test_different_models_cached_independently(self, stub_ollama_factory):
+        stub = stub_ollama_factory(num_ctx_map={"A": 8192, "B": 32768})
+        assert await _get_model_ctx("A", stub) == 8192
+        assert await _get_model_ctx("B", stub) == 32768
+        assert stub.show_calls == {"A": 1, "B": 1}
+```
+
+Add a small factory fixture to `projects/rp/tests/conftest.py` (append to the end):
+
+```python
+import pytest
+
+
+@pytest.fixture
+def stub_ollama_factory():
+    """Factory that builds a fresh StubOllama with the given config."""
+    def _make(**kwargs):
+        return StubOllama(**kwargs)
+    return _make
+```
+
+- [ ] **Step 2.3: Run tests to verify they fail**
+
+```bash
+cd /mnt/d/prg/plum-prompt-budgeting
+cd projects/aiserver && source .venv/bin/activate && cd ../..
+pytest projects/rp/tests/test_budget.py -v
+```
+
+Expected: FAIL — `ModuleNotFoundError: No module named 'projects.rp.budget'`.
+
+- [ ] **Step 2.4: Create the minimal `budget.py`**
+
+Create `projects/rp/budget.py`:
+
+```python
+"""Prompt budgeting: fit rp pipeline and lora_generate prompts into model_ctx.
+
+See docs/superpowers/specs/2026-04-07-rp-prompt-budgeting-design.md.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Protocol
+
+if TYPE_CHECKING:
+    from .context import ContextStrategy
+
+_log = logging.getLogger(__name__)
+
+
+class _OllamaLike(Protocol):
+    async def get_num_ctx(self, model: str) -> int: ...
+    async def chat(self, model, messages, tools=None, think=False): ...
+
+
+# Module-level cache: model name -> num_ctx. Populated on first use per model.
+_ctx_cache: dict[str, int] = {}
+_ctx_locks: dict[str, asyncio.Lock] = {}
+
+
+class BudgetError(Exception):
+    """Raised when the minimum viable prompt exceeds model_ctx - response_reserve."""
+
+    def __init__(self, message: str, report: "BudgetReport"):
+        super().__init__(message)
+        self.report = report
+
+
+@dataclass
+class BudgetReport:
+    model: str
+    model_ctx: int
+    response_reserve: int
+    available: int              # model_ctx - reserve
+    overhead: int               # system_prompt + post_prompt (estimator)
+    messages_budget: int        # available - overhead
+    messages_kept: int
+    messages_dropped: int
+    summary_dropped: bool
+    mes_example_truncated: bool
+    estimator_tokens: int
+    actual_tokens: int | None
+    warnings: list[str] = field(default_factory=list)
+
+
+def _estimate_tokens(text: str) -> int:
+    """Rough token count: ~4 chars per token. Cheap, used for iterative shrinking."""
+    return len(text) // 4
+
+
+async def _get_model_ctx(model: str, ollama: _OllamaLike) -> int:
+    """Return cached num_ctx for `model`, fetching once on first use.
+
+    Uses a per-model asyncio.Lock so concurrent first-use calls don't
+    issue duplicate /api/show requests.
+    """
+    cached = _ctx_cache.get(model)
+    if cached is not None:
+        return cached
+
+    lock = _ctx_locks.setdefault(model, asyncio.Lock())
+    async with lock:
+        cached = _ctx_cache.get(model)
+        if cached is not None:
+            return cached
+        num_ctx = await ollama.get_num_ctx(model)
+        _ctx_cache[model] = num_ctx
+        _log.info("Loaded num_ctx=%d for model %s", num_ctx, model)
+        return num_ctx
+```
+
+- [ ] **Step 2.5: Run tests and verify they pass**
+
+```bash
+pytest projects/rp/tests/test_budget.py -v
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 2.6: Commit**
+
+```bash
+git add projects/rp/budget.py projects/rp/tests/test_budget.py projects/rp/tests/conftest.py
+git commit --author="Claude <noreply@anthropic.com>" -m "feat(rp): add budget module foundations
+
+New module projects/rp/budget.py with:
+- BudgetError + BudgetReport types
+- _get_model_ctx caching helper (one /api/show call per model
+  per process, with per-model lock to prevent thundering)
+- Estimator-based _estimate_tokens helper
+
+Also adds a StubOllama fixture in projects/rp/tests/conftest.py
+for isolated unit tests.
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: `_ollama_count_messages` — ground-truth token counting
+
+**Why:** Budgeting needs a way to ask Ollama "how many tokens would this exact set of messages consume?". We use `/api/chat` with `num_predict: 0` and read `prompt_eval_count` from the response.
+
+**Files:**
+- Modify: `projects/rp/budget.py` (add helper function)
+- Modify: `projects/rp/tests/test_budget.py` (add test class)
+
+- [ ] **Step 3.1: Write the failing test**
+
+Append to `projects/rp/tests/test_budget.py`:
+
+```python
+from projects.rp.budget import _ollama_count_messages
+
+
+class TestOllamaCountMessages:
+    @pytest.mark.asyncio
+    async def test_returns_prompt_eval_count(self, stub_ollama_factory):
+        stub = stub_ollama_factory(count_map={"modelA": 1234})
+        messages = [
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "Hi"},
+        ]
+        count = await _ollama_count_messages(messages, "modelA", stub)
+        assert count == 1234
+        assert stub.chat_calls == 1
+
+    @pytest.mark.asyncio
+    async def test_returns_zero_when_missing(self, stub_ollama_factory):
+        """If Ollama doesn't return prompt_eval_count, return 0 and let caller
+        decide. Never silently inflate or deflate."""
+        stub = stub_ollama_factory(count_map={})  # default_count=0
+        count = await _ollama_count_messages([{"role": "user", "content": "x"}], "modelA", stub)
+        assert count == 0
+```
+
+- [ ] **Step 3.2: Run tests to verify they fail**
+
+```bash
+pytest projects/rp/tests/test_budget.py::TestOllamaCountMessages -v
+```
+
+Expected: FAIL — `ImportError: cannot import name '_ollama_count_messages'`.
+
+- [ ] **Step 3.3: Implement `_ollama_count_messages`**
+
+Add to `projects/rp/budget.py` (after `_get_model_ctx`):
+
+```python
+async def _ollama_count_messages(
+    messages: list[dict],
+    model: str,
+    ollama: _OllamaLike,
+) -> int:
+    """Ask Ollama for the ground-truth token count of `messages`.
+
+    Calls /api/chat with num_predict=0 (no generation, just tokenize
+    the prompt). Reads prompt_eval_count from the response. Returns 0
+    if Ollama doesn't surface the field — caller decides how to handle
+    a missing value.
+    """
+    result = await ollama.chat(model=model, messages=messages)
+    return int(result.get("prompt_eval_count", 0) or 0)
+```
+
+Note: the real `OllamaClient.chat` signature doesn't accept an `options` dict. For counting we rely on Ollama's behavior: a `chat` call with no `num_predict` override still returns `prompt_eval_count` because the prompt is tokenized before generation. In practice `prompt_eval_count` is what we want regardless of how much is generated, so we don't need to set `num_predict=0`. This also avoids a signature change to `OllamaClient.chat`.
+
+If we later decide we *do* need `num_predict=0` (to save a few ms of generation), we'll add an `options` kwarg to `chat` in a separate change.
+
+- [ ] **Step 3.4: Run tests and verify they pass**
+
+```bash
+pytest projects/rp/tests/test_budget.py -v
+```
+
+Expected: all tests in `test_budget.py` PASS.
+
+- [ ] **Step 3.5: Commit**
+
+```bash
+git add projects/rp/budget.py projects/rp/tests/test_budget.py
+git commit --author="Claude <noreply@anthropic.com>" -m "feat(rp/budget): add _ollama_count_messages ground-truth helper
+
+Calls Ollama /api/chat and reads prompt_eval_count from the
+response. Used by fit_prompt for the single ground-truth
+verification step per request.
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: `fit_prompt` happy path + Priority 2 (strategy drops oldest)
+
+**Why:** The main entry point. Starts with the happy path and the most common shrink case — delegating to `ContextStrategy.fit` with a correctly-computed `messages_budget`.
+
+**Files:**
+- Modify: `projects/rp/budget.py` (add `fit_prompt`)
+- Modify: `projects/rp/tests/test_budget.py` (add test class)
+
+- [ ] **Step 4.1: Write failing tests**
+
+Append to `projects/rp/tests/test_budget.py`:
+
+```python
+from projects.rp.budget import fit_prompt
+from projects.rp.context import SlidingWindow
+
+
+def _build_ctx(system_prompt="", post_prompt="", messages=None, ai_card=None):
+    """Build a minimal ctx dict for fit_prompt tests."""
+    return {
+        "system_prompt": system_prompt,
+        "post_prompt": post_prompt,
+        "messages": messages or [],
+        "ai_card": ai_card or {"card_data": {"data": {"mes_example": ""}}},
+    }
+
+
+class TestFitPromptHappyPath:
+    @pytest.mark.asyncio
+    async def test_everything_fits_no_shrink(self, stub_ollama_factory):
+        stub = stub_ollama_factory(num_ctx_map={"m": 8192})
+        ctx = _build_ctx(
+            system_prompt="system",  # ~1 token
+            post_prompt="post",       # ~1 token
+            messages=[
+                {"role": "assistant", "content": "greeting"},
+                {"role": "user", "content": "hi"},
+                {"role": "assistant", "content": "hello"},
+            ],
+        )
+        report = await fit_prompt(
+            ctx, model="m", ollama=stub, strategy=SlidingWindow(),
+            num_predict=512, ground_truth=False,
+        )
+        assert len(ctx["messages"]) == 3
+        assert report.model == "m"
+        assert report.model_ctx == 8192
+        assert report.response_reserve == 512
+        assert report.available == 8192 - 512
+        assert report.messages_kept == 3
+        assert report.messages_dropped == 0
+        assert report.summary_dropped is False
+        assert report.mes_example_truncated is False
+        assert ctx["_num_ctx"] == 8192
+        assert ctx["_budget_report"] is report
+
+    @pytest.mark.asyncio
+    async def test_default_response_reserve_is_1024(self, stub_ollama_factory):
+        stub = stub_ollama_factory(num_ctx_map={"m": 8192})
+        ctx = _build_ctx(messages=[{"role": "user", "content": "hi"}])
+        report = await fit_prompt(
+            ctx, model="m", ollama=stub, strategy=SlidingWindow(),
+            num_predict=None, ground_truth=False,
+        )
+        assert report.response_reserve == 1024
+
+    @pytest.mark.asyncio
+    async def test_priority_2_drops_oldest_messages(self, stub_ollama_factory):
+        """When messages exceed budget, SlidingWindow drops oldest first."""
+        stub = stub_ollama_factory(num_ctx_map={"m": 2048})  # small ctx
+        # Each message ~= 25 tokens under len//4
+        messages = [
+            {"role": "assistant", "content": "G" * 100},   # greeting (kept)
+            {"role": "user", "content": "A" * 100},        # oldest (droppable)
+            {"role": "assistant", "content": "B" * 100},   # droppable
+            {"role": "user", "content": "C" * 100},        # droppable
+            {"role": "assistant", "content": "D" * 100},   # droppable
+            {"role": "user", "content": "E" * 100},        # most recent (kept)
+        ]
+        ctx = _build_ctx(messages=messages)
+        # With num_predict=2000, available = 48, overhead = 0,
+        # messages_budget = 48 -> can only fit greeting (25) + one (25)
+        # = only greeting actually fits since 25+25=50 > 48, or ==
+        report = await fit_prompt(
+            ctx, model="m", ollama=stub, strategy=SlidingWindow(),
+            num_predict=2000, ground_truth=False,
+        )
+        # Greeting is always kept; most-recent should be kept too.
+        contents = [m["content"] for m in ctx["messages"]]
+        assert "G" * 100 in contents  # greeting
+        assert "E" * 100 in contents  # most recent
+        assert "A" * 100 not in contents  # oldest dropped
+        assert report.messages_dropped > 0
+
+    @pytest.mark.asyncio
+    async def test_overhead_counted_against_budget(self, stub_ollama_factory):
+        """Large system_prompt should reduce messages_budget accordingly."""
+        stub = stub_ollama_factory(num_ctx_map={"m": 1000})
+        ctx = _build_ctx(
+            system_prompt="X" * 2000,  # ~500 tokens
+            messages=[{"role": "user", "content": "hi"}],
+        )
+        report = await fit_prompt(
+            ctx, model="m", ollama=stub, strategy=SlidingWindow(),
+            num_predict=200, ground_truth=False,
+        )
+        # available = 1000 - 200 = 800
+        # overhead = ~500 (system) + 0 (post) = 500
+        # messages_budget = 300
+        assert report.available == 800
+        assert report.overhead == 500
+        assert report.messages_budget == 300
+```
+
+- [ ] **Step 4.2: Run tests to verify they fail**
+
+```bash
+pytest projects/rp/tests/test_budget.py::TestFitPromptHappyPath -v
+```
+
+Expected: FAIL — `ImportError: cannot import name 'fit_prompt'`.
+
+- [ ] **Step 4.3: Implement `fit_prompt` happy path + Priority 2**
+
+Append to `projects/rp/budget.py`:
+
+```python
+async def fit_prompt(
+    ctx: dict,
+    *,
+    model: str,
+    ollama: _OllamaLike,
+    strategy: "ContextStrategy",
+    num_predict: int | None = None,
+    ground_truth: bool = True,
+) -> BudgetReport:
+    """Shrink ctx["messages"] (and, if needed, other prompt pieces) so the
+    assembled prompt fits within model_ctx - response_reserve.
+
+    Mutates ctx:
+      - ctx["messages"]: potentially trimmed by the strategy
+      - ctx["_summary"]: potentially deleted (Priority 3)
+      - ctx["ai_card"]: mes_example potentially truncated (Priority 4)
+      - ctx["system_prompt"] / ctx["post_prompt"]: re-rendered on P4
+      - ctx["_num_ctx"]: set to the model's context window
+      - ctx["_budget_report"]: set to the returned BudgetReport
+
+    Raises BudgetError with a populated report if the minimum viable
+    prompt (system + greeting + most-recent user message) doesn't fit.
+    """
+    model_ctx = await _get_model_ctx(model, ollama)
+    response_reserve = num_predict if num_predict is not None else 1024
+    available = model_ctx - response_reserve
+
+    warnings: list[str] = []
+    messages_before = len(ctx.get("messages", []))
+
+    # Estimator-based overhead.
+    overhead = _estimate_tokens(ctx.get("system_prompt", "")) + _estimate_tokens(
+        ctx.get("post_prompt", "")
+    )
+    messages_budget = available - overhead
+
+    # Priority 2: delegate to strategy.fit with the corrected budget.
+    # The strategy (SlidingWindow / SummaryBuffer) handles greeting
+    # protection, oldest-first drop, and summary injection.
+    if messages_budget > 0:
+        ctx["messages"] = strategy.fit(
+            ctx.get("messages", []), messages_budget, ctx=ctx
+        )
+
+    messages_after = len(ctx.get("messages", []))
+    messages_dropped = max(0, messages_before - messages_after)
+
+    report = BudgetReport(
+        model=model,
+        model_ctx=model_ctx,
+        response_reserve=response_reserve,
+        available=available,
+        overhead=overhead,
+        messages_budget=messages_budget,
+        messages_kept=messages_after,
+        messages_dropped=messages_dropped,
+        summary_dropped=False,
+        mes_example_truncated=False,
+        estimator_tokens=overhead + sum(
+            _estimate_tokens(m.get("content", "")) for m in ctx.get("messages", [])
+        ),
+        actual_tokens=None,
+        warnings=warnings,
+    )
+
+    ctx["_num_ctx"] = model_ctx
+    ctx["_budget_report"] = report
+    return report
+```
+
+- [ ] **Step 4.4: Run tests and verify they pass**
+
+```bash
+pytest projects/rp/tests/test_budget.py::TestFitPromptHappyPath -v
+```
+
+Expected: all 4 tests PASS. Debug any token-count edge cases until green (the test message sizes are set so len//4 arithmetic lines up).
+
+- [ ] **Step 4.5: Commit**
+
+```bash
+git add projects/rp/budget.py projects/rp/tests/test_budget.py
+git commit --author="Claude <noreply@anthropic.com>" -m "feat(rp/budget): add fit_prompt with Priority 2 (strategy drop)
+
+Happy path + delegation to ContextStrategy.fit with a corrected
+messages budget (model_ctx - response_reserve - overhead). Ground
+truth check and higher-priority shrink steps follow in later
+commits.
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Priority 3 — drop summary when still over budget
+
+**Why:** After strategy.fit drops all droppable messages, if we're still over (e.g., because the summary itself is the overflow source), the next-cheapest thing to lose is the summary.
+
+**Files:**
+- Modify: `projects/rp/budget.py` (add post-strategy check)
+- Modify: `projects/rp/tests/test_budget.py`
+
+- [ ] **Step 5.1: Write failing test**
+
+Append to `projects/rp/tests/test_budget.py`:
+
+```python
+from projects.rp.context import SummaryBuffer
+
+
+class TestFitPromptPriority3:
+    @pytest.mark.asyncio
+    async def test_summary_dropped_when_still_over(self, stub_ollama_factory):
+        """After strategy.fit drops all messages but a single huge user msg,
+        and overhead + summary + that msg still exceeds budget, the summary
+        should be dropped."""
+        stub = stub_ollama_factory(num_ctx_map={"m": 1000})
+        ctx = _build_ctx(
+            system_prompt="",
+            post_prompt="",
+            messages=[
+                {"role": "assistant", "content": "greeting",
+                 "_sequence": 1},
+                {"role": "user", "content": "X" * 1000,
+                 "_sequence": 10},  # ~250 tokens, most recent
+            ],
+        )
+        # Summary is ~200 tokens (would normally fit under 25% cap of 1000 = 250)
+        ctx["_summary"] = "Y" * 800
+        ctx["_summary_through_sequence"] = 5
+
+        # available = 1000 - 100 = 900
+        # overhead = 0
+        # messages_budget = 900
+        # SummaryBuffer would include summary (~200) + greeting + recent msg (~250)
+        # Total ~ 450 — fits. This test needs tighter budget to force drop.
+
+        report = await fit_prompt(
+            ctx, model="m", ollama=stub, strategy=SummaryBuffer(),
+            num_predict=500, ground_truth=False,
+        )
+        # available = 500, overhead=0, messages_budget=500
+        # summary_buffer injects summary (~200) + greeting (~2) + recent (~250) = 452
+        # fits without dropping summary
+        assert report.summary_dropped is False
+
+    @pytest.mark.asyncio
+    async def test_summary_dropped_when_budget_too_tight(self, stub_ollama_factory):
+        """When even after strategy.fit the prompt is still over budget
+        (we check via the estimator on the rendered messages), drop summary."""
+        stub = stub_ollama_factory(num_ctx_map={"m": 1200})
+        huge_recent = "Z" * 3600  # ~900 tokens
+        ctx = _build_ctx(
+            messages=[
+                {"role": "assistant", "content": "hi", "_sequence": 1},
+                {"role": "user", "content": huge_recent, "_sequence": 10},
+            ],
+        )
+        ctx["_summary"] = "S" * 400  # ~100 tokens
+        ctx["_summary_through_sequence"] = 5
+
+        # available = 1200 - 200 = 1000
+        # overhead = 0
+        # messages_budget = 1000
+        # SummaryBuffer: summary (100) + greeting (~0) + recent (900) = 1000 — exactly fits
+        # Force it tighter: num_predict=300 -> available=900 -> over by ~100
+        report = await fit_prompt(
+            ctx, model="m", ollama=stub, strategy=SummaryBuffer(),
+            num_predict=300, ground_truth=False,
+        )
+        assert report.summary_dropped is True
+        # summary should no longer be in ctx["messages"] as a [Story so far] entry
+        for m in ctx["messages"]:
+            assert "[Story so far]" not in m.get("content", "")
+```
+
+- [ ] **Step 5.2: Run tests and verify they fail**
+
+```bash
+pytest projects/rp/tests/test_budget.py::TestFitPromptPriority3 -v
+```
+
+Expected: the second test FAILs (summary not dropped).
+
+- [ ] **Step 5.3: Add Priority 3 logic**
+
+Replace the body of `fit_prompt` in `projects/rp/budget.py` to add the post-strategy check. Find this block inside `fit_prompt`:
+
+```python
+    # Priority 2: delegate to strategy.fit with the corrected budget.
+    if messages_budget > 0:
+        ctx["messages"] = strategy.fit(
+            ctx.get("messages", []), messages_budget, ctx=ctx
+        )
+```
+
+Replace it with:
+
+```python
+    summary_dropped = False
+
+    # Priority 2: delegate to strategy.fit with the corrected budget.
+    if messages_budget > 0:
+        ctx["messages"] = strategy.fit(
+            ctx.get("messages", []), messages_budget, ctx=ctx
+        )
+
+    # Priority 3: if still over budget, drop the summary (if any) and re-fit.
+    def _current_messages_tokens() -> int:
+        return sum(_estimate_tokens(m.get("content", "")) for m in ctx.get("messages", []))
+
+    if ctx.get("_summary") and _current_messages_tokens() > messages_budget:
+        ctx["_summary"] = None
+        # Re-run strategy with summary gone
+        if messages_budget > 0:
+            ctx["messages"] = strategy.fit(
+                ctx.get("messages", []), messages_budget, ctx=ctx
+            )
+        summary_dropped = True
+        warnings.append("summary dropped to fit messages budget")
+```
+
+Then update the `BudgetReport` construction at the bottom of `fit_prompt`:
+
+```python
+    report = BudgetReport(
+        ...
+        summary_dropped=summary_dropped,
+        ...
+    )
+```
+
+- [ ] **Step 5.4: Run tests and verify they pass**
+
+```bash
+pytest projects/rp/tests/test_budget.py::TestFitPromptPriority3 -v
+```
+
+Expected: both tests PASS.
+
+- [ ] **Step 5.5: Run the full budget test suite to confirm no regressions**
+
+```bash
+pytest projects/rp/tests/test_budget.py -v
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5.6: Commit**
+
+```bash
+git add projects/rp/budget.py projects/rp/tests/test_budget.py
+git commit --author="Claude <noreply@anthropic.com>" -m "feat(rp/budget): drop summary when still over budget (Priority 3)
+
+After strategy.fit, if the kept messages still exceed the budget,
+clear ctx[_summary] and re-run the strategy. SummaryBuffer then
+degrades to SlidingWindow behavior without the summary slot.
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Priority 4 — truncate `mes_example`
+
+**Why:** When the system prompt is so large that even with zero message history we can't fit, the one piece of character identity we're willing to shrink is `mes_example` — usually the biggest and most redundant field.
+
+**Files:**
+- Modify: `projects/rp/budget.py`
+- Modify: `projects/rp/tests/test_budget.py`
+
+- [ ] **Step 6.1: Write failing test**
+
+Append to `projects/rp/tests/test_budget.py`:
+
+```python
+class TestFitPromptPriority4:
+    @pytest.mark.asyncio
+    async def test_mes_example_truncated_when_overhead_dominates(
+        self, stub_ollama_factory
+    ):
+        """When system_prompt (which includes mes_example) exceeds the
+        available budget, truncate mes_example and re-render."""
+        stub = stub_ollama_factory(num_ctx_map={"m": 1000})
+
+        # system_prompt that embeds a long mes_example section
+        mes_example = "Example line.\n" * 200  # ~700 tokens
+        system_prompt = "character intro\n\nExample dialogue:\n" + mes_example + "\n\nmore intro"
+
+        ctx = _build_ctx(
+            system_prompt=system_prompt,
+            messages=[{"role": "user", "content": "hi"}],
+            ai_card={"card_data": {"data": {"mes_example": mes_example}}},
+        )
+        # Pre-populate ctx so we can re-run assembly
+        ctx["user_card"] = {"card_data": {"data": {}}}
+        ctx["scenario"] = {}
+        ctx["prompt_template"] = ""
+
+        report = await fit_prompt(
+            ctx, model="m", ollama=stub, strategy=SlidingWindow(),
+            num_predict=500, ground_truth=False,
+        )
+        # available = 500, overhead before truncation ~ (len(system)+len(post))//4 ~ 200+
+        # after truncation mes_example should be ~25% (~175 tokens) or >= 200 tokens
+        assert report.mes_example_truncated is True
+        # ai_card mes_example should be smaller now
+        truncated = ctx["ai_card"]["card_data"]["data"]["mes_example"]
+        assert len(truncated) < len(mes_example)
+```
+
+- [ ] **Step 6.2: Run tests and verify they fail**
+
+```bash
+pytest projects/rp/tests/test_budget.py::TestFitPromptPriority4 -v
+```
+
+Expected: FAIL — `mes_example_truncated` is False.
+
+- [ ] **Step 6.3: Add Priority 4 logic**
+
+Add this helper to `projects/rp/budget.py` (above `fit_prompt`):
+
+```python
+def _truncate_mes_example(ctx: dict) -> bool:
+    """Truncate ai_card's mes_example in place and re-run the assembly hooks.
+
+    Keeps whole lines up to max(25% of original tokens, 200 tokens).
+    Returns True if truncation happened, False if there was nothing to
+    truncate (empty or already small).
+
+    Imports from .pipeline are local to avoid a circular import: pipeline
+    can freely import budget without risk.
+    """
+    ai_card = ctx.get("ai_card") or {}
+    card_data = ai_card.get("card_data") or {}
+    ai_data = card_data.get("data", card_data)
+    original = ai_data.get("mes_example", "") or ""
+    if not original:
+        return False
+
+    original_tokens = _estimate_tokens(original)
+    target_tokens = max(original_tokens // 4, 200)
+    if original_tokens <= target_tokens:
+        return False
+
+    target_chars = target_tokens * 4
+    truncated_lines: list[str] = []
+    running = 0
+    for line in original.splitlines():
+        next_len = running + len(line) + 1
+        if next_len > target_chars:
+            break
+        truncated_lines.append(line)
+        running = next_len
+    truncated = "\n".join(truncated_lines).rstrip()
+    if not truncated:
+        truncated = original[:target_chars]  # last-resort char-slice
+    ai_data["mes_example"] = truncated
+
+    # Re-run the prompt assembly chain to rebuild system_prompt/post_prompt.
+    from .pipeline import assemble_prompt, expand_variables, inject_tools
+    assemble_prompt(ctx)
+    expand_variables(ctx)
+    inject_tools(ctx)
+    return True
+```
+
+Then extend `fit_prompt`. Insert the Priority 4 block AFTER Priority 3 and BEFORE the report construction. Replace the block starting with `# Priority 3` through the `summary_dropped = True` line with:
+
+```python
+    summary_dropped = False
+    mes_example_truncated = False
+
+    def _current_messages_tokens() -> int:
+        return sum(_estimate_tokens(m.get("content", "")) for m in ctx.get("messages", []))
+
+    def _current_overhead() -> int:
+        return _estimate_tokens(ctx.get("system_prompt", "")) + _estimate_tokens(
+            ctx.get("post_prompt", "")
+        )
+
+    # Priority 2: delegate to strategy.fit with the corrected budget.
+    if messages_budget > 0:
+        ctx["messages"] = strategy.fit(
+            ctx.get("messages", []), messages_budget, ctx=ctx
+        )
+
+    # Priority 3: if still over, drop summary and re-fit.
+    if ctx.get("_summary") and _current_messages_tokens() > messages_budget:
+        ctx["_summary"] = None
+        if messages_budget > 0:
+            ctx["messages"] = strategy.fit(
+                ctx.get("messages", []), messages_budget, ctx=ctx
+            )
+        summary_dropped = True
+        warnings.append("summary dropped to fit messages budget")
+
+    # Priority 4: if overhead alone exceeds available (or messages_budget <= 0),
+    # truncate mes_example and re-run assembly.
+    if messages_budget <= 0 or _current_overhead() > available:
+        if _truncate_mes_example(ctx):
+            mes_example_truncated = True
+            warnings.append("mes_example truncated to fit system prompt")
+            # Recompute overhead and re-fit messages with new budget
+            overhead = _current_overhead()
+            messages_budget = available - overhead
+            if messages_budget > 0:
+                # Re-grab original messages list (already trimmed above, use as-is)
+                ctx["messages"] = strategy.fit(
+                    ctx.get("messages", []), messages_budget, ctx=ctx
+                )
+```
+
+And update the `BudgetReport` construction to use the new locals:
+
+```python
+    report = BudgetReport(
+        model=model,
+        model_ctx=model_ctx,
+        response_reserve=response_reserve,
+        available=available,
+        overhead=_current_overhead(),
+        messages_budget=messages_budget,
+        messages_kept=len(ctx.get("messages", [])),
+        messages_dropped=max(0, messages_before - len(ctx.get("messages", []))),
+        summary_dropped=summary_dropped,
+        mes_example_truncated=mes_example_truncated,
+        estimator_tokens=_current_overhead() + _current_messages_tokens(),
+        actual_tokens=None,
+        warnings=warnings,
+    )
+```
+
+- [ ] **Step 6.4: Run tests and verify they pass**
+
+```bash
+pytest projects/rp/tests/test_budget.py -v
+```
+
+Expected: all tests pass, including the new P4 test.
+
+- [ ] **Step 6.5: Commit**
+
+```bash
+git add projects/rp/budget.py projects/rp/tests/test_budget.py
+git commit --author="Claude <noreply@anthropic.com>" -m "feat(rp/budget): truncate mes_example when overhead dominates (Priority 4)
+
+When the assembled system_prompt exceeds the available budget,
+truncate the character card's mes_example to max(25%, 200 tokens),
+re-run the pipeline assembly hooks, and retry the messages fit.
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Priority 5 — raise `BudgetError` when nothing left to shrink
+
+**Why:** If even the minimum viable prompt (system + greeting + most-recent user message) still doesn't fit, we raise a typed error. Callers decide what to do (HTTP 413 for runtime, skip-and-continue for lora_generate).
+
+**Files:**
+- Modify: `projects/rp/budget.py`
+- Modify: `projects/rp/tests/test_budget.py`
+
+- [ ] **Step 7.1: Write failing test**
+
+Append to `projects/rp/tests/test_budget.py`:
+
+```python
+class TestFitPromptPriority5:
+    @pytest.mark.asyncio
+    async def test_budget_error_when_single_user_message_too_big(
+        self, stub_ollama_factory
+    ):
+        """A user message larger than model_ctx on its own can't be shrunk."""
+        stub = stub_ollama_factory(num_ctx_map={"m": 500})
+        huge = "X" * 20000  # ~5000 tokens
+        ctx = _build_ctx(
+            messages=[
+                {"role": "assistant", "content": "greeting"},
+                {"role": "user", "content": huge},
+            ],
+        )
+        with pytest.raises(BudgetError) as exc_info:
+            await fit_prompt(
+                ctx, model="m", ollama=stub, strategy=SlidingWindow(),
+                num_predict=100, ground_truth=False,
+            )
+        report = exc_info.value.report
+        assert report.model == "m"
+        assert report.model_ctx == 500
+        # Error message should be informative
+        assert "fit" in str(exc_info.value).lower()
+
+    @pytest.mark.asyncio
+    async def test_budget_error_when_system_alone_exceeds_available(
+        self, stub_ollama_factory
+    ):
+        """Even after mes_example truncation, if the rest of the system
+        prompt exceeds available, we raise."""
+        stub = stub_ollama_factory(num_ctx_map={"m": 200})
+        ctx = _build_ctx(
+            system_prompt="X" * 4000,  # ~1000 tokens — overhead dominates
+            messages=[{"role": "user", "content": "hi"}],
+            ai_card={"card_data": {"data": {"mes_example": ""}}},  # nothing to truncate
+        )
+        ctx["user_card"] = {"card_data": {"data": {}}}
+        ctx["scenario"] = {}
+        ctx["prompt_template"] = ""
+
+        with pytest.raises(BudgetError):
+            await fit_prompt(
+                ctx, model="m", ollama=stub, strategy=SlidingWindow(),
+                num_predict=50, ground_truth=False,
+            )
+```
+
+- [ ] **Step 7.2: Run tests to verify they fail**
+
+```bash
+pytest projects/rp/tests/test_budget.py::TestFitPromptPriority5 -v
+```
+
+Expected: FAIL — `BudgetError` not raised (currently fit_prompt just returns an over-budget report).
+
+- [ ] **Step 7.3: Add Priority 5 check**
+
+In `projects/rp/budget.py`, after the Priority 4 block and BEFORE the `report = BudgetReport(...)` construction, add:
+
+```python
+    # Priority 5: if after all shrinking the messages still can't fit under
+    # messages_budget, raise BudgetError. We check: does the minimum viable
+    # set (greeting + most-recent user message) fit?
+    final_msg_tokens = _current_messages_tokens()
+    final_overhead = _current_overhead()
+    if final_overhead + final_msg_tokens > available or messages_budget <= 0:
+        failing_report = BudgetReport(
+            model=model,
+            model_ctx=model_ctx,
+            response_reserve=response_reserve,
+            available=available,
+            overhead=final_overhead,
+            messages_budget=messages_budget,
+            messages_kept=len(ctx.get("messages", [])),
+            messages_dropped=max(0, messages_before - len(ctx.get("messages", []))),
+            summary_dropped=summary_dropped,
+            mes_example_truncated=mes_example_truncated,
+            estimator_tokens=final_overhead + final_msg_tokens,
+            actual_tokens=None,
+            warnings=warnings + ["prompt does not fit after all shrink steps"],
+        )
+        ctx["_budget_report"] = failing_report
+        raise BudgetError(
+            f"Prompt does not fit: model_ctx={model_ctx}, reserve={response_reserve}, "
+            f"overhead={final_overhead}, messages={final_msg_tokens}. "
+            f"The most recent user message may be too long for this model.",
+            failing_report,
+        )
+```
+
+- [ ] **Step 7.4: Run tests and verify they pass**
+
+```bash
+pytest projects/rp/tests/test_budget.py -v
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 7.5: Commit**
+
+```bash
+git add projects/rp/budget.py projects/rp/tests/test_budget.py
+git commit --author="Claude <noreply@anthropic.com>" -m "feat(rp/budget): raise BudgetError when nothing left to shrink (Priority 5)
+
+When even the minimum viable prompt exceeds model_ctx - reserve
+after all shrink priorities, raise a typed BudgetError carrying a
+populated BudgetReport so callers can surface a meaningful message.
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: Ground-truth check path
+
+**Why:** The estimator is ±30% accurate. After estimator-based shrinking, we call Ollama once to get the real `prompt_eval_count`. If still over, we do one more shrink + recount, then raise.
+
+**Files:**
+- Modify: `projects/rp/budget.py`
+- Modify: `projects/rp/tests/test_budget.py`
+
+- [ ] **Step 8.1: Write failing tests**
+
+Append to `projects/rp/tests/test_budget.py`:
+
+```python
+class TestFitPromptGroundTruth:
+    def _render_messages_for_count(self, ctx):
+        """Build the messages list as it would be sent to Ollama."""
+        msgs = [{"role": "system", "content": ctx["system_prompt"]}]
+        msgs.extend(ctx["messages"])
+        if ctx.get("post_prompt"):
+            msgs.append({"role": "system", "content": ctx["post_prompt"]})
+        return msgs
+
+    @pytest.mark.asyncio
+    async def test_ground_truth_fits_first_try(self, stub_ollama_factory):
+        """Estimator says fits, ground-truth confirms."""
+        stub = stub_ollama_factory(
+            num_ctx_map={"m": 8192},
+            count_map={"m": 100},  # ground truth says 100 tokens
+            default_count=100,
+        )
+        ctx = _build_ctx(
+            system_prompt="hello",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+        report = await fit_prompt(
+            ctx, model="m", ollama=stub, strategy=SlidingWindow(),
+            num_predict=1024, ground_truth=True,
+        )
+        assert report.actual_tokens == 100
+        assert stub.chat_calls == 1
+
+    @pytest.mark.asyncio
+    async def test_ground_truth_triggers_one_more_shrink(self, stub_ollama_factory):
+        """Estimator said fits but ground truth says over -> shrink once more."""
+        class ShrinkingStub(StubOllama):
+            def __init__(self):
+                super().__init__(
+                    num_ctx_map={"m": 1000},
+                    default_count=2000,  # first call: over
+                )
+                self.counts = [2000, 400]  # decreasing per call
+                self.call_idx = 0
+
+            async def chat(self, model, messages, tools=None, think=False):
+                self.chat_calls += 1
+                idx = min(self.call_idx, len(self.counts) - 1)
+                self.call_idx += 1
+                return {"done": True, "prompt_eval_count": self.counts[idx]}
+
+        from projects.rp.tests.conftest import StubOllama  # noqa: F401
+        stub = ShrinkingStub()
+        ctx = _build_ctx(
+            messages=[
+                {"role": "assistant", "content": "g"},
+                {"role": "user", "content": "A" * 100},
+                {"role": "user", "content": "B" * 100},
+            ],
+        )
+        report = await fit_prompt(
+            ctx, model="m", ollama=stub, strategy=SlidingWindow(),
+            num_predict=100, ground_truth=True,
+        )
+        assert stub.chat_calls == 2  # first check + recount after shrink
+        assert report.actual_tokens == 400
+
+    @pytest.mark.asyncio
+    async def test_ground_truth_over_twice_raises(self, stub_ollama_factory):
+        """Ground truth still over after one more shrink -> BudgetError."""
+        class OverStub(StubOllama):
+            def __init__(self):
+                super().__init__(
+                    num_ctx_map={"m": 500},
+                    default_count=1000,  # always over
+                )
+
+            async def chat(self, model, messages, tools=None, think=False):
+                self.chat_calls += 1
+                return {"done": True, "prompt_eval_count": 1000}
+
+        from projects.rp.tests.conftest import StubOllama  # noqa: F401
+        stub = OverStub()
+        ctx = _build_ctx(
+            messages=[
+                {"role": "assistant", "content": "g"},
+                {"role": "user", "content": "hi"},
+            ],
+        )
+        with pytest.raises(BudgetError):
+            await fit_prompt(
+                ctx, model="m", ollama=stub, strategy=SlidingWindow(),
+                num_predict=100, ground_truth=True,
+            )
+```
+
+- [ ] **Step 8.2: Run tests to verify they fail**
+
+```bash
+pytest projects/rp/tests/test_budget.py::TestFitPromptGroundTruth -v
+```
+
+Expected: FAIL — first test fails because `ground_truth=True` is not yet wired to make any call.
+
+- [ ] **Step 8.3: Implement ground-truth check**
+
+In `projects/rp/budget.py`, modify `fit_prompt`. After Priority 4 block but BEFORE the Priority 5 block, add:
+
+```python
+    # Ground-truth check: ask Ollama for the real prompt_eval_count.
+    actual_tokens: int | None = None
+    if ground_truth and messages_budget > 0:
+        # Render messages as routes.py / lora_generate.py will send them.
+        gt_messages = _render_for_count(ctx)
+        actual_tokens = await _ollama_count_messages(gt_messages, model, ollama)
+
+        if actual_tokens + response_reserve > model_ctx:
+            # One more shrink: drop one more oldest message (if any) and recount.
+            if len(ctx.get("messages", [])) > 2:
+                # Pop the message right after the greeting (oldest non-greeting).
+                ctx["messages"] = [ctx["messages"][0]] + ctx["messages"][2:]
+                gt_messages = _render_for_count(ctx)
+                actual_tokens = await _ollama_count_messages(gt_messages, model, ollama)
+            # If still over, let Priority 5 below raise.
+```
+
+Also add this helper function above `fit_prompt`:
+
+```python
+def _render_for_count(ctx: dict) -> list[dict]:
+    """Build the messages list that would actually be sent to Ollama.
+
+    Mirrors routes.py _build_chat_messages: system_prompt, then the
+    budgeted messages, then post_prompt (if any) as a trailing system
+    message. Does NOT append the "assistant: name " anchor — that's a
+    runtime concern and tokenizes to only a few tokens.
+    """
+    msgs = [{"role": "system", "content": ctx.get("system_prompt", "")}]
+    msgs.extend(ctx.get("messages", []))
+    if ctx.get("post_prompt"):
+        msgs.append({"role": "system", "content": ctx["post_prompt"]})
+    return msgs
+```
+
+Then update the Priority 5 condition to use `actual_tokens` when available:
+
+```python
+    # Priority 5: ...
+    final_msg_tokens = _current_messages_tokens()
+    final_overhead = _current_overhead()
+    effective_total = (
+        actual_tokens if actual_tokens is not None
+        else final_overhead + final_msg_tokens
+    )
+    if effective_total + response_reserve > model_ctx or messages_budget <= 0:
+        # ... same BudgetError block as before, but with actual_tokens set
+```
+
+Update the failing_report construction in Priority 5 to include `actual_tokens=actual_tokens,`.
+
+And in the non-error return path at the bottom, set `actual_tokens=actual_tokens` on the successful `BudgetReport`.
+
+- [ ] **Step 8.4: Run tests and verify they pass**
+
+```bash
+pytest projects/rp/tests/test_budget.py -v
+```
+
+Expected: all tests pass. If `test_ground_truth_triggers_one_more_shrink` fails, verify the shrink step removes the correct message and that the second chat call returns the smaller count.
+
+- [ ] **Step 8.5: Commit**
+
+```bash
+git add projects/rp/budget.py projects/rp/tests/test_budget.py
+git commit --author="Claude <noreply@anthropic.com>" -m "feat(rp/budget): add ground-truth token count verification
+
+After estimator-based shrinking, call Ollama once via _ollama_count_messages
+to get the real prompt_eval_count. If still over, drop one more
+oldest message and recount once. If still over, Priority 5 raises.
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 9: `fit_raw_prompt` for single-shot prompts
+
+**Why:** `lora_generate.py` builds raw prompts (not chat messages) and needs a simpler budgeting API that just checks fit and raises if not.
+
+**Files:**
+- Modify: `projects/rp/budget.py`
+- Modify: `projects/rp/tests/test_budget.py`
+
+- [ ] **Step 9.1: Write failing tests**
+
+Append to `projects/rp/tests/test_budget.py`:
+
+```python
+from projects.rp.budget import fit_raw_prompt
+
+
+class TestFitRawPrompt:
+    @pytest.mark.asyncio
+    async def test_small_prompt_fits(self, stub_ollama_factory):
+        stub = stub_ollama_factory(
+            num_ctx_map={"m": 8192},
+            count_map={"m": 200},
+        )
+        prompt, report = await fit_raw_prompt(
+            prompt="hello world",
+            system="be helpful",
+            model="m",
+            ollama=stub,
+            num_predict=500,
+            ground_truth=True,
+        )
+        assert prompt == "hello world"
+        assert report.actual_tokens == 200
+        assert report.model_ctx == 8192
+
+    @pytest.mark.asyncio
+    async def test_oversized_prompt_raises(self, stub_ollama_factory):
+        stub = stub_ollama_factory(
+            num_ctx_map={"m": 500},
+            count_map={"m": 10000},  # ground-truth says way over
+        )
+        with pytest.raises(BudgetError) as exc_info:
+            await fit_raw_prompt(
+                prompt="X" * 40000,
+                system="",
+                model="m",
+                ollama=stub,
+                num_predict=100,
+                ground_truth=True,
+            )
+        assert exc_info.value.report.model_ctx == 500
+
+    @pytest.mark.asyncio
+    async def test_ground_truth_off_uses_estimator(self, stub_ollama_factory):
+        stub = stub_ollama_factory(num_ctx_map={"m": 8192})
+        prompt, report = await fit_raw_prompt(
+            prompt="hi",
+            system=None,
+            model="m",
+            ollama=stub,
+            num_predict=1024,
+            ground_truth=False,
+        )
+        assert report.actual_tokens is None
+        assert stub.chat_calls == 0
+
+    @pytest.mark.asyncio
+    async def test_default_num_predict_is_1024(self, stub_ollama_factory):
+        stub = stub_ollama_factory(num_ctx_map={"m": 8192})
+        _, report = await fit_raw_prompt(
+            prompt="hi", system=None, model="m", ollama=stub,
+            num_predict=None, ground_truth=False,
+        )
+        assert report.response_reserve == 1024
+```
+
+- [ ] **Step 9.2: Run tests to verify they fail**
+
+```bash
+pytest projects/rp/tests/test_budget.py::TestFitRawPrompt -v
+```
+
+Expected: FAIL — `cannot import name 'fit_raw_prompt'`.
+
+- [ ] **Step 9.3: Implement `fit_raw_prompt`**
+
+Append to `projects/rp/budget.py`:
+
+```python
+async def fit_raw_prompt(
+    *,
+    prompt: str,
+    system: str | None,
+    model: str,
+    ollama: _OllamaLike,
+    num_predict: int | None = None,
+    ground_truth: bool = True,
+) -> tuple[str, BudgetReport]:
+    """Budget a single-shot raw prompt (used by lora_generate).
+
+    Does NOT shrink the prompt — single-shot prompts have no safe
+    shrinking heuristic. If it doesn't fit, raises BudgetError and the
+    caller (lora_generate) decides to skip that scenario/turn.
+    """
+    model_ctx = await _get_model_ctx(model, ollama)
+    response_reserve = num_predict if num_predict is not None else 1024
+    available = model_ctx - response_reserve
+
+    prompt = prompt or ""
+    system = system or ""
+    overhead = _estimate_tokens(prompt) + _estimate_tokens(system)
+
+    actual_tokens: int | None = None
+    if ground_truth:
+        # Build a minimal messages list matching how lora_generate sends it.
+        gt_messages: list[dict] = []
+        if system:
+            gt_messages.append({"role": "system", "content": system})
+        gt_messages.append({"role": "user", "content": prompt})
+        actual_tokens = await _ollama_count_messages(gt_messages, model, ollama)
+
+    effective_total = actual_tokens if actual_tokens is not None else overhead
+    fits = (effective_total + response_reserve) <= model_ctx
+
+    report = BudgetReport(
+        model=model,
+        model_ctx=model_ctx,
+        response_reserve=response_reserve,
+        available=available,
+        overhead=overhead,
+        messages_budget=available - overhead,
+        messages_kept=1,
+        messages_dropped=0,
+        summary_dropped=False,
+        mes_example_truncated=False,
+        estimator_tokens=overhead,
+        actual_tokens=actual_tokens,
+        warnings=[],
+    )
+
+    if not fits:
+        raise BudgetError(
+            f"Raw prompt does not fit: model_ctx={model_ctx}, reserve={response_reserve}, "
+            f"prompt_tokens={effective_total}.",
+            report,
+        )
+    return prompt, report
+```
+
+- [ ] **Step 9.4: Run tests and verify they pass**
+
+```bash
+pytest projects/rp/tests/test_budget.py -v
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 9.5: Commit**
+
+```bash
+git add projects/rp/budget.py projects/rp/tests/test_budget.py
+git commit --author="Claude <noreply@anthropic.com>" -m "feat(rp/budget): add fit_raw_prompt for single-shot prompts
+
+Simpler API used by lora_generate.py: checks fit of a raw prompt +
+system against model_ctx - reserve. No shrinking (single-shot
+prompts have no safe heuristic). Raises BudgetError with a
+populated report when the prompt won't fit.
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 10: Wire `fit_prompt` into `routes.py` — `send_message` + delete old hook
+
+**Why:** This is the biggest behavioral change. Do `send_message` first (the main code path), verify manually with the running server, then roll out to the other call sites.
+
+**Files:**
+- Modify: `projects/rp/routes.py`
+- Modify: `projects/rp/pipeline.py` (remove `apply_context_strategy` from default pipeline)
+
+- [ ] **Step 10.1: Add an imports block and a budgeting helper to `routes.py`**
+
+At the top of `projects/rp/routes.py`, find the existing import block that has:
+
+```python
+from .pipeline import create_default_pipeline
+```
+
+Change it to:
+
+```python
+from .pipeline import create_default_pipeline
+from .budget import fit_prompt, BudgetError
+from .context import get_strategy
+```
+
+Then, inside the `register(app, ollama, resolve_model)` function body (the place where `_build_pipeline_ctx` is defined, around line 425), add this helper right after `_build_pipeline_ctx`:
+
+```python
+    async def _budget_ctx(ctx, model, ollama_options):
+        """Run fit_prompt against ctx, using scenario-configured strategy.
+
+        On BudgetError, logs a WARNING and re-raises — callers handle the
+        response (HTTP 413, stream error chunk, etc.).
+        """
+        scenario = ctx.get("scenario") or {}
+        settings = scenario.get("settings", {})
+        strategy = get_strategy(settings.get("context_strategy", "summary_buffer"))
+        num_predict = ollama_options.get("num_predict") if ollama_options else None
+        try:
+            return await fit_prompt(
+                ctx, model=model, ollama=_ollama,
+                strategy=strategy, num_predict=num_predict,
+                ground_truth=True,
+            )
+        except BudgetError as e:
+            _log.warning("Budget error for model=%s: %s", model, e)
+            raise
+```
+
+- [ ] **Step 10.2: Wire `_budget_ctx` into `send_message` around line 743**
+
+Find this block in `send_message` (around line 743):
+
+```python
+        chat_messages = _build_chat_messages(ctx)
+        user_name = _get_user_name(ctx)
+```
+
+Insert a call to `_budget_ctx` right before it, and also merge `num_ctx` into the Ollama options. Replace those two lines with:
+
+```python
+        try:
+            await _budget_ctx(ctx, model, ollama_options)
+        except BudgetError as e:
+            async def _err_stream():
+                yield json.dumps({
+                    "error": f"Prompt does not fit model context: {e}",
+                    "done": True,
+                }) + "\n"
+            return StreamingResponse(_err_stream(), media_type="application/x-ndjson",
+                                     status_code=413)
+
+        # Tell Ollama to load the model with its real context window
+        ollama_options = {**ollama_options, "num_ctx": ctx["_num_ctx"]}
+
+        chat_messages = _build_chat_messages(ctx)
+        user_name = _get_user_name(ctx)
+```
+
+- [ ] **Step 10.3: Remove `apply_context_strategy` from the default pipeline**
+
+Open `projects/rp/pipeline.py`. Find `create_default_pipeline` (around line 208):
+
+```python
+def create_default_pipeline() -> Pipeline:
+    """Create pipeline with standard hooks."""
+    p = Pipeline()
+    p.add_pre(assemble_prompt)
+    p.add_pre(expand_variables)
+    p.add_pre(inject_tools)
+    p.add_pre(apply_context_strategy)
+    p.add_post(clean_response)
+    return p
+```
+
+Remove the `p.add_pre(apply_context_strategy)` line:
+
+```python
+def create_default_pipeline() -> Pipeline:
+    """Create pipeline with standard hooks.
+
+    NOTE: context budgeting is no longer part of the pipeline — it's
+    now done explicitly at each call site via budget.fit_prompt, which
+    needs access to the ollama client and resolved model name.
+    """
+    p = Pipeline()
+    p.add_pre(assemble_prompt)
+    p.add_pre(expand_variables)
+    p.add_pre(inject_tools)
+    p.add_post(clean_response)
+    return p
+```
+
+Leave `apply_context_strategy` defined for now — we'll delete it in Task 13 after all call sites are migrated.
+
+- [ ] **Step 10.4: Run the pipeline tests**
+
+```bash
+pytest projects/rp/tests/test_pipeline.py -v
+```
+
+Expected: any tests that asserted `apply_context_strategy` was in the pipeline will fail. If such a test exists, remove or update it (the hook is no longer in the default pipeline).
+
+- [ ] **Step 10.5: Sanity-check the runtime by hand**
+
+Restart aiserver and send one message to an existing conversation:
+
+```bash
+bash projects/aiserver/restart.sh
+# In another shell, or via the rp UI at http://localhost:8080/rp/
+# send a message to an existing conversation.
+tail -20 /tmp/aiserver.log
+```
+
+Expected: request completes normally. Look for `INFO: Loaded num_ctx=<N> for model <M>` on the first request for each model.
+
+- [ ] **Step 10.6: Commit**
+
+```bash
+git add projects/rp/routes.py projects/rp/pipeline.py
+git commit --author="Claude <noreply@anthropic.com>" -m "feat(rp/routes): wire fit_prompt into send_message
+
+Replaces the old apply_context_strategy pre-hook with an explicit
+_budget_ctx helper called after pipeline pre-hooks. On BudgetError,
+returns HTTP 413 with an error stream chunk. Also passes num_ctx
+into the Ollama options dict so the model is loaded with its real
+context window.
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 11: Wire `fit_prompt` into the remaining `routes.py` call sites
+
+**Why:** `regenerate`, `auto_user`, and two other code paths all call `_build_pipeline_ctx` + Ollama. They need the same treatment as `send_message`.
+
+**Files:**
+- Modify: `projects/rp/routes.py` (4 locations)
+
+Identified call sites (from the earlier grep at Preflight time):
+1. `regenerate` — around line 855
+2. The three call sites at lines ~913, ~991, ~1011 (auto-user / swap / other branches)
+
+For each call site: find the pattern `_build_pipeline_ctx` → `_build_ollama_options` → `_build_chat_messages`, and wrap it the same way as `send_message`.
+
+- [ ] **Step 11.1: Wire `_budget_ctx` into `regenerate` (line ~855)**
+
+Find in `regenerate`:
+
+```python
+        ctx = await _build_pipeline_ctx(conv, messages)
+
+        model = _resolve_model(conv["model"])
+        scenario = ctx.get("scenario") or {}
+        settings = scenario.get("settings", {})
+        ollama_options = _build_ollama_options(settings)
+
+        chat_messages = _build_chat_messages(ctx)
+```
+
+Replace with:
+
+```python
+        ctx = await _build_pipeline_ctx(conv, messages)
+
+        model = _resolve_model(conv["model"])
+        scenario = ctx.get("scenario") or {}
+        settings = scenario.get("settings", {})
+        ollama_options = _build_ollama_options(settings)
+
+        try:
+            await _budget_ctx(ctx, model, ollama_options)
+        except BudgetError as e:
+            async def _err_stream():
+                yield json.dumps({
+                    "error": f"Prompt does not fit model context: {e}",
+                    "done": True,
+                }) + "\n"
+            return StreamingResponse(_err_stream(), media_type="application/x-ndjson",
+                                     status_code=413)
+        ollama_options = {**ollama_options, "num_ctx": ctx["_num_ctx"]}
+
+        chat_messages = _build_chat_messages(ctx)
+```
+
+- [ ] **Step 11.2: Wire `_budget_ctx` into the remaining 3 call sites**
+
+Repeat the same pattern at each of the other `_build_pipeline_ctx` call sites in `routes.py` (around lines 913, 991, 1011). In each case:
+
+1. After the `ollama_options = _build_ollama_options(settings)` line.
+2. Before the `chat_messages = _build_chat_messages(ctx)` line.
+3. Insert the `try: await _budget_ctx(ctx, model, ollama_options)` block and the `ollama_options = {**ollama_options, "num_ctx": ctx["_num_ctx"]}` line.
+
+Grep to find any you missed:
+
+```bash
+grep -n "_build_chat_messages(ctx)" projects/rp/routes.py
+```
+
+Each match should now have `_budget_ctx` called above it. If any don't, apply the same pattern.
+
+- [ ] **Step 11.3: Smoke-test each code path by hand**
+
+Through the rp UI or curl, exercise:
+1. Regenerate the last assistant message (`POST /rp/conversations/{id}/regenerate`)
+2. Auto-user message (the "user types for me" flow, if wired)
+3. Any other flow hitting `_build_chat_messages`
+
+Expected: all complete successfully, `/tmp/aiserver.log` shows no BudgetError unless triggered by a truly oversized conversation.
+
+- [ ] **Step 11.4: Commit**
+
+```bash
+git add projects/rp/routes.py
+git commit --author="Claude <noreply@anthropic.com>" -m "feat(rp/routes): wire fit_prompt into regenerate and other call sites
+
+Applies the same _budget_ctx + num_ctx injection pattern to
+regenerate, auto-user, and the remaining call sites identified by
+grepping for _build_chat_messages.
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 12: Wire `fit_raw_prompt` into `lora_generate.py`
+
+**Why:** The synthetic data generator has no pipeline; each of its Ollama calls needs its own budget check. On `BudgetError`, the current scenario/turn is skipped and the run continues.
+
+**Files:**
+- Modify: `projects/rp/lora_generate.py`
+- Test: `projects/rp/tests/test_lora_generate_budget.py` (new)
+
+- [ ] **Step 12.1: Write the failing tests**
+
+Create `projects/rp/tests/test_lora_generate_budget.py`:
+
+```python
+"""Tests for lora_generate.py integration with budget.fit_raw_prompt."""
+
+import pytest
+from unittest.mock import AsyncMock
+
+from projects.rp import lora_generate
+from projects.rp.budget import BudgetError, BudgetReport
+
+
+def _report(model_ctx=8192):
+    return BudgetReport(
+        model="m", model_ctx=model_ctx, response_reserve=500,
+        available=model_ctx - 500, overhead=100, messages_budget=0,
+        messages_kept=0, messages_dropped=0,
+        summary_dropped=False, mes_example_truncated=False,
+        estimator_tokens=100, actual_tokens=100, warnings=[],
+    )
+
+
+class TestGenerateScenariosBudgetSkip:
+    @pytest.mark.asyncio
+    async def test_budget_error_skips_category(self, monkeypatch):
+        """If fit_raw_prompt raises for one category, that category is
+        skipped but generate_scenarios returns scenarios from the others."""
+        ollama = AsyncMock()
+        ollama.get_num_ctx = AsyncMock(return_value=8192)
+        ollama.generate = AsyncMock(return_value='["s1.", "s2.", "s3."]')
+        ollama.chat = AsyncMock(return_value={"prompt_eval_count": 100, "done": True})
+
+        call_count = {"n": 0}
+
+        async def _fake_fit_raw_prompt(**kwargs):
+            call_count["n"] += 1
+            if call_count["n"] == 2:
+                raise BudgetError("too big", _report(500))
+            return kwargs["prompt"], _report()
+
+        monkeypatch.setattr(lora_generate, "fit_raw_prompt", _fake_fit_raw_prompt)
+
+        ai_card = {"data": {"name": "Ann", "description": "x", "personality": "y"}}
+        user_card = {"data": {"name": "Bea", "description": "z"}}
+        scenarios = await lora_generate.generate_scenarios(
+            ollama, "m", ai_card, user_card, num_per_category=3
+        )
+        # 8 categories * 3 scenarios each = 24, minus 3 from skipped = 21
+        assert len(scenarios) == 21
+
+
+class TestGenerateUserMessageBudgetError:
+    @pytest.mark.asyncio
+    async def test_returns_empty_on_budget_error(self, monkeypatch):
+        """BudgetError in generate_user_message returns '' so the existing
+        'empty message' branch in generate_conversation stops the turn."""
+        ollama = AsyncMock()
+
+        async def _fake_fit(**kwargs):
+            raise BudgetError("too big", _report(500))
+
+        monkeypatch.setattr(lora_generate, "fit_raw_prompt", _fake_fit)
+
+        context = {
+            "char_name": "Ann", "user_name": "Bea",
+            "user_personality": "p", "scenario": "s", "history": [],
+        }
+        result = await lora_generate.generate_user_message(ollama, "m", context)
+        assert result == ""
+```
+
+- [ ] **Step 12.2: Run tests to verify they fail**
+
+```bash
+pytest projects/rp/tests/test_lora_generate_budget.py -v
+```
+
+Expected: FAIL — tests exercise code paths that don't yet call `fit_raw_prompt`.
+
+- [ ] **Step 12.3: Wire `fit_raw_prompt` into `lora_generate.py`**
+
+Open `projects/rp/lora_generate.py`. Add the import at the top after the existing `from .pipeline import ...` line:
+
+```python
+from .budget import fit_raw_prompt, BudgetError
+```
+
+In `generate_scenarios` (around line 182), find the block:
+
+```python
+        raw = await ollama.generate(
+            model=model, prompt=prompt,
+            system="Output valid JSON only. No markdown fences.",
+            options={"temperature": 0.9, "num_predict": 1024, "think": False},
+        )
+```
+
+Wrap it with budget check:
+
+```python
+        try:
+            prompt, _ = await fit_raw_prompt(
+                prompt=prompt,
+                system="Output valid JSON only. No markdown fences.",
+                model=model,
+                ollama=ollama,
+                num_predict=1024,
+            )
+        except BudgetError as e:
+            _log.warning(
+                "Skipping category %s for %s: prompt does not fit (%s)",
+                cat["category"], char_name, e,
+            )
+            continue
+
+        raw = await ollama.generate(
+            model=model, prompt=prompt,
+            system="Output valid JSON only. No markdown fences.",
+            options={"temperature": 0.9, "num_predict": 1024, "think": False,
+                     "num_ctx": (await _get_model_ctx_hint(model, ollama))},
+        )
+```
+
+That last `num_ctx` argument needs a helper that just calls `_get_model_ctx`. Add at the top of the file after imports:
+
+```python
+from .budget import _get_model_ctx
+
+async def _get_model_ctx_hint(model: str, ollama) -> int:
+    """Wrap _get_model_ctx for direct use in options dicts."""
+    return await _get_model_ctx(model, ollama)
+```
+
+Actually this is awkward. Simpler approach: capture the num_ctx once in `generate_conversation` and `generate_scenarios` and thread it down. Refactor:
+
+At the top of `generate_scenarios`:
+
+```python
+    num_ctx = await _get_model_ctx(model, ollama)
+```
+
+Then pass `"num_ctx": num_ctx` into every `options` dict in that function. Same for `generate_conversation` → `generate_user_message` / `generate_assistant_message`: resolve `num_ctx` once in `generate_conversation`, pass it via the `context` dict, and the sub-functions read it when building options.
+
+Concretely, in `generate_user_message`, change:
+
+```python
+    raw = await ollama.generate(
+        model=model, prompt=prompt,
+        system=f"You are {context['user_name']}. Write their next message only.",
+        options={"temperature": 1.0, "num_predict": 300, "think": False},
+    )
+    return raw.strip().strip('"')
+```
+
+to:
+
+```python
+    try:
+        prompt, _ = await fit_raw_prompt(
+            prompt=prompt,
+            system=f"You are {context['user_name']}. Write their next message only.",
+            model=model, ollama=ollama, num_predict=300,
+        )
+    except BudgetError as e:
+        _log.warning("User msg budget error: %s", e)
+        return ""
+
+    raw = await ollama.generate(
+        model=model, prompt=prompt,
+        system=f"You are {context['user_name']}. Write their next message only.",
+        options={
+            "temperature": 1.0, "num_predict": 300, "think": False,
+            "num_ctx": context.get("_num_ctx") or 2048,
+        },
+    )
+    return raw.strip().strip('"')
+```
+
+In `generate_assistant_message`, apply the same treatment — the prompt here is effectively `system_prompt + messages`. Build a single string or just pass `system_prompt` as system + the last user message as prompt. Since `fit_raw_prompt` takes `prompt` + `system`, use:
+
+```python
+    # Serialize chat messages into a single prompt for budget checking.
+    serialized = "\n".join(f"{m['role']}: {m['content']}" for m in chat_msgs[1:])
+    try:
+        _, _ = await fit_raw_prompt(
+            prompt=serialized, system=system_prompt,
+            model=model, ollama=ollama, num_predict=768,
+        )
+    except BudgetError as e:
+        _log.warning("Assistant msg budget error: %s", e)
+        return ""
+```
+
+And add `"num_ctx": context_num_ctx` to the options (read from a module-level cache or threaded in).
+
+To keep this simple, have `generate_conversation` fetch and cache `num_ctx`:
+
+```python
+async def generate_conversation(ollama, model_70b: str, ai_card: dict, user_card: dict,
+                                scenario: dict, num_turns: int = 12) -> dict | None:
+    """Generate a full multi-turn conversation."""
+    try:
+        num_ctx = await _get_model_ctx(model_70b, ollama)
+    except Exception as e:
+        _log.error("Cannot determine num_ctx for %s: %s", model_70b, e)
+        return None
+
+    ai_data = ai_card.get("data", ai_card)
+    # ... existing code ...
+
+    context = {
+        "char_name": char_name,
+        "user_name": user_name,
+        "user_personality": user_data.get("personality", "") or user_data.get("description", ""),
+        "scenario": scenario["text"],
+        "history": messages,
+        "_num_ctx": num_ctx,
+    }
+```
+
+Then `generate_user_message` and `generate_assistant_message` read `context["_num_ctx"]` for their options. (The test in Step 12.1 doesn't inspect options so this refactoring is compatible.)
+
+- [ ] **Step 12.4: Run tests and verify they pass**
+
+```bash
+pytest projects/rp/tests/test_lora_generate_budget.py -v
+pytest projects/rp/tests/ -v
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 12.5: Run the ruff linter over the changed files**
+
+```bash
+cd projects/aiserver && source .venv/bin/activate && cd ../..
+ruff check projects/rp/lora_generate.py projects/rp/budget.py projects/rp/routes.py
+```
+
+Expected: no errors (or only pre-existing ones you didn't touch).
+
+- [ ] **Step 12.6: Commit**
+
+```bash
+git add projects/rp/lora_generate.py projects/rp/tests/test_lora_generate_budget.py
+git commit --author="Claude <noreply@anthropic.com>" -m "feat(rp/lora_generate): budget each Ollama call via fit_raw_prompt
+
+generate_scenarios, generate_user_message, and generate_assistant_message
+now call fit_raw_prompt before hitting Ollama. BudgetError results in
+skip-and-log (scenarios) or empty-return (turns), letting the existing
+control flow continue the overall run instead of aborting.
+
+Also threads num_ctx from generate_conversation's single /api/show call
+into every Ollama options dict so long lora runs don't thrash the model
+load.
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 13: Delete `apply_context_strategy` and add equivalence regression test
+
+**Why:** All call sites are migrated. The old function is dead code and should be removed. Add one regression test to confirm that the new `fit_prompt + SlidingWindow` path produces the same message trimming as the old `apply_context_strategy` did for the equivalence case (empty system prompt).
+
+**Files:**
+- Modify: `projects/rp/pipeline.py` (delete function)
+- Modify: `projects/rp/tests/test_pipeline.py` (remove tests that reference the deleted function, if any)
+- Modify: `projects/rp/tests/test_budget.py` (add equivalence test)
+
+- [ ] **Step 13.1: Verify no remaining references**
+
+```bash
+grep -rn "apply_context_strategy" projects/ docs/ 2>&1
+```
+
+Expected: only matches in `projects/rp/pipeline.py` (the definition) and possibly `projects/rp/tests/test_pipeline.py` (an old test).
+
+- [ ] **Step 13.2: Delete the function from `pipeline.py`**
+
+Open `projects/rp/pipeline.py` and delete lines 172–180 (the `apply_context_strategy` function definition).
+
+- [ ] **Step 13.3: Update or remove any tests that referenced it**
+
+If `projects/rp/tests/test_pipeline.py` imports or uses `apply_context_strategy`, delete or update those test functions.
+
+- [ ] **Step 13.4: Add an equivalence regression test**
+
+Append to `projects/rp/tests/test_budget.py`:
+
+```python
+class TestEquivalenceWithOldBehavior:
+    @pytest.mark.asyncio
+    async def test_empty_system_prompt_matches_sliding_window(
+        self, stub_ollama_factory
+    ):
+        """With an empty system prompt, fit_prompt should produce the same
+        messages trimming that the old apply_context_strategy did — that is,
+        pure SlidingWindow behavior against the raw max_tokens."""
+        stub = stub_ollama_factory(num_ctx_map={"m": 1000})
+        # Each msg ~25 tokens (len//4). Budget 1000 - 500 reserve = 500.
+        # Overhead = 0. messages_budget = 500. ~20 messages fit, but the
+        # strategy also protects the greeting.
+        messages = [
+            {"role": "assistant", "content": "G" * 100},  # greeting
+        ]
+        for i in range(30):
+            messages.append({"role": "user", "content": f"msg {i:02d} " + "X" * 100})
+
+        ctx = _build_ctx(system_prompt="", post_prompt="", messages=messages)
+        expected = SlidingWindow().fit(list(messages), max_tokens=500)
+
+        await fit_prompt(
+            ctx, model="m", ollama=stub, strategy=SlidingWindow(),
+            num_predict=500, ground_truth=False,
+        )
+        assert ctx["messages"] == expected
+```
+
+- [ ] **Step 13.5: Run tests**
+
+```bash
+pytest projects/rp/tests/test_budget.py projects/rp/tests/test_pipeline.py projects/rp/tests/test_context.py -v
+```
+
+Expected: all pass.
+
+- [ ] **Step 13.6: Commit**
+
+```bash
+git add projects/rp/pipeline.py projects/rp/tests/test_pipeline.py projects/rp/tests/test_budget.py
+git commit --author="Claude <noreply@anthropic.com>" -m "refactor(rp): delete apply_context_strategy + add equivalence test
+
+All call sites now use budget.fit_prompt. Removes the dead
+apply_context_strategy function from pipeline.py. Adds an equivalence
+regression test confirming that fit_prompt with an empty system prompt
+produces the same messages trimming that SlidingWindow did directly.
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 14: End-to-end smoke test with the running aiserver
+
+**Why:** Unit tests mock everything. Before opening a PR, run one real request through the stack to confirm `num_ctx` propagation actually takes effect and the ground-truth counting works with real Ollama.
+
+**Files:** none (manual verification)
+
+- [ ] **Step 14.1: Restart aiserver in the worktree**
+
+```bash
+cd /mnt/d/prg/plum-prompt-budgeting/projects/aiserver
+source .venv/bin/activate
+# Kill any running aiserver from the main tree first
+bash /mnt/d/prg/plum/projects/aiserver/restart.sh || true
+# Start fresh from the worktree
+nohup python main.py > /tmp/aiserver-pb.log 2>&1 &
+sleep 3
+curl -s http://localhost:8080/health
+```
+
+Expected: JSON with `status: ok`, `ollama_connected: true`.
+
+- [ ] **Step 14.2: Send a real conversation turn**
+
+Via the rp UI at http://localhost:8080/rp/, or via curl with an existing conversation ID:
+
+```bash
+curl -N -X POST http://localhost:8080/rp/conversations/78/message \
+  -H "Content-Type: application/json" \
+  -d '{"content": "hello, how are you today?"}'
+```
+
+Expected: streaming NDJSON response. Generation completes normally.
+
+- [ ] **Step 14.3: Inspect the log for budgeting activity**
+
+```bash
+grep -E "Loaded num_ctx|Budget|budget|num_ctx" /tmp/aiserver-pb.log | tail -20
+```
+
+Expected: an INFO line like `Loaded num_ctx=<N> for model <M>` for each model hit. No errors.
+
+- [ ] **Step 14.4: (Optional) Force a BudgetError**
+
+Paste a very long message (50k+ characters) via the UI to a conversation on a small-context model. Expected: stream returns an `error` chunk containing "Prompt does not fit model context", HTTP status 413.
+
+- [ ] **Step 14.5: Kill the worktree aiserver and restart the main one**
+
+```bash
+pkill -f "python main.py" || true
+bash /mnt/d/prg/plum/projects/aiserver/restart.sh
+```
+
+Expected: main tree aiserver running again.
+
+This task has no commit — it's a verification step. Proceed to Task 15.
+
+---
+
+## Task 15: Open the PR
+
+**Files:** none (PR creation via `gh`)
+
+- [ ] **Step 15.1: Push the branch**
+
+```bash
+cd /mnt/d/prg/plum-prompt-budgeting
+git push -u origin prompt-budgeting
+```
+
+- [ ] **Step 15.2: Open the PR**
+
+```bash
+gh pr create --title "feat(rp): prompt budgeting for runtime + lora_generate" --body "$(cat <<'EOF'
+## Summary
+
+- New `projects/rp/budget.py` shared module with `fit_prompt` and `fit_raw_prompt` entry points
+- `OllamaClient.get_num_ctx` reads the model's real context window from `/api/show`, cached per process
+- rp runtime pipeline and `lora_generate.py` both budget against `model_ctx - response_reserve` using a deterministic shrink policy (oldest messages → summary → mes_example truncation → typed `BudgetError`)
+- `num_ctx` is now passed explicitly to Ollama on every generation call, eliminating the silent 2048 default
+
+## Test plan
+
+- [ ] `cd /mnt/d/prg/plum-prompt-budgeting && cd projects/aiserver && source .venv/bin/activate && cd ../.. && pytest projects/rp/tests/ projects/aiserver/tests/ -v` — all unit tests pass
+- [ ] `bash projects/aiserver/restart.sh` — aiserver starts cleanly
+- [ ] Send one message via the rp UI to an existing conversation — generation completes normally
+- [ ] `grep "Loaded num_ctx" /tmp/aiserver.log` — shows one entry per model on first request
+- [ ] Paste a 50k-character wall of text as a user message on a small-context model — receive HTTP 413 with "Prompt does not fit model context" error chunk
+
+## Spec & plan
+
+- Design: `docs/superpowers/specs/2026-04-07-rp-prompt-budgeting-design.md`
+- Implementation plan: `docs/superpowers/plans/2026-04-07-rp-prompt-budgeting.md`
+
+## Migration notes
+
+- `max_context_tokens` in scenario settings is now ignored (deprecated, not rejected). Users who relied on it to deliberately cap context on a big model will see longer context used after this lands.
+- First request to each model after aiserver restart triggers a one-time model reload with the full `num_ctx`. For large models (70B) this can take tens of seconds. Subsequent requests are fast.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Expected: PR URL is printed. The task is done.
+
+---
+
+## Self-Review Checklist (performed before handing off)
+
+**Spec coverage:**
+
+- ✅ `OllamaClient.get_num_ctx` — Task 1
+- ✅ `budget.py` module with `BudgetError`, `BudgetReport`, `_get_model_ctx` caching + per-model lock — Task 2
+- ✅ `_ollama_count_messages` ground-truth helper — Task 3
+- ✅ `fit_prompt` happy path + Priority 2 (strategy drop) — Task 4
+- ✅ Priority 3 (drop summary) — Task 5
+- ✅ Priority 4 (truncate mes_example + re-run assembly) — Task 6
+- ✅ Priority 5 (BudgetError with populated report) — Task 7
+- ✅ Ground-truth check + one-more-shrink retry — Task 8
+- ✅ `fit_raw_prompt` for single-shot prompts — Task 9
+- ✅ `routes.py` send_message integration — Task 10
+- ✅ `routes.py` regenerate + 3 other call sites — Task 11
+- ✅ `lora_generate.py` integration at all 3 Ollama call points — Task 12
+- ✅ `num_ctx` propagation in Ollama options — Tasks 10, 11, 12
+- ✅ Delete dead `apply_context_strategy` + equivalence regression test — Task 13
+- ✅ End-to-end smoke test — Task 14
+- ✅ PR opening with inline test plan — Task 15
+
+**Placeholder scan:** No TBDs, TODOs, or "handle appropriately" phrases. Every code step shows the actual code.
+
+**Type consistency:** `BudgetReport` fields match across Task 2 (definition), Task 4 (construction), Task 7 (failing_report), Task 9 (fit_raw_prompt construction), Task 12 (test fixture).
+
+**Naming consistency:** `_get_model_ctx`, `fit_prompt`, `fit_raw_prompt`, `_budget_ctx` (the routes helper), `BudgetError`, `BudgetReport`, `_ollama_count_messages`, `_render_for_count`, `_estimate_tokens`, `_truncate_mes_example` — used identically everywhere they appear.
+
+**Scope:** Exactly the two paths scoped at brainstorming time (runtime pipeline + lora_generate). Nothing crept in (eval scripts, fewshot retrieval, summarizer — all explicitly out of scope in the spec).

--- a/docs/superpowers/specs/2026-04-07-rp-prompt-budgeting-design.md
+++ b/docs/superpowers/specs/2026-04-07-rp-prompt-budgeting-design.md
@@ -1,0 +1,395 @@
+# Prompt Budgeting for rp + lora_generate
+
+**Status:** Design approved
+**Date:** 2026-04-07
+**Branch:** `prompt-budgeting`
+
+## Problem
+
+The rp runtime pipeline and `lora_generate.py` both assemble prompts that can silently overflow the model's context window. The current budgeting logic in `projects/rp/pipeline.py:apply_context_strategy` has three gaps:
+
+1. It budgets only `messages`, not the system prompt, tool descriptions, `post_prompt`, or `scene_state`. A fat `mes_example` plus injected tool descriptions can add 2–3k tokens that nobody counts.
+2. The budget value is a hardcoded-per-scenario `max_context_tokens` (default 6144) that bears no relation to the model's actual context window.
+3. No headroom is reserved for the response. Ollama's generation can get cut off mid-token.
+
+`lora_generate.py` bypasses the pipeline entirely and has no budgeting at all.
+
+The runtime fallout is degraded generation quality when the effective window shrinks to whatever Ollama silently truncates to. The lora_generate fallout is worse: synthetic runs can fail mid-job on oversized scenarios.
+
+## Goals
+
+- Every prompt sent to Ollama by rp runtime chat and `lora_generate.py` fits within `model_ctx - response_reserve`, verified by ground-truth token count.
+- The budget is derived from the model's real context length (via `/api/show`), not a hardcoded scenario setting.
+- Ollama is told to load the model with its full `num_ctx`, so the runtime window matches what we budgeted for.
+- When a prompt is over budget, a deterministic shrink policy drops the least-valuable content first and protects character identity + most-recent user turn.
+- When even the minimum prompt doesn't fit, callers get a typed error with a diagnostic report rather than a silent truncation.
+
+## Non-goals
+
+- Replacing the `len(text) // 4` estimator with a real client-side tokenizer (e.g., `tiktoken`, HF `AutoTokenizer`). The estimator + one ground-truth Ollama call per request is sufficient.
+- Per-request budget overrides from scenario settings. `max_context_tokens` is deprecated; the model's real context window is the single source of truth.
+- TTL caching of `/api/show` results. Cache lives for the process lifetime; aiserver restart picks up model reloads.
+- Budgeting for eval scripts, fewshot retrieval, or the summarizer. (Future work.)
+
+## Architecture
+
+### New module: `projects/rp/budget.py`
+
+Single shared module used by both the rp runtime pipeline and `lora_generate.py`.
+
+#### Public API
+
+```python
+class BudgetError(Exception):
+    """Raised when the minimum viable prompt exceeds model_ctx - response_reserve."""
+    def __init__(self, message: str, report: "BudgetReport"):
+        super().__init__(message)
+        self.report = report
+
+@dataclass
+class BudgetReport:
+    model: str
+    model_ctx: int
+    response_reserve: int
+    available: int              # model_ctx - response_reserve
+    overhead: int               # system_prompt + post_prompt (estimator)
+    messages_budget: int        # available - overhead
+    messages_kept: int
+    messages_dropped: int
+    summary_dropped: bool
+    mes_example_truncated: bool
+    estimator_tokens: int
+    actual_tokens: int | None   # from ground-truth Ollama call, if run
+    warnings: list[str]
+
+async def fit_prompt(
+    ctx: dict,
+    *,
+    model: str,
+    ollama: "OllamaClient",
+    strategy: "ContextStrategy",
+    num_predict: int | None = None,
+    ground_truth: bool = True,
+) -> BudgetReport:
+    """Mutate ctx so the assembled prompt fits model_ctx - response_reserve.
+
+    Runs the active context strategy against a corrected messages budget
+    (model_ctx - response_reserve - system/post overhead), performs an
+    optional ground-truth token count via Ollama, and applies the shrink
+    policy if still over.
+
+    Sets ctx["_num_ctx"] = model_ctx so the caller can pass num_ctx in
+    Ollama options.
+
+    Raises BudgetError (with a populated BudgetReport) if the minimum
+    viable prompt (system + first message + most-recent user message)
+    does not fit.
+    """
+
+async def fit_raw_prompt(
+    *,
+    prompt: str,
+    system: str | None,
+    model: str,
+    ollama: "OllamaClient",
+    num_predict: int | None = None,
+    ground_truth: bool = True,
+) -> tuple[str, BudgetReport]:
+    """Budget a single-shot raw prompt (used by lora_generate).
+
+    Returns the (possibly unchanged) prompt and a BudgetReport. Raises
+    BudgetError if the prompt + system + response_reserve exceed model_ctx.
+    lora_generate catches this and skips the scenario.
+    """
+```
+
+#### Module state
+
+```python
+_ctx_cache: dict[str, int] = {}
+_ctx_locks: dict[str, asyncio.Lock] = {}
+
+async def _get_model_ctx(model: str, ollama: "OllamaClient") -> int:
+    """Return cached num_ctx for model, fetching once on first use."""
+```
+
+One `/api/show` call per model per process lifetime. Per-model `asyncio.Lock` prevents concurrent first-use from issuing duplicate requests.
+
+### New method: `OllamaClient.get_num_ctx`
+
+Added to `projects/aiserver/ollama.py`:
+
+```python
+async def get_num_ctx(self, model: str) -> int:
+    """Return effective context length for a model via /api/show.
+
+    Prefers parameters.num_ctx (the runtime-loaded window) and falls
+    back to model_info['<arch>.context_length'] (the architectural max
+    from the GGUF file). Raises OllamaError if neither is present.
+    """
+```
+
+Rationale for placement: it's a general Ollama capability, not rp-specific. `budget.py` calls it; aiserver stats/dashboard code can reuse it.
+
+### Integration points
+
+**Runtime pipeline (`projects/rp/pipeline.py`)**
+
+`create_default_pipeline()` removes `apply_context_strategy` from the pre-chain. The pipeline stays a pure prompt-assembly chain: `assemble_prompt → expand_variables → inject_tools`. No Ollama or model dependency leaks into the pipeline.
+
+`apply_context_strategy` is deleted (the caller invokes `fit_prompt` directly — see below).
+
+**Runtime call sites (`projects/rp/routes.py`)**
+
+`_build_pipeline_ctx` currently ends with `return await _pipeline.run_pre(ctx)`. After this change, routes.py calls `fit_prompt` explicitly after `run_pre`, where `_ollama` and the resolved model name are already in scope:
+
+```python
+ctx = await _build_pipeline_ctx(conv, messages)
+strategy = get_strategy(
+    conv.get("scenario_settings", {}).get("context_strategy", "summary_buffer")
+)
+report = await fit_prompt(
+    ctx,
+    model=resolved_model,
+    ollama=_ollama,
+    strategy=strategy,
+    num_predict=request_options.get("num_predict"),
+)
+ctx["_budget_report"] = report
+```
+
+This happens at each of the ~5 `_build_pipeline_ctx` call sites in `routes.py` (message send, regenerate, swap, etc.). A small helper wraps the `fit_prompt` call to avoid duplication.
+
+The Ollama call sites then merge `ctx["_num_ctx"]` into the options dict:
+
+```python
+options = {**request_options, "num_ctx": ctx["_num_ctx"]}
+```
+
+This tells Ollama to load the model with its full context window. First request after aiserver start triggers a model reload (slow for large models); subsequent requests are fast. An INFO log line is emitted on the first reload for observability.
+
+**lora_generate (`projects/rp/lora_generate.py`)**
+
+Each of `generate_scenarios`, `generate_user_message`, `generate_assistant_message` wraps its Ollama call in `fit_raw_prompt`. On `BudgetError`:
+
+- `generate_scenarios`: log a warning with the category and character pair, skip that category, continue the run.
+- `generate_user_message` / `generate_assistant_message`: log a warning with the conversation index and turn, return `None`, which the existing control flow already interprets as "stop this conversation" (see `lora_generate.py:354`).
+
+The overall run continues — one oversized scenario does not abort a multi-hour job.
+
+### Data flow (per request)
+
+```
+1. Pipeline pre-hooks run as today:
+   assemble_prompt → expand_variables → inject_tools
+   ctx now has: system_prompt (with tools appended), post_prompt (with
+   scene_state appended), raw messages from DB.
+
+2. routes.py calls fit_prompt(ctx, model=..., ollama=..., strategy=..., num_predict=...):
+
+   2a. model_ctx = await _get_model_ctx(model, ollama)
+       - Cache hit: return immediately.
+       - Cache miss: acquire per-model lock, call ollama.get_num_ctx,
+         cache, return. Concurrent callers on the same model wait on
+         the lock and see the cached value.
+
+   2b. response_reserve = num_predict if num_predict is not None else 1024
+       available = model_ctx - response_reserve
+
+   2c. Count overhead with estimator:
+         overhead = count(system_prompt) + count(post_prompt)
+       messages_budget = available - overhead
+
+   2d. If messages_budget <= 0:
+       Try shrink-policy step 4 (mes_example truncation).
+       If still <= 0, raise BudgetError.
+
+   2e. ctx["messages"] = strategy.fit(messages, messages_budget, ctx=ctx)
+       SlidingWindow / SummaryBuffer are unchanged — they just get a
+       correctly-computed budget.
+
+   2f. Ground-truth check (if ground_truth=True):
+         full_prompt = render(system_prompt, messages, post_prompt)
+         actual = await _ollama_count(full_prompt, model)
+       If actual + response_reserve > model_ctx:
+         apply shrink policy, re-count once more.
+         If still over, raise BudgetError.
+
+   2g. ctx["_num_ctx"] = model_ctx
+       Return BudgetReport.
+
+3. routes.py proceeds to generation, merging ctx["_num_ctx"] into
+   the Ollama options dict.
+```
+
+#### Why the estimator drives shrinking but ground-truth verifies
+
+- The estimator is good enough to pick *which* messages to drop (relative sizing is accurate).
+- Ground-truth is the real contract: "did this actually fit in the model's window?"
+- One ground-truth call per request (~50–150ms local). Not cheap but small vs. generation time.
+- Ground-truth checking *every* shrink iteration would be 3–5 calls per turn — too expensive. Estimator drives the loop; ground-truth is the safety net.
+- If ground-truth says "still over," at most one additional shrink + recount is performed, then `BudgetError`. The estimator is empirically accurate enough that this second recount almost never fails.
+
+### Ground-truth counting mechanism
+
+```python
+async def _ollama_count(prompt: str, model: str, ollama: "OllamaClient") -> int:
+    """Return prompt_eval_count for the given prompt.
+
+    Calls /api/generate with num_predict=0, stream=false. The response's
+    prompt_eval_count is Ollama's real token count using the model's
+    tokenizer.
+    """
+```
+
+This is added to `budget.py` rather than `OllamaClient` because its only purpose is budgeting — it's not a general Ollama capability, and keeping it local avoids adding a narrow method to the shared client.
+
+## Shrink policy (priority order)
+
+Each step is one operation; after each, re-measure and stop as soon as the prompt fits.
+
+### Priority 1 — Always protected, never touched
+
+- Character description
+- Character personality
+- `post_prompt` (instruction tail)
+- `scene_state`
+- Tool descriptions
+- First message (greeting)
+- Most recent user message
+
+### Priority 2 — Drop oldest messages
+
+Handled inside the active `ContextStrategy.fit()` call. `SlidingWindow` and `SummaryBuffer` already drop oldest-first and protect the greeting. `budget.py` just passes them the correct budget.
+
+### Priority 3 — Drop the injected summary
+
+Only applies when `SummaryBuffer` is active and a summary was added. A summary is a lossy compression of history; if all droppable history is already gone and we still don't fit, the summary is the next-cheapest thing to lose.
+
+Implementation: after strategy.fit, if still over, clear `ctx["_summary"]` and re-run strategy.fit.
+
+### Priority 4 — Truncate `mes_example`
+
+The only Priority 1 → shrinkable promotion. `mes_example` is typically the biggest and most redundant field on a character card (full example dialogues, often 500–2000 tokens).
+
+Truncation rule: keep the first N lines such that the resulting `mes_example` is max(25% of original tokens, 200 tokens). Re-run `assemble_prompt` with the truncated value, re-measure.
+
+Mark `report.mes_example_truncated = True` and add a warning to `report.warnings`.
+
+### Priority 5 — Nothing left to shrink
+
+Raise `BudgetError` with the populated `BudgetReport`. Callers decide:
+
+- Runtime pipeline: return an error to the user. The message is explicit ("This turn does not fit in the model's context. The most recent user message alone is {N} tokens, model context is {M}.") so the user knows what to do (shorten input or switch models).
+- `lora_generate`: log at WARNING, skip this scenario/turn, continue the run.
+
+### Most-recent user message protection
+
+If a user pastes a 20k-token wall of text into an 8k-context model, we raise `BudgetError` immediately rather than silently dropping it. The user must know their message did not fit, not receive a reply to a truncated version of what they said.
+
+## `num_ctx` propagation
+
+Ollama's `num_ctx` at load time defaults to **2048** unless passed in the `options` block. Even if `/api/show` reports that a model supports 32k, if nobody loaded it with `num_ctx: 32768`, the running model only sees 2048 tokens.
+
+Fix: `fit_prompt` sets `ctx["_num_ctx"] = model_ctx`. All callers merge this into the options dict on their Ollama calls:
+
+```python
+options = {**request_options, "num_ctx": ctx["_num_ctx"]}
+```
+
+Consequences:
+
+- First request after aiserver start triggers a model reload into the larger context. Slow for large models (tens of seconds for 70B). Subsequent requests are fast.
+- Log at INFO on the first reload: `"Loading {model} with num_ctx={n}"`.
+- No thrashing: the same model always receives the same `num_ctx` (both pulled from `/api/show`), so concurrent scenarios using the same model don't cause reloads.
+- `lora_generate` call sites also pass `num_ctx` — this is important because lora_generate can run for hours and any thrashing would be expensive.
+
+## Error handling
+
+### `BudgetError`
+
+Raised by `fit_prompt` and `fit_raw_prompt` when the minimum viable prompt does not fit. Carries a populated `BudgetReport` for diagnostics.
+
+Callers:
+
+- **Runtime pipeline** (`routes.py`): catch, return HTTP 413 (Payload Too Large) with a user-facing message built from the report. The streaming response, if already started, sends a final error chunk.
+- **lora_generate**: catch, log at WARNING with `report.model`, `report.overhead`, `report.estimator_tokens`, skip the current scenario/turn, continue.
+
+### Degraded scenarios (not errors)
+
+Anything handled by shrink policy steps 2–4 is logged but does not raise. The `BudgetReport` carries flags (`summary_dropped`, `mes_example_truncated`, `messages_dropped > 0`) and a `warnings` list. Callers can log or surface these as desired.
+
+### Ollama unreachable during `_get_model_ctx`
+
+Propagate the underlying `OllamaError`. No attempt to fall back to a hardcoded default — if we can't learn the model's context, we can't safely budget.
+
+## Testing
+
+### Unit tests — `projects/rp/tests/test_budget.py`
+
+All mocked, no network. Fast, runs on every commit.
+
+- `fit_prompt` with `ground_truth=False`:
+  - Happy path: small context, everything fits, nothing dropped.
+  - Messages exceed budget: oldest dropped, first message + most-recent user message protected.
+  - System prompt alone exceeds `available`: Priority 4 (mes_example truncation) fires.
+  - Even truncated mes_example doesn't fit: `BudgetError` raised with populated report.
+  - Each shrink priority level: force conditions and assert the `BudgetReport` flag for that level is set.
+- `fit_prompt` with `ground_truth=True` and mocked `_ollama_count`:
+  - Estimator says "fits" but ground-truth says "over": one additional shrink + recount succeeds.
+  - Estimator says "fits" but ground-truth says "over" twice: `BudgetError`.
+- `_get_model_ctx` caching:
+  - First call hits the mock once.
+  - Second call returns from cache without hitting the mock.
+  - Concurrent first calls via `asyncio.gather(*[_get_model_ctx(m, o) for _ in range(10)])` only hit the mock once.
+- `response_reserve` logic: `None` → 1024, explicit value → honored verbatim.
+- `OllamaClient.get_num_ctx`:
+  - Prefers `parameters.num_ctx` from `/api/show`.
+  - Falls back to `model_info['<arch>.context_length']`.
+  - Raises `OllamaError` when neither is present.
+  - Three fixture `/api/show` responses cover these cases.
+
+### Integration tests — `projects/rp/tests/test_budget_integration.py`
+
+Marked `@pytest.mark.integration`. Skipped in default test runs (`pytest -m "not integration"`); opt-in for local verification.
+
+- Ground-truth check with a small real model: assemble a known prompt, call `fit_prompt(ground_truth=True)`, assert `actual_tokens` is within 5% of the estimator.
+- `num_ctx` propagation: send an oversized prompt through `fit_prompt`, verify `BudgetError` fires rather than Ollama silently truncating.
+
+### Regression tests
+
+- Existing `test_context.py` tests for `SlidingWindow` and `SummaryBuffer` stay unchanged — the strategies are unmodified.
+- One new equivalence test: given an empty system prompt, `fit_prompt` produces the same `messages` list as the old `apply_context_strategy` pathway did (smoke test that replacing the hook didn't break message-fitting).
+
+### `lora_generate` tests
+
+- Monkey-patch `ollama.generate` with a counter.
+- Force `fit_raw_prompt` to raise `BudgetError` on a specific scenario.
+- Assert: (a) the oversized scenario is skipped with a warning log, (b) the overall run continues and produces output for non-oversized scenarios, (c) the counter shows the skipped scenario never triggered the underlying `ollama.generate` call.
+
+### Explicitly NOT tested
+
+- Exact token counts from the estimator (it's a heuristic; ground-truth is the contract).
+- Ollama's own context-truncation behavior (that's Ollama's job).
+- Every possible shrink priority combination (the order is linear; each level has one dedicated test).
+
+## Migration / compatibility
+
+- `max_context_tokens` in scenario settings is deprecated. Code no longer reads it. Existing scenarios with the field set continue to work (the field is ignored, not rejected). A cleanup migration to remove the column is out of scope for this change.
+- `apply_context_strategy` is deleted. Any external code referencing it would break — a repo-wide grep confirms there are no such references outside `pipeline.py` itself.
+- `ContextStrategy` and its subclasses are unchanged. They remain the mechanism for choosing *which* messages to drop.
+- Tests that construct a pipeline without an `OllamaClient` will need to inject a stub. A helper `make_test_ollama(num_ctx=8192)` will be added to `tests/conftest.py`.
+
+## Open questions
+
+None at spec-approval time.
+
+## References
+
+- `projects/rp/pipeline.py:172-180` — current `apply_context_strategy` being replaced
+- `projects/rp/context.py` — `SlidingWindow` and `SummaryBuffer` (unchanged by this work)
+- `projects/aiserver/ollama.py` — `OllamaClient` (adds `get_num_ctx` method)
+- `projects/rp/lora_generate.py:182-239` — `generate_scenarios` (gets `fit_raw_prompt` integration)
+- `projects/rp/lora_generate.py:244-325` — `generate_user_message` / `generate_assistant_message` (get `fit_raw_prompt` integration)
+- Ollama API: `POST /api/show` returns `parameters` and `model_info` fields used by `get_num_ctx`
+- Ollama API: `POST /api/generate` with `num_predict: 0` returns `prompt_eval_count` used by `_ollama_count`

--- a/projects/aiserver/ollama.py
+++ b/projects/aiserver/ollama.py
@@ -252,6 +252,50 @@ class OllamaClient:
             pass
         return []
 
+    async def get_num_ctx(self, model: str) -> int:
+        """Return effective context length for a model via /api/show.
+
+        Prefers the runtime-loaded num_ctx from the parameters field (a
+        whitespace-formatted string). Falls back to any <arch>.context_length
+        entry in model_info (the architectural max from the GGUF file).
+        Raises OllamaError if neither is present or the request fails.
+        """
+        try:
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                resp = await client.post(
+                    f"{self.base_url}/api/show", json={"model": model}
+                )
+                if resp.status_code != 200:
+                    raise OllamaError(
+                        f"Ollama /api/show returned {resp.status_code}: {resp.text}"
+                    )
+                data = resp.json()
+        except httpx.ConnectError:
+            raise OllamaError(f"Cannot connect to Ollama at {self.base_url}")
+        except httpx.HTTPError as e:
+            raise OllamaError(f"HTTP error from /api/show: {e}") from e
+
+        # Parse parameters for "num_ctx <value>"
+        params_str = data.get("parameters", "") or ""
+        for line in params_str.splitlines():
+            parts = line.split()
+            if len(parts) >= 2 and parts[0] == "num_ctx":
+                try:
+                    return int(parts[1])
+                except ValueError:
+                    pass
+
+        # Fall back to model_info[<arch>.context_length]
+        model_info = data.get("model_info", {}) or {}
+        for key, value in model_info.items():
+            if key.endswith(".context_length") and isinstance(value, int):
+                return value
+
+        raise OllamaError(
+            f"Could not determine context length for model {model!r}: "
+            f"no num_ctx in parameters and no <arch>.context_length in model_info"
+        )
+
     async def embed(self, model: str, text: str) -> list[float]:
         """Get embedding vector for text via Ollama /api/embed."""
         try:

--- a/projects/aiserver/ollama.py
+++ b/projects/aiserver/ollama.py
@@ -172,6 +172,39 @@ class OllamaClient:
                 tokens.append(chunk["token"])
         return "".join(tokens)
 
+    async def count_generate_prompt(
+        self,
+        model: str,
+        prompt: str,
+        system: str | None = None,
+    ) -> int:
+        """Tokenize a prompt via /api/generate and return prompt_eval_count.
+
+        Posts with `num_predict: 0` so Ollama tokenizes the prompt but
+        generates no output. Used by budget.fit_raw_prompt for ground-truth
+        counting that matches the generate endpoint's template — /api/chat
+        would apply chat role markers that /api/generate does not.
+        """
+        body: dict = {
+            "model": model,
+            "prompt": prompt,
+            "stream": False,
+            "options": {"num_predict": 0},
+        }
+        if system:
+            body["system"] = system
+        try:
+            async with httpx.AsyncClient(timeout=120.0) as client:
+                resp = await client.post(f"{self.base_url}/api/generate", json=body)
+                if resp.status_code != 200:
+                    raise OllamaError(f"Ollama returned {resp.status_code}: {resp.text}")
+                data = resp.json()
+                return int(data.get("prompt_eval_count", 0) or 0)
+        except httpx.ConnectError:
+            raise OllamaError(f"Cannot connect to Ollama at {self.base_url}")
+        except httpx.HTTPError as e:
+            raise OllamaError(f"HTTP error communicating with Ollama: {e}") from e
+
     async def chat(
         self,
         model: str,

--- a/projects/aiserver/tests/test_ollama_chat.py
+++ b/projects/aiserver/tests/test_ollama_chat.py
@@ -1,6 +1,7 @@
 import json
 import sys
 from pathlib import Path
+from unittest.mock import patch
 
 import httpx
 import pytest
@@ -8,7 +9,7 @@ import pytest
 # Allow imports from aiserver directory
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from ollama import OllamaClient
+from ollama import OllamaClient, OllamaError
 
 
 class FakeStreamResponse:
@@ -122,3 +123,64 @@ async def test_chat_stream_passes_options_and_stop(monkeypatch):
 
     assert fake_client.last_request["options"] == {"temperature": 0.8, "repeat_penalty": 1.1}
     assert fake_client.last_request["stop"] == ["Valentina:"]
+
+
+class TestGetNumCtx:
+    @pytest.mark.asyncio
+    async def test_prefers_parameters_num_ctx(self):
+        client = OllamaClient("http://localhost:11434")
+        show_response = {
+            "parameters": "num_ctx                        32768\ntemperature                    0.8",
+            "model_info": {"llama.context_length": 131072},
+        }
+        with patch("httpx.AsyncClient.post") as mock_post:
+            mock_post.return_value.status_code = 200
+            mock_post.return_value.json = lambda: show_response
+            result = await client.get_num_ctx("mymodel")
+        assert result == 32768
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_model_info_context_length(self):
+        client = OllamaClient("http://localhost:11434")
+        show_response = {
+            "parameters": "temperature                    0.8",
+            "model_info": {"llama.context_length": 8192},
+        }
+        with patch("httpx.AsyncClient.post") as mock_post:
+            mock_post.return_value.status_code = 200
+            mock_post.return_value.json = lambda: show_response
+            result = await client.get_num_ctx("mymodel")
+        assert result == 8192
+
+    @pytest.mark.asyncio
+    async def test_tries_any_arch_context_length(self):
+        """model_info keys look like <arch>.context_length — e.g. qwen2.context_length."""
+        client = OllamaClient("http://localhost:11434")
+        show_response = {
+            "parameters": "",
+            "model_info": {"qwen2.context_length": 4096, "general.architecture": "qwen2"},
+        }
+        with patch("httpx.AsyncClient.post") as mock_post:
+            mock_post.return_value.status_code = 200
+            mock_post.return_value.json = lambda: show_response
+            result = await client.get_num_ctx("mymodel")
+        assert result == 4096
+
+    @pytest.mark.asyncio
+    async def test_raises_when_neither_present(self):
+        client = OllamaClient("http://localhost:11434")
+        show_response = {"parameters": "temperature 0.8", "model_info": {}}
+        with patch("httpx.AsyncClient.post") as mock_post:
+            mock_post.return_value.status_code = 200
+            mock_post.return_value.json = lambda: show_response
+            with pytest.raises(OllamaError, match="context length"):
+                await client.get_num_ctx("mymodel")
+
+    @pytest.mark.asyncio
+    async def test_raises_on_show_http_error(self):
+        client = OllamaClient("http://localhost:11434")
+        with patch("httpx.AsyncClient.post") as mock_post:
+            mock_post.return_value.status_code = 404
+            mock_post.return_value.text = "model not found"
+            with pytest.raises(OllamaError):
+                await client.get_num_ctx("nope")

--- a/projects/rp/budget.py
+++ b/projects/rp/budget.py
@@ -72,3 +72,18 @@ async def _get_model_ctx(model: str, ollama: _OllamaLike) -> int:
         _ctx_cache[model] = num_ctx
         _log.info("Loaded num_ctx=%d for model %s", num_ctx, model)
         return num_ctx
+
+
+async def _ollama_count_messages(
+    messages: list[dict],
+    model: str,
+    ollama: _OllamaLike,
+) -> int:
+    """Ask Ollama for the ground-truth token count of `messages`.
+
+    Calls /api/chat and reads prompt_eval_count from the response.
+    Returns 0 if Ollama doesn't surface the field — caller decides
+    how to handle a missing value.
+    """
+    result = await ollama.chat(model=model, messages=messages)
+    return int(result.get("prompt_eval_count", 0) or 0)

--- a/projects/rp/budget.py
+++ b/projects/rp/budget.py
@@ -8,7 +8,10 @@ from __future__ import annotations
 import asyncio
 import logging
 from dataclasses import dataclass, field
-from typing import Protocol
+from typing import TYPE_CHECKING, Protocol
+
+if TYPE_CHECKING:
+    from .context import ContextStrategy  # noqa: F401
 
 _log = logging.getLogger(__name__)
 
@@ -87,3 +90,73 @@ async def _ollama_count_messages(
     """
     result = await ollama.chat(model=model, messages=messages)
     return int(result.get("prompt_eval_count", 0) or 0)
+
+
+async def fit_prompt(
+    ctx: dict,
+    *,
+    model: str,
+    ollama: _OllamaLike,
+    strategy: "ContextStrategy",
+    num_predict: int | None = None,
+    ground_truth: bool = True,
+) -> BudgetReport:
+    """Shrink ctx["messages"] (and, if needed, other prompt pieces) so the
+    assembled prompt fits within model_ctx - response_reserve.
+
+    Mutates ctx:
+      - ctx["messages"]: potentially trimmed by the strategy
+      - ctx["_summary"]: potentially deleted (Priority 3)
+      - ctx["ai_card"]: mes_example potentially truncated (Priority 4)
+      - ctx["system_prompt"] / ctx["post_prompt"]: re-rendered on P4
+      - ctx["_num_ctx"]: set to the model's context window
+      - ctx["_budget_report"]: set to the returned BudgetReport
+
+    Raises BudgetError with a populated report if the minimum viable
+    prompt (system + greeting + most-recent user message) doesn't fit.
+    """
+    model_ctx = await _get_model_ctx(model, ollama)
+    response_reserve = num_predict if num_predict is not None else 1024
+    available = model_ctx - response_reserve
+
+    warnings: list[str] = []
+    messages_before = len(ctx.get("messages", []))
+
+    # Estimator-based overhead.
+    overhead = _estimate_tokens(ctx.get("system_prompt", "")) + _estimate_tokens(
+        ctx.get("post_prompt", "")
+    )
+    messages_budget = available - overhead
+
+    # Priority 2: delegate to strategy.fit with the corrected budget.
+    # The strategy (SlidingWindow / SummaryBuffer) handles greeting
+    # protection, oldest-first drop, and summary injection.
+    if messages_budget > 0:
+        ctx["messages"] = strategy.fit(
+            ctx.get("messages", []), messages_budget, ctx=ctx
+        )
+
+    messages_after = len(ctx.get("messages", []))
+    messages_dropped = max(0, messages_before - messages_after)
+
+    report = BudgetReport(
+        model=model,
+        model_ctx=model_ctx,
+        response_reserve=response_reserve,
+        available=available,
+        overhead=overhead,
+        messages_budget=messages_budget,
+        messages_kept=messages_after,
+        messages_dropped=messages_dropped,
+        summary_dropped=False,
+        mes_example_truncated=False,
+        estimator_tokens=overhead + sum(
+            _estimate_tokens(m.get("content", "")) for m in ctx.get("messages", [])
+        ),
+        actual_tokens=None,
+        warnings=warnings,
+    )
+
+    ctx["_num_ctx"] = model_ctx
+    ctx["_budget_report"] = report
+    return report

--- a/projects/rp/budget.py
+++ b/projects/rp/budget.py
@@ -129,16 +129,18 @@ async def fit_prompt(
     messages_budget = available - overhead
 
     summary_dropped = False
+    messages_snapshot = list(ctx.get("messages", []))
 
     # Priority 2: delegate to strategy.fit with the corrected budget.
     # The strategy (SlidingWindow / SummaryBuffer) handles greeting
     # protection, oldest-first drop, and summary injection.
     if messages_budget > 0:
         ctx["messages"] = strategy.fit(
-            ctx.get("messages", []), messages_budget, ctx=ctx
+            messages_snapshot, messages_budget, ctx=ctx
         )
 
-    # Priority 3: if still over budget, drop the summary (if any) and re-fit.
+    # Priority 3: if still over budget, drop the summary (if any) and re-fit
+    # from the pre-strategy snapshot so any injected summary message is gone.
     def _current_messages_tokens() -> int:
         return sum(
             _estimate_tokens(m.get("content", ""))
@@ -147,14 +149,9 @@ async def fit_prompt(
 
     if ctx.get("_summary") and _current_messages_tokens() > messages_budget:
         ctx["_summary"] = None
-        # Strip any injected summary message (added by SummaryBuffer) before re-fitting.
-        ctx["messages"] = [
-            m for m in ctx.get("messages", [])
-            if not m.get("content", "").startswith("[Story so far]")
-        ]
         if messages_budget > 0:
             ctx["messages"] = strategy.fit(
-                ctx.get("messages", []), messages_budget, ctx=ctx
+                messages_snapshot, messages_budget, ctx=ctx
             )
         summary_dropped = True
         warnings.append("summary dropped to fit messages budget")

--- a/projects/rp/budget.py
+++ b/projects/rp/budget.py
@@ -136,6 +136,20 @@ def _truncate_mes_example(ctx: dict) -> bool:
     return True
 
 
+def _render_for_count(ctx: dict) -> list[dict]:
+    """Build the messages list that would actually be sent to Ollama.
+
+    Mirrors routes.py chat message assembly: system_prompt, then the
+    budgeted messages, then post_prompt (if any) as a trailing system
+    message.
+    """
+    msgs = [{"role": "system", "content": ctx.get("system_prompt", "")}]
+    msgs.extend(ctx.get("messages", []))
+    if ctx.get("post_prompt"):
+        msgs.append({"role": "system", "content": ctx["post_prompt"]})
+    return msgs
+
+
 async def fit_prompt(
     ctx: dict,
     *,
@@ -219,6 +233,20 @@ async def fit_prompt(
                     messages_snapshot, messages_budget, ctx=ctx
                 )
 
+    # Ground-truth check: ask Ollama for the real prompt_eval_count.
+    actual_tokens: int | None = None
+    if ground_truth and messages_budget > 0:
+        gt_messages = _render_for_count(ctx)
+        actual_tokens = await _ollama_count_messages(gt_messages, model, ollama)
+
+        if actual_tokens + response_reserve > model_ctx:
+            # One more shrink: drop one more oldest non-greeting message and recount.
+            if len(ctx.get("messages", [])) > 2:
+                ctx["messages"] = [ctx["messages"][0]] + ctx["messages"][2:]
+                gt_messages = _render_for_count(ctx)
+                actual_tokens = await _ollama_count_messages(gt_messages, model, ollama)
+            # If still over, let Priority 5 below raise.
+
     # Priority 5: if after all shrinking the messages still can't fit,
     # raise BudgetError with a populated report.
     #
@@ -235,7 +263,11 @@ async def fit_prompt(
     last_user_dropped = last_user_msg is not None and not any(
         m is last_user_msg for m in ctx.get("messages", [])
     )
-    if final_overhead + final_msg_tokens > available or messages_budget <= 0 or last_user_dropped:
+    effective_total = (
+        actual_tokens if actual_tokens is not None
+        else final_overhead + final_msg_tokens
+    )
+    if effective_total + response_reserve > model_ctx or messages_budget <= 0 or last_user_dropped:
         failing_report = BudgetReport(
             model=model,
             model_ctx=model_ctx,
@@ -248,7 +280,7 @@ async def fit_prompt(
             summary_dropped=summary_dropped,
             mes_example_truncated=mes_example_truncated,
             estimator_tokens=final_overhead + final_msg_tokens,
-            actual_tokens=None,
+            actual_tokens=actual_tokens,
             warnings=warnings + ["prompt does not fit after all shrink steps"],
         )
         ctx["_budget_report"] = failing_report
@@ -271,7 +303,7 @@ async def fit_prompt(
         summary_dropped=summary_dropped,
         mes_example_truncated=mes_example_truncated,
         estimator_tokens=_current_overhead() + _current_messages_tokens(),
-        actual_tokens=None,
+        actual_tokens=actual_tokens,
         warnings=warnings,
     )
 

--- a/projects/rp/budget.py
+++ b/projects/rp/budget.py
@@ -92,6 +92,50 @@ async def _ollama_count_messages(
     return int(result.get("prompt_eval_count", 0) or 0)
 
 
+def _truncate_mes_example(ctx: dict) -> bool:
+    """Truncate ai_card's mes_example in place and re-run the assembly hooks.
+
+    Keeps whole lines up to max(25% of original tokens, 200 tokens).
+    Returns True if truncation happened, False if there was nothing to
+    truncate (empty or already small).
+
+    Imports from .pipeline are local to avoid a circular import: pipeline
+    can freely import budget without risk.
+    """
+    ai_card = ctx.get("ai_card") or {}
+    card_data = ai_card.get("card_data") or {}
+    ai_data = card_data.get("data", card_data)
+    original = ai_data.get("mes_example", "") or ""
+    if not original:
+        return False
+
+    original_tokens = _estimate_tokens(original)
+    target_tokens = max(original_tokens // 4, 200)
+    if original_tokens <= target_tokens:
+        return False
+
+    target_chars = target_tokens * 4
+    truncated_lines: list[str] = []
+    running = 0
+    for line in original.splitlines():
+        next_len = running + len(line) + 1
+        if next_len > target_chars:
+            break
+        truncated_lines.append(line)
+        running = next_len
+    truncated = "\n".join(truncated_lines).rstrip()
+    if not truncated:
+        truncated = original[:target_chars]
+    ai_data["mes_example"] = truncated
+
+    # Re-run the prompt assembly chain to rebuild system_prompt/post_prompt.
+    from .pipeline import assemble_prompt, expand_variables, inject_tools
+    assemble_prompt(ctx)
+    expand_variables(ctx)
+    inject_tools(ctx)
+    return True
+
+
 async def fit_prompt(
     ctx: dict,
     *,
@@ -129,7 +173,13 @@ async def fit_prompt(
     messages_budget = available - overhead
 
     summary_dropped = False
+    mes_example_truncated = False
     messages_snapshot = list(ctx.get("messages", []))
+
+    def _current_overhead() -> int:
+        return _estimate_tokens(ctx.get("system_prompt", "")) + _estimate_tokens(
+            ctx.get("post_prompt", "")
+        )
 
     # Priority 2: delegate to strategy.fit with the corrected budget.
     # The strategy (SlidingWindow / SummaryBuffer) handles greeting
@@ -156,23 +206,31 @@ async def fit_prompt(
         summary_dropped = True
         warnings.append("summary dropped to fit messages budget")
 
-    messages_after = len(ctx.get("messages", []))
-    messages_dropped = max(0, messages_before - messages_after)
+    # Priority 4: if overhead alone exceeds available (or messages_budget <= 0),
+    # truncate mes_example and re-run assembly.
+    if messages_budget <= 0 or _current_overhead() > available:
+        if _truncate_mes_example(ctx):
+            mes_example_truncated = True
+            warnings.append("mes_example truncated to fit system prompt")
+            overhead = _current_overhead()
+            messages_budget = available - overhead
+            if messages_budget > 0:
+                ctx["messages"] = strategy.fit(
+                    messages_snapshot, messages_budget, ctx=ctx
+                )
 
     report = BudgetReport(
         model=model,
         model_ctx=model_ctx,
         response_reserve=response_reserve,
         available=available,
-        overhead=overhead,
+        overhead=_current_overhead(),
         messages_budget=messages_budget,
-        messages_kept=messages_after,
-        messages_dropped=messages_dropped,
+        messages_kept=len(ctx.get("messages", [])),
+        messages_dropped=max(0, messages_before - len(ctx.get("messages", []))),
         summary_dropped=summary_dropped,
-        mes_example_truncated=False,
-        estimator_tokens=overhead + sum(
-            _estimate_tokens(m.get("content", "")) for m in ctx.get("messages", [])
-        ),
+        mes_example_truncated=mes_example_truncated,
+        estimator_tokens=_current_overhead() + _current_messages_tokens(),
         actual_tokens=None,
         warnings=warnings,
     )

--- a/projects/rp/budget.py
+++ b/projects/rp/budget.py
@@ -219,6 +219,46 @@ async def fit_prompt(
                     messages_snapshot, messages_budget, ctx=ctx
                 )
 
+    # Priority 5: if after all shrinking the messages still can't fit,
+    # raise BudgetError with a populated report.
+    #
+    # Two failure modes:
+    # (a) Total size still exceeds available after all shrink steps.
+    # (b) The most recent user message was dropped entirely — a broken
+    #     conversation where we have no user turn to respond to.
+    final_msg_tokens = _current_messages_tokens()
+    final_overhead = _current_overhead()
+    last_user_msg = next(
+        (m for m in reversed(messages_snapshot) if m.get("role") == "user"),
+        None,
+    )
+    last_user_dropped = last_user_msg is not None and not any(
+        m is last_user_msg for m in ctx.get("messages", [])
+    )
+    if final_overhead + final_msg_tokens > available or messages_budget <= 0 or last_user_dropped:
+        failing_report = BudgetReport(
+            model=model,
+            model_ctx=model_ctx,
+            response_reserve=response_reserve,
+            available=available,
+            overhead=final_overhead,
+            messages_budget=messages_budget,
+            messages_kept=len(ctx.get("messages", [])),
+            messages_dropped=max(0, messages_before - len(ctx.get("messages", []))),
+            summary_dropped=summary_dropped,
+            mes_example_truncated=mes_example_truncated,
+            estimator_tokens=final_overhead + final_msg_tokens,
+            actual_tokens=None,
+            warnings=warnings + ["prompt does not fit after all shrink steps"],
+        )
+        ctx["_budget_report"] = failing_report
+        raise BudgetError(
+            f"Prompt does not fit: model_ctx={model_ctx}, reserve={response_reserve}, "
+            f"overhead={final_overhead}, messages={final_msg_tokens}. "
+            f"The most recent user message may be too long for this model.",
+            failing_report,
+        )
+
     report = BudgetReport(
         model=model,
         model_ctx=model_ctx,

--- a/projects/rp/budget.py
+++ b/projects/rp/budget.py
@@ -139,14 +139,20 @@ def _truncate_mes_example(ctx: dict) -> bool:
 def _render_for_count(ctx: dict) -> list[dict]:
     """Build the messages list that would actually be sent to Ollama.
 
-    Mirrors routes.py chat message assembly: system_prompt, then the
-    budgeted messages, then post_prompt (if any) as a trailing system
-    message.
+    Must stay in lockstep with routes.py `_build_chat_messages`: system_prompt,
+    the budgeted messages, optional post_prompt as a trailing system message,
+    and the assistant priming anchor "{ai_name} " that anchors the model's
+    voice. Omitting the anchor would systematically undercount prompt_eval_count.
     """
     msgs = [{"role": "system", "content": ctx.get("system_prompt", "")}]
     msgs.extend(ctx.get("messages", []))
     if ctx.get("post_prompt"):
         msgs.append({"role": "system", "content": ctx["post_prompt"]})
+    ai_data = ctx.get("ai_card", {}).get("card_data", {}).get(
+        "data", ctx.get("ai_card", {}).get("card_data", {})
+    )
+    ai_name = ai_data.get("name", "Character")
+    msgs.append({"role": "assistant", "content": ai_name + " "})
     return msgs
 
 
@@ -239,12 +245,27 @@ async def fit_prompt(
         gt_messages = _render_for_count(ctx)
         actual_tokens = await _ollama_count_messages(gt_messages, model, ollama)
 
-        if actual_tokens + response_reserve > model_ctx:
+        # If Ollama returned a nonsense value (missing field, zero, negative),
+        # discard it and fall back to the estimator. A silent "0 tokens" would
+        # otherwise make any prompt appear to fit.
+        if actual_tokens <= 0:
+            warnings.append(
+                f"ollama returned non-positive prompt_eval_count ({actual_tokens}); "
+                "falling back to estimator"
+            )
+            actual_tokens = None
+        elif actual_tokens + response_reserve > model_ctx:
             # One more shrink: drop one more oldest non-greeting message and recount.
             if len(ctx.get("messages", [])) > 2:
                 ctx["messages"] = [ctx["messages"][0]] + ctx["messages"][2:]
                 gt_messages = _render_for_count(ctx)
                 actual_tokens = await _ollama_count_messages(gt_messages, model, ollama)
+                if actual_tokens <= 0:
+                    warnings.append(
+                        f"ollama returned non-positive prompt_eval_count on recount "
+                        f"({actual_tokens}); falling back to estimator"
+                    )
+                    actual_tokens = None
             # If still over, let Priority 5 below raise.
 
     # Priority 5: if after all shrinking the messages still can't fit,

--- a/projects/rp/budget.py
+++ b/projects/rp/budget.py
@@ -331,3 +331,71 @@ async def fit_prompt(
     ctx["_num_ctx"] = model_ctx
     ctx["_budget_report"] = report
     return report
+
+
+async def fit_raw_prompt(
+    *,
+    prompt: str,
+    system: str | None,
+    model: str,
+    ollama: _OllamaLike,
+    num_predict: int | None = None,
+    ground_truth: bool = True,
+) -> tuple[str, BudgetReport]:
+    """Budget a single-shot raw prompt (used by lora_generate).
+
+    Does NOT shrink — single-shot prompts have no safe shrink heuristic.
+    If it doesn't fit, raises BudgetError and the caller decides to skip
+    that scenario/turn.
+    """
+    model_ctx = await _get_model_ctx(model, ollama)
+    response_reserve = num_predict if num_predict is not None else 1024
+    available = model_ctx - response_reserve
+
+    prompt = prompt or ""
+    system = system or ""
+    overhead = _estimate_tokens(prompt) + _estimate_tokens(system)
+
+    actual_tokens: int | None = None
+    warnings: list[str] = []
+    if ground_truth:
+        gt_messages: list[dict] = []
+        if system:
+            gt_messages.append({"role": "system", "content": system})
+        gt_messages.append({"role": "user", "content": prompt})
+        actual_tokens = await _ollama_count_messages(gt_messages, model, ollama)
+        # Silent-failure guard: treat non-positive counts as estimator fallback
+        # (matches fit_prompt behavior added in Task 8 review).
+        if actual_tokens <= 0:
+            warnings.append(
+                f"ollama returned non-positive prompt_eval_count ({actual_tokens}); "
+                "falling back to estimator"
+            )
+            actual_tokens = None
+
+    effective_total = actual_tokens if actual_tokens is not None else overhead
+    fits = (effective_total + response_reserve) <= model_ctx
+
+    report = BudgetReport(
+        model=model,
+        model_ctx=model_ctx,
+        response_reserve=response_reserve,
+        available=available,
+        overhead=overhead,
+        messages_budget=available - overhead,
+        messages_kept=1,
+        messages_dropped=0,
+        summary_dropped=False,
+        mes_example_truncated=False,
+        estimator_tokens=overhead,
+        actual_tokens=actual_tokens,
+        warnings=warnings,
+    )
+
+    if not fits:
+        raise BudgetError(
+            f"Raw prompt does not fit: model_ctx={model_ctx}, reserve={response_reserve}, "
+            f"prompt_tokens={effective_total}.",
+            report,
+        )
+    return prompt, report

--- a/projects/rp/budget.py
+++ b/projects/rp/budget.py
@@ -1,0 +1,74 @@
+"""Prompt budgeting: fit rp pipeline and lora_generate prompts into model_ctx.
+
+See docs/superpowers/specs/2026-04-07-rp-prompt-budgeting-design.md.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from typing import Protocol
+
+_log = logging.getLogger(__name__)
+
+
+class _OllamaLike(Protocol):
+    async def get_num_ctx(self, model: str) -> int: ...
+    async def chat(self, model, messages, tools=None, think=False): ...
+
+
+# Module-level cache: model name -> num_ctx. Populated on first use per model.
+_ctx_cache: dict[str, int] = {}
+_ctx_locks: dict[str, asyncio.Lock] = {}
+
+
+class BudgetError(Exception):
+    """Raised when the minimum viable prompt exceeds model_ctx - response_reserve."""
+
+    def __init__(self, message: str, report: "BudgetReport"):
+        super().__init__(message)
+        self.report = report
+
+
+@dataclass
+class BudgetReport:
+    model: str
+    model_ctx: int
+    response_reserve: int
+    available: int              # model_ctx - reserve
+    overhead: int               # system_prompt + post_prompt (estimator)
+    messages_budget: int        # available - overhead
+    messages_kept: int
+    messages_dropped: int
+    summary_dropped: bool
+    mes_example_truncated: bool
+    estimator_tokens: int
+    actual_tokens: int | None
+    warnings: list[str] = field(default_factory=list)
+
+
+def _estimate_tokens(text: str) -> int:
+    """Rough token count: ~4 chars per token. Cheap, used for iterative shrinking."""
+    return len(text) // 4
+
+
+async def _get_model_ctx(model: str, ollama: _OllamaLike) -> int:
+    """Return cached num_ctx for `model`, fetching once on first use.
+
+    Uses a per-model asyncio.Lock so concurrent first-use calls don't
+    issue duplicate /api/show requests.
+    """
+    cached = _ctx_cache.get(model)
+    if cached is not None:
+        return cached
+
+    lock = _ctx_locks.setdefault(model, asyncio.Lock())
+    async with lock:
+        cached = _ctx_cache.get(model)
+        if cached is not None:
+            return cached
+        num_ctx = await ollama.get_num_ctx(model)
+        _ctx_cache[model] = num_ctx
+        _log.info("Loaded num_ctx=%d for model %s", num_ctx, model)
+        return num_ctx

--- a/projects/rp/budget.py
+++ b/projects/rp/budget.py
@@ -19,6 +19,9 @@ _log = logging.getLogger(__name__)
 class _OllamaLike(Protocol):
     async def get_num_ctx(self, model: str) -> int: ...
     async def chat(self, model, messages, tools=None, think=False): ...
+    async def count_generate_prompt(
+        self, model: str, prompt: str, system: str | None = None
+    ) -> int: ...
 
 
 # Module-level cache: model name -> num_ctx. Populated on first use per model.
@@ -90,6 +93,22 @@ async def _ollama_count_messages(
     """
     result = await ollama.chat(model=model, messages=messages)
     return int(result.get("prompt_eval_count", 0) or 0)
+
+
+async def _ollama_count_raw_prompt(
+    prompt: str,
+    system: str | None,
+    model: str,
+    ollama: _OllamaLike,
+) -> int:
+    """Ask Ollama for the ground-truth token count of a /api/generate prompt.
+
+    Chat and generate apply different templates (role markers vs raw),
+    so `_ollama_count_messages` would systematically over-count for the
+    generate endpoint. Raw-prompt callers (lora_generate) must use this
+    helper to match what they actually send.
+    """
+    return await ollama.count_generate_prompt(model=model, prompt=prompt, system=system)
 
 
 def _truncate_mes_example(ctx: dict) -> bool:
@@ -359,11 +378,12 @@ async def fit_raw_prompt(
     actual_tokens: int | None = None
     warnings: list[str] = []
     if ground_truth:
-        gt_messages: list[dict] = []
-        if system:
-            gt_messages.append({"role": "system", "content": system})
-        gt_messages.append({"role": "user", "content": prompt})
-        actual_tokens = await _ollama_count_messages(gt_messages, model, ollama)
+        # Count via /api/generate to match how lora_generate actually sends
+        # the prompt. /api/chat applies role markers that /api/generate
+        # doesn't, so counting via chat would systematically over-count.
+        actual_tokens = await _ollama_count_raw_prompt(
+            prompt, system or None, model, ollama
+        )
         # Silent-failure guard: treat non-positive counts as estimator fallback
         # (matches fit_prompt behavior added in Task 8 review).
         if actual_tokens <= 0:

--- a/projects/rp/budget.py
+++ b/projects/rp/budget.py
@@ -128,6 +128,8 @@ async def fit_prompt(
     )
     messages_budget = available - overhead
 
+    summary_dropped = False
+
     # Priority 2: delegate to strategy.fit with the corrected budget.
     # The strategy (SlidingWindow / SummaryBuffer) handles greeting
     # protection, oldest-first drop, and summary injection.
@@ -135,6 +137,27 @@ async def fit_prompt(
         ctx["messages"] = strategy.fit(
             ctx.get("messages", []), messages_budget, ctx=ctx
         )
+
+    # Priority 3: if still over budget, drop the summary (if any) and re-fit.
+    def _current_messages_tokens() -> int:
+        return sum(
+            _estimate_tokens(m.get("content", ""))
+            for m in ctx.get("messages", [])
+        )
+
+    if ctx.get("_summary") and _current_messages_tokens() > messages_budget:
+        ctx["_summary"] = None
+        # Strip any injected summary message (added by SummaryBuffer) before re-fitting.
+        ctx["messages"] = [
+            m for m in ctx.get("messages", [])
+            if not m.get("content", "").startswith("[Story so far]")
+        ]
+        if messages_budget > 0:
+            ctx["messages"] = strategy.fit(
+                ctx.get("messages", []), messages_budget, ctx=ctx
+            )
+        summary_dropped = True
+        warnings.append("summary dropped to fit messages budget")
 
     messages_after = len(ctx.get("messages", []))
     messages_dropped = max(0, messages_before - messages_after)
@@ -148,7 +171,7 @@ async def fit_prompt(
         messages_budget=messages_budget,
         messages_kept=messages_after,
         messages_dropped=messages_dropped,
-        summary_dropped=False,
+        summary_dropped=summary_dropped,
         mes_example_truncated=False,
         estimator_tokens=overhead + sum(
             _estimate_tokens(m.get("content", "")) for m in ctx.get("messages", [])

--- a/projects/rp/lora_generate.py
+++ b/projects/rp/lora_generate.py
@@ -22,9 +22,11 @@ import json
 import logging
 import random
 import re
+from pathlib import Path
 
 import asyncpg
 
+from .budget import BudgetError, fit_raw_prompt
 from .pipeline import DEFAULT_PROMPT_TEMPLATE, _split_template, render_template
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
@@ -215,6 +217,19 @@ async def generate_scenarios(ollama, model: str, ai_card: dict, user_card: dict,
             "Example: [\"Scenario one.\", \"Scenario two.\", \"Scenario three.\"]"
         )
 
+        try:
+            prompt, _ = await fit_raw_prompt(
+                prompt=prompt,
+                system="Output valid JSON only. No markdown fences.",
+                model=model, ollama=ollama, num_predict=1024,
+            )
+        except BudgetError as e:
+            _log.warning(
+                "Skipping category %s for %s: prompt does not fit (%s)",
+                cat["category"], char_name, e,
+            )
+            continue
+
         raw = await ollama.generate(
             model=model, prompt=prompt,
             system="Output valid JSON only. No markdown fences.",
@@ -266,9 +281,18 @@ async def generate_user_message(ollama, model: str, context: dict) -> str:
         "No prefix like 'User:'. Just the message."
     )
 
+    system = f"You are {context['user_name']}. Write their next message only."
+    try:
+        prompt, _ = await fit_raw_prompt(
+            prompt=prompt, system=system,
+            model=model, ollama=ollama, num_predict=300,
+        )
+    except BudgetError as e:
+        _log.warning("User msg budget error: %s", e)
+        return ""
+
     raw = await ollama.generate(
-        model=model, prompt=prompt,
-        system=f"You are {context['user_name']}. Write their next message only.",
+        model=model, prompt=prompt, system=system,
         options={"temperature": 1.0, "num_predict": 300, "think": False},
     )
     return raw.strip().strip('"')
@@ -282,6 +306,17 @@ async def generate_assistant_message(ollama, model: str, system_prompt: str,
     for msg in messages:
         role = "user" if msg["from"] == "human" else "assistant"
         chat_msgs.append({"role": role, "content": msg["value"]})
+
+    serialized = "\n".join(f"{m['role']}: {m['content']}" for m in chat_msgs[1:])
+    try:
+        _, _ = await fit_raw_prompt(
+            prompt=serialized, system=system_prompt,
+            model=model, ollama=ollama, num_predict=768,
+            ground_truth=False,
+        )
+    except BudgetError as e:
+        _log.warning("Assistant msg budget error: %s", e)
+        return ""
 
     raw = await ollama.chat(
         model=model, messages=chat_msgs,
@@ -415,8 +450,28 @@ async def generate_conversation(ollama, model_70b: str, ai_card: dict, user_card
 class OllamaClient:
     """Minimal async Ollama client for generation."""
 
-    def __init__(self, base_url: str = "http://127.0.0.1:8080"):
+    def __init__(self, base_url: str = "http://127.0.0.1:8080", ollama_url: str | None = None):
         self.base_url = base_url
+        if not ollama_url:
+            try:
+                config_path = Path(__file__).parent.parent / "aiserver" / "config.json"
+                ollama_url = json.loads(config_path.read_text()).get(
+                    "ollama_url", "http://localhost:11434"
+                )
+            except Exception:
+                ollama_url = "http://localhost:11434"
+        from aiserver.ollama import OllamaClient as _BudgetOllamaClient
+        self._budget = _BudgetOllamaClient(ollama_url)
+
+    async def get_num_ctx(self, model: str) -> int:
+        """Delegate to real Ollama for budget protocol."""
+        return await self._budget.get_num_ctx(model)
+
+    async def count_generate_prompt(
+        self, model: str, prompt: str, system: str | None = None
+    ) -> int:
+        """Delegate to real Ollama for budget protocol."""
+        return await self._budget.count_generate_prompt(model, prompt, system)
 
     @staticmethod
     def _parse_ndjson(text: str) -> str:
@@ -497,12 +552,14 @@ async def main():
     parser.add_argument("--scenarios-per-category", type=int, default=2, help="Scenarios per category (default: 2)")
     parser.add_argument("--scenarios-only", action="store_true", help="Only generate and print scenarios")
     parser.add_argument("--aiserver-url", type=str, default="http://127.0.0.1:8080")
+    parser.add_argument("--ollama-url", type=str, default=None,
+                        help="Raw Ollama URL for budget counting (default: from aiserver/config.json)")
     parser.add_argument("--output", "-o", type=str, default="lora_generated.json")
     args = parser.parse_args()
 
     import os
     pool = await asyncpg.create_pool(os.environ["DATABASE_URL"], min_size=1, max_size=2)
-    ollama = OllamaClient(args.aiserver_url)
+    ollama = OllamaClient(args.aiserver_url, ollama_url=args.ollama_url)
 
     ai_card_ids = [int(x.strip()) for x in args.ai_card_ids.split(",")]
     user_card = await _get_card(pool, args.user_card_id)

--- a/projects/rp/pipeline.py
+++ b/projects/rp/pipeline.py
@@ -206,11 +206,15 @@ def inject_tools(ctx: dict) -> dict:
 
 
 def create_default_pipeline() -> Pipeline:
-    """Create pipeline with standard hooks."""
+    """Create pipeline with standard hooks.
+
+    NOTE: context budgeting is no longer part of the pipeline — it's
+    now done explicitly at each call site via budget.fit_prompt, which
+    needs access to the ollama client and resolved model name.
+    """
     p = Pipeline()
     p.add_pre(assemble_prompt)
     p.add_pre(expand_variables)
     p.add_pre(inject_tools)
-    p.add_pre(apply_context_strategy)
     p.add_post(clean_response)
     return p

--- a/projects/rp/pipeline.py
+++ b/projects/rp/pipeline.py
@@ -1,7 +1,6 @@
 import asyncio
 import logging
 from typing import Callable
-from .context import get_strategy
 from .mcp_client import get_router
 
 _log = logging.getLogger(__name__)
@@ -167,17 +166,6 @@ def render_template(template: str, values: dict) -> str:
     for key, val in values.items():
         result = result.replace("{{" + key + "}}", str(val))
     return result.strip()
-
-
-def apply_context_strategy(ctx: dict) -> dict:
-    """Fit messages within token budget using the active strategy."""
-    settings = ctx.get("scenario", {}).get("settings", {})
-    strategy_name = settings.get("context_strategy", "summary_buffer")
-    max_tokens = settings.get("max_context_tokens", 6144)
-
-    strategy = get_strategy(strategy_name)
-    ctx["messages"] = strategy.fit(ctx["messages"], max_tokens, ctx=ctx)
-    return ctx
 
 
 # -- Built-in post-processing hooks --

--- a/projects/rp/routes.py
+++ b/projects/rp/routes.py
@@ -474,7 +474,7 @@ def setup(app: FastAPI, ollama, resolve_model=None):
         scenario = ctx.get("scenario") or {}
         settings = scenario.get("settings", {})
         strategy = get_strategy(settings.get("context_strategy", "summary_buffer"))
-        num_predict = ollama_options.get("num_predict") if ollama_options else None
+        num_predict = ollama_options.get("num_predict")
         try:
             return await fit_prompt(
                 ctx, model=model, ollama=_ollama,

--- a/projects/rp/routes.py
+++ b/projects/rp/routes.py
@@ -14,6 +14,8 @@ from .models import (
     MessageResponse, SendMessageRequest, EditMessageRequest, SceneStateRequest,
 )
 from .pipeline import create_default_pipeline
+from .budget import fit_prompt, BudgetError
+from .context import get_strategy
 from .mcp_client import get_router as get_mcp_router
 from .research import research_dispatch
 from .fewshot import get_fewshot_messages
@@ -463,6 +465,26 @@ def setup(app: FastAPI, ollama, resolve_model=None):
 
         return await _pipeline.run_pre(ctx)
 
+    async def _budget_ctx(ctx, model, ollama_options):
+        """Run fit_prompt against ctx, using scenario-configured strategy.
+
+        On BudgetError, logs a WARNING and re-raises — callers handle the
+        response (HTTP 413, stream error chunk, etc.).
+        """
+        scenario = ctx.get("scenario") or {}
+        settings = scenario.get("settings", {})
+        strategy = get_strategy(settings.get("context_strategy", "summary_buffer"))
+        num_predict = ollama_options.get("num_predict") if ollama_options else None
+        try:
+            return await fit_prompt(
+                ctx, model=model, ollama=_ollama,
+                strategy=strategy, num_predict=num_predict,
+                ground_truth=True,
+            )
+        except BudgetError as e:
+            _log.warning("Budget error for model=%s: %s", model, e)
+            raise
+
     def _get_ai_name(ctx):
         """Extract AI character name for response prefixing."""
         ai_data = ctx.get("ai_card", {}).get("card_data", {}).get("data", ctx.get("ai_card", {}).get("card_data", {}))
@@ -739,6 +761,23 @@ def setup(app: FastAPI, ollama, resolve_model=None):
             conv_log.log_fewshot(conv_id, len(fewshot_msgs) // 2, fewshot_msgs)
             # Prepend after greeting (messages[0]), before real conversation
             ctx["messages"] = [ctx["messages"][0]] + fewshot_msgs + ctx["messages"][1:]
+
+        try:
+            await _budget_ctx(ctx, model, ollama_options)
+        except BudgetError as e:
+            err_msg = f"Prompt does not fit model context: {e}"
+            async def _err_stream():
+                yield json.dumps({
+                    "error": err_msg,
+                    "done": True,
+                }) + "\n"
+            return StreamingResponse(
+                _err_stream(), media_type="application/x-ndjson",
+                status_code=413,
+            )
+
+        # Tell Ollama to load the model with its real context window
+        ollama_options = {**ollama_options, "num_ctx": ctx["_num_ctx"]}
 
         chat_messages = _build_chat_messages(ctx)
         user_name = _get_user_name(ctx)

--- a/projects/rp/routes.py
+++ b/projects/rp/routes.py
@@ -898,6 +898,23 @@ def setup(app: FastAPI, ollama, resolve_model=None):
         settings = scenario.get("settings", {})
         ollama_options = _build_ollama_options(settings)
 
+        try:
+            await _budget_ctx(ctx, model, ollama_options)
+        except BudgetError as e:
+            err_msg = f"Prompt does not fit model context: {e}"
+            async def _err_stream():
+                yield json.dumps({
+                    "error": err_msg,
+                    "done": True,
+                }) + "\n"
+            return StreamingResponse(
+                _err_stream(), media_type="application/x-ndjson",
+                status_code=413,
+            )
+
+        # Tell Ollama to load the model with its real context window
+        ollama_options = {**ollama_options, "num_ctx": ctx["_num_ctx"]}
+
         chat_messages = _build_chat_messages(ctx)
         user_name = _get_user_name(ctx)
         conv_log.log_prompt(conv_id, "regenerate", model,
@@ -955,6 +972,23 @@ def setup(app: FastAPI, ollama, resolve_model=None):
         scenario = ctx.get("scenario") or {}
         settings = scenario.get("settings", {})
         ollama_options = _build_ollama_options(settings)
+
+        try:
+            await _budget_ctx(ctx, model, ollama_options)
+        except BudgetError as e:
+            err_msg = f"Prompt does not fit model context: {e}"
+            async def _err_stream():
+                yield json.dumps({
+                    "error": err_msg,
+                    "done": True,
+                }) + "\n"
+            return StreamingResponse(
+                _err_stream(), media_type="application/x-ndjson",
+                status_code=413,
+            )
+
+        # Tell Ollama to load the model with its real context window
+        ollama_options = {**ollama_options, "num_ctx": ctx["_num_ctx"]}
 
         chat_messages = _build_chat_messages(ctx)
         user_name = _get_user_name(ctx)
@@ -1060,6 +1094,23 @@ def setup(app: FastAPI, ollama, resolve_model=None):
         if generating_as_user:
             # Instruct model: lower temperature, no thinking
             ollama_options = {"temperature": 0.7, "num_predict": 256, "think": False}
+
+        try:
+            await _budget_ctx(ctx, model, ollama_options)
+        except BudgetError as e:
+            err_msg = f"Prompt does not fit model context: {e}"
+            async def _err_stream():
+                yield json.dumps({
+                    "error": err_msg,
+                    "done": True,
+                }) + "\n"
+            return StreamingResponse(
+                _err_stream(), media_type="application/x-ndjson",
+                status_code=413,
+            )
+
+        # Tell Ollama to load the model with its real context window
+        ollama_options = {**ollama_options, "num_ctx": ctx["_num_ctx"]}
 
         chat_messages = _build_chat_messages(ctx)
         user_name = _get_user_name(ctx)

--- a/projects/rp/tests/conftest.py
+++ b/projects/rp/tests/conftest.py
@@ -27,6 +27,7 @@ class StubOllama:
     show_calls: dict[str, int] = field(default_factory=dict)
     chat_calls: int = 0
     default_count: int = 0
+    last_chat_messages: list | None = None
 
     async def get_num_ctx(self, model: str) -> int:
         self.show_calls[model] = self.show_calls.get(model, 0) + 1
@@ -43,6 +44,7 @@ class StubOllama:
         our stub returns count_map[model] or default_count.
         """
         self.chat_calls += 1
+        self.last_chat_messages = list(messages)
         count = self.count_map.get(model, self.default_count)
         return {
             "message": {"role": "assistant", "content": ""},

--- a/projects/rp/tests/conftest.py
+++ b/projects/rp/tests/conftest.py
@@ -1,0 +1,57 @@
+"""Shared test fixtures for the rp test suite."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import pytest
+
+
+@dataclass
+class StubOllama:
+    """Stand-in for OllamaClient in unit tests.
+
+    - `num_ctx_map` is what get_num_ctx returns per model.
+    - `count_map` lets tests stub the ground-truth count helper by
+      registering a dict of {prompt_key: token_count}. Tests that don't
+      care about ground-truth counting can leave it empty.
+    - `show_calls` records how many times get_num_ctx was called per
+      model (for cache-hit tests).
+    - `chat_calls` records how many times chat() was called (for the
+      ground-truth call counter).
+    """
+
+    num_ctx_map: dict[str, int] = field(default_factory=dict)
+    count_map: dict[str, int] = field(default_factory=dict)
+    show_calls: dict[str, int] = field(default_factory=dict)
+    chat_calls: int = 0
+    default_count: int = 0
+
+    async def get_num_ctx(self, model: str) -> int:
+        self.show_calls[model] = self.show_calls.get(model, 0) + 1
+        if model not in self.num_ctx_map:
+            from aiserver.ollama import OllamaError
+            raise OllamaError(f"stub has no num_ctx for model {model!r}")
+        return self.num_ctx_map[model]
+
+    async def chat(self, model: str, messages, tools=None, think=False):
+        """Stub /api/chat that returns a prompt_eval_count.
+
+        Ground-truth counting calls this with num_predict=0 in options;
+        our stub returns count_map[model] or default_count.
+        """
+        self.chat_calls += 1
+        count = self.count_map.get(model, self.default_count)
+        return {
+            "message": {"role": "assistant", "content": ""},
+            "done": True,
+            "prompt_eval_count": count,
+        }
+
+
+@pytest.fixture
+def stub_ollama_factory():
+    """Factory that builds a fresh StubOllama with the given config."""
+    def _make(**kwargs):
+        return StubOllama(**kwargs)
+    return _make

--- a/projects/rp/tests/conftest.py
+++ b/projects/rp/tests/conftest.py
@@ -52,6 +52,18 @@ class StubOllama:
             "prompt_eval_count": count,
         }
 
+    async def count_generate_prompt(
+        self, model: str, prompt: str, system: str | None = None
+    ) -> int:
+        """Stub /api/generate counting path used by fit_raw_prompt.
+
+        Reuses `count_map` / `default_count` and increments `chat_calls`
+        as the unified "ground-truth call counter" so tests can assert
+        that counting happened without caring which endpoint was used.
+        """
+        self.chat_calls += 1
+        return self.count_map.get(model, self.default_count)
+
 
 @pytest.fixture
 def stub_ollama_factory():

--- a/projects/rp/tests/conftest.py
+++ b/projects/rp/tests/conftest.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass, field
 
 import pytest
@@ -29,6 +30,7 @@ class StubOllama:
 
     async def get_num_ctx(self, model: str) -> int:
         self.show_calls[model] = self.show_calls.get(model, 0) + 1
+        await asyncio.sleep(0)
         if model not in self.num_ctx_map:
             from aiserver.ollama import OllamaError
             raise OllamaError(f"stub has no num_ctx for model {model!r}")

--- a/projects/rp/tests/test_budget.py
+++ b/projects/rp/tests/test_budget.py
@@ -4,7 +4,14 @@ import asyncio
 import pytest
 
 from projects.rp import budget
-from projects.rp.budget import BudgetError, BudgetReport, _get_model_ctx, _ollama_count_messages, fit_prompt
+from projects.rp.budget import (
+    BudgetError,
+    BudgetReport,
+    _get_model_ctx,
+    _ollama_count_messages,
+    fit_prompt,
+    fit_raw_prompt,
+)
 from projects.rp.context import SlidingWindow, SummaryBuffer
 from projects.rp.tests.conftest import StubOllama
 
@@ -470,3 +477,63 @@ class TestFitPromptGroundTruth:
         )
         assert report.actual_tokens is None
         assert any("non-positive prompt_eval_count" in w for w in report.warnings)
+
+
+class TestFitRawPrompt:
+    @pytest.mark.asyncio
+    async def test_small_prompt_fits(self, stub_ollama_factory):
+        stub = stub_ollama_factory(
+            num_ctx_map={"m": 8192},
+            count_map={"m": 200},
+        )
+        prompt, report = await fit_raw_prompt(
+            prompt="hello world",
+            system="be helpful",
+            model="m",
+            ollama=stub,
+            num_predict=500,
+            ground_truth=True,
+        )
+        assert prompt == "hello world"
+        assert report.actual_tokens == 200
+        assert report.model_ctx == 8192
+
+    @pytest.mark.asyncio
+    async def test_oversized_prompt_raises(self, stub_ollama_factory):
+        stub = stub_ollama_factory(
+            num_ctx_map={"m": 500},
+            count_map={"m": 10000},  # ground-truth says way over
+        )
+        with pytest.raises(BudgetError) as exc_info:
+            await fit_raw_prompt(
+                prompt="X" * 40000,
+                system="",
+                model="m",
+                ollama=stub,
+                num_predict=100,
+                ground_truth=True,
+            )
+        assert exc_info.value.report.model_ctx == 500
+
+    @pytest.mark.asyncio
+    async def test_ground_truth_off_uses_estimator(self, stub_ollama_factory):
+        stub = stub_ollama_factory(num_ctx_map={"m": 8192})
+        prompt, report = await fit_raw_prompt(
+            prompt="hi",
+            system=None,
+            model="m",
+            ollama=stub,
+            num_predict=1024,
+            ground_truth=False,
+        )
+        assert report.actual_tokens is None
+        assert stub.chat_calls == 0
+
+    @pytest.mark.asyncio
+    async def test_default_num_predict_is_1024(self, stub_ollama_factory):
+        stub = stub_ollama_factory(num_ctx_map={"m": 8192})
+        _, report = await fit_raw_prompt(
+            prompt="hi", system=None, model="m", ollama=stub,
+            num_predict=None, ground_truth=False,
+        )
+        assert report.response_reserve == 1024

--- a/projects/rp/tests/test_budget.py
+++ b/projects/rp/tests/test_budget.py
@@ -1,0 +1,74 @@
+"""Unit tests for projects/rp/budget.py."""
+
+import asyncio
+import pytest
+
+from projects.rp import budget
+from projects.rp.budget import BudgetError, BudgetReport, _get_model_ctx
+
+
+@pytest.fixture(autouse=True)
+def _clear_budget_cache():
+    """Ensure each test sees a fresh module-level cache."""
+    budget._ctx_cache.clear()
+    budget._ctx_locks.clear()
+    yield
+    budget._ctx_cache.clear()
+    budget._ctx_locks.clear()
+
+
+class TestBudgetReport:
+    def test_fields_have_sensible_defaults(self):
+        report = BudgetReport(
+            model="m", model_ctx=8192, response_reserve=1024,
+            available=7168, overhead=500, messages_budget=6668,
+            messages_kept=10, messages_dropped=0,
+            summary_dropped=False, mes_example_truncated=False,
+            estimator_tokens=5000, actual_tokens=None, warnings=[],
+        )
+        assert report.model == "m"
+        assert report.warnings == []
+
+    def test_budget_error_carries_report(self):
+        report = BudgetReport(
+            model="m", model_ctx=1024, response_reserve=1024,
+            available=0, overhead=0, messages_budget=0,
+            messages_kept=0, messages_dropped=0,
+            summary_dropped=False, mes_example_truncated=False,
+            estimator_tokens=0, actual_tokens=None, warnings=[],
+        )
+        err = BudgetError("doesn't fit", report)
+        assert err.report is report
+        assert str(err) == "doesn't fit"
+
+
+class TestGetModelCtx:
+    @pytest.mark.asyncio
+    async def test_first_call_fetches_from_ollama(self, stub_ollama_factory):
+        stub = stub_ollama_factory(num_ctx_map={"modelA": 8192})
+        result = await _get_model_ctx("modelA", stub)
+        assert result == 8192
+        assert stub.show_calls["modelA"] == 1
+
+    @pytest.mark.asyncio
+    async def test_second_call_uses_cache(self, stub_ollama_factory):
+        stub = stub_ollama_factory(num_ctx_map={"modelA": 8192})
+        await _get_model_ctx("modelA", stub)
+        await _get_model_ctx("modelA", stub)
+        assert stub.show_calls["modelA"] == 1
+
+    @pytest.mark.asyncio
+    async def test_concurrent_first_calls_only_fetch_once(self, stub_ollama_factory):
+        stub = stub_ollama_factory(num_ctx_map={"modelA": 8192})
+        results = await asyncio.gather(*[
+            _get_model_ctx("modelA", stub) for _ in range(10)
+        ])
+        assert all(r == 8192 for r in results)
+        assert stub.show_calls["modelA"] == 1
+
+    @pytest.mark.asyncio
+    async def test_different_models_cached_independently(self, stub_ollama_factory):
+        stub = stub_ollama_factory(num_ctx_map={"A": 8192, "B": 32768})
+        assert await _get_model_ctx("A", stub) == 8192
+        assert await _get_model_ctx("B", stub) == 32768
+        assert stub.show_calls == {"A": 1, "B": 1}

--- a/projects/rp/tests/test_budget.py
+++ b/projects/rp/tests/test_budget.py
@@ -537,3 +537,35 @@ class TestFitRawPrompt:
             num_predict=None, ground_truth=False,
         )
         assert report.response_reserve == 1024
+
+    @pytest.mark.asyncio
+    async def test_zero_prompt_eval_count_falls_back_to_estimator(
+        self, stub_ollama_factory
+    ):
+        """Non-positive count from Ollama must fall back to estimator,
+        not silently report success. Mirrors the Task 8 guard for fit_prompt."""
+        stub = stub_ollama_factory(num_ctx_map={"m": 8192}, default_count=0)
+        prompt, report = await fit_raw_prompt(
+            prompt="hi", system=None, model="m", ollama=stub,
+            num_predict=1024, ground_truth=True,
+        )
+        assert report.actual_tokens is None
+        assert any("non-positive prompt_eval_count" in w for w in report.warnings)
+
+    @pytest.mark.asyncio
+    async def test_oversized_via_estimator_raises(self, stub_ollama_factory):
+        """With ground_truth=False, the estimator path alone must still
+        reject prompts larger than model_ctx - reserve. Prevents the
+        previous test from silently short-circuiting via ground-truth."""
+        stub = stub_ollama_factory(num_ctx_map={"m": 500})
+        with pytest.raises(BudgetError) as exc_info:
+            await fit_raw_prompt(
+                prompt="X" * 40000,  # estimator: 10000 tokens
+                system="",
+                model="m",
+                ollama=stub,
+                num_predict=100,
+                ground_truth=False,
+            )
+        assert exc_info.value.report.model_ctx == 500
+        assert stub.chat_calls == 0

--- a/projects/rp/tests/test_budget.py
+++ b/projects/rp/tests/test_budget.py
@@ -569,3 +569,28 @@ class TestFitRawPrompt:
             )
         assert exc_info.value.report.model_ctx == 500
         assert stub.chat_calls == 0
+
+
+class TestEquivalenceWithOldBehavior:
+    @pytest.mark.asyncio
+    async def test_empty_system_prompt_matches_sliding_window(
+        self, stub_ollama_factory
+    ):
+        """With an empty system prompt, fit_prompt should produce the same
+        messages trimming that the old apply_context_strategy did — that is,
+        pure SlidingWindow behavior against the raw max_tokens."""
+        stub = stub_ollama_factory(num_ctx_map={"m": 1000})
+        messages = [
+            {"role": "assistant", "content": "G" * 100},  # greeting
+        ]
+        for i in range(30):
+            messages.append({"role": "user", "content": f"msg {i:02d} " + "X" * 100})
+
+        ctx = _build_ctx(system_prompt="", post_prompt="", messages=messages)
+        expected = SlidingWindow().fit(list(messages), max_tokens=500)
+
+        await fit_prompt(
+            ctx, model="m", ollama=stub, strategy=SlidingWindow(),
+            num_predict=500, ground_truth=False,
+        )
+        assert ctx["messages"] == expected

--- a/projects/rp/tests/test_budget.py
+++ b/projects/rp/tests/test_budget.py
@@ -232,8 +232,8 @@ class TestFitPromptPriority3:
           summary "S"*400 -> 100 tokens; cap = 900*0.25 = 225; 100 <= 225, injected.
           budget_for_recent = 900 - 0 (greeting "hi"=2 chars=0t) - 100 = 800
           recent "Z"*3200 -> 800 tokens; 800 <= 800, kept by strategy.
-          Injected msg = "[Story so far]\\n" + "S"*400 = 416 chars = 104 tokens.
-          Post-strategy total = 104 + 0 + 800 = 904 > 900 -> Priority 3 fires.
+          Injected msg = "[Story so far]\\n" + "S"*400 = 415 chars = 103 tokens.
+          Post-strategy total = 103 + 0 + 800 = 903 > 900 -> Priority 3 fires.
         """
         stub = stub_ollama_factory(num_ctx_map={"m": 1200})
         # 800 tokens exactly fills recent budget; "[Story so far]\\n" prefix (3t) pushes total over

--- a/projects/rp/tests/test_budget.py
+++ b/projects/rp/tests/test_budget.py
@@ -254,3 +254,33 @@ class TestFitPromptPriority3:
         assert report.summary_dropped is True
         for m in ctx["messages"]:
             assert "[Story so far]" not in m.get("content", "")
+
+
+class TestFitPromptPriority4:
+    @pytest.mark.asyncio
+    async def test_mes_example_truncated_when_overhead_dominates(
+        self, stub_ollama_factory
+    ):
+        """When system_prompt (which includes mes_example) exceeds the
+        available budget, truncate mes_example and re-render."""
+        stub = stub_ollama_factory(num_ctx_map={"m": 1000})
+
+        mes_example = "Example line.\n" * 200
+        system_prompt = "character intro\n\nExample dialogue:\n" + mes_example + "\n\nmore intro"
+
+        ctx = _build_ctx(
+            system_prompt=system_prompt,
+            messages=[{"role": "user", "content": "hi"}],
+            ai_card={"card_data": {"data": {"mes_example": mes_example}}},
+        )
+        ctx["user_card"] = {"card_data": {"data": {}}}
+        ctx["scenario"] = {}
+        ctx["prompt_template"] = ""
+
+        report = await fit_prompt(
+            ctx, model="m", ollama=stub, strategy=SlidingWindow(),
+            num_predict=500, ground_truth=False,
+        )
+        assert report.mes_example_truncated is True
+        truncated = ctx["ai_card"]["card_data"]["data"]["mes_example"]
+        assert len(truncated) < len(mes_example)

--- a/projects/rp/tests/test_budget.py
+++ b/projects/rp/tests/test_budget.py
@@ -5,7 +5,7 @@ import pytest
 
 from projects.rp import budget
 from projects.rp.budget import BudgetError, BudgetReport, _get_model_ctx, _ollama_count_messages, fit_prompt
-from projects.rp.context import SlidingWindow
+from projects.rp.context import SlidingWindow, SummaryBuffer
 
 
 @pytest.fixture(autouse=True)
@@ -198,3 +198,59 @@ class TestFitPromptHappyPath:
         assert report.available == 800
         assert report.overhead == 500
         assert report.messages_budget == 300
+
+
+class TestFitPromptPriority3:
+    @pytest.mark.asyncio
+    async def test_summary_kept_when_it_fits(self, stub_ollama_factory):
+        """Happy case: summary fits within budget, should not be dropped."""
+        stub = stub_ollama_factory(num_ctx_map={"m": 1000})
+        ctx = _build_ctx(
+            system_prompt="",
+            post_prompt="",
+            messages=[
+                {"role": "assistant", "content": "greeting", "_sequence": 1},
+                {"role": "user", "content": "X" * 1000, "_sequence": 10},
+            ],
+        )
+        ctx["_summary"] = "Y" * 800
+        ctx["_summary_through_sequence"] = 5
+
+        report = await fit_prompt(
+            ctx, model="m", ollama=stub, strategy=SummaryBuffer(),
+            num_predict=500, ground_truth=False,
+        )
+        assert report.summary_dropped is False
+
+    @pytest.mark.asyncio
+    async def test_summary_dropped_when_budget_too_tight(self, stub_ollama_factory):
+        """When even after strategy.fit the prompt is still over budget
+        (we check via the estimator on the rendered messages), drop summary.
+
+        Budget math (4-chars-per-token estimator):
+          model_ctx=1200, num_predict=300 -> available=900, messages_budget=900
+          summary "S"*400 -> 100 tokens; cap = 900*0.25 = 225; 100 <= 225, injected.
+          budget_for_recent = 900 - 0 (greeting "hi"=2 chars=0t) - 100 = 800
+          recent "Z"*3200 -> 800 tokens; 800 <= 800, kept by strategy.
+          Injected msg = "[Story so far]\\n" + "S"*400 = 416 chars = 104 tokens.
+          Post-strategy total = 104 + 0 + 800 = 904 > 900 -> Priority 3 fires.
+        """
+        stub = stub_ollama_factory(num_ctx_map={"m": 1200})
+        # 800 tokens exactly fills recent budget; "[Story so far]\\n" prefix (3t) pushes total over
+        huge_recent = "Z" * 3200  # 800 tokens
+        ctx = _build_ctx(
+            messages=[
+                {"role": "assistant", "content": "hi", "_sequence": 1},
+                {"role": "user", "content": huge_recent, "_sequence": 10},
+            ],
+        )
+        ctx["_summary"] = "S" * 400  # 100 tokens, within 25% cap
+        ctx["_summary_through_sequence"] = 5
+
+        report = await fit_prompt(
+            ctx, model="m", ollama=stub, strategy=SummaryBuffer(),
+            num_predict=300, ground_truth=False,
+        )
+        assert report.summary_dropped is True
+        for m in ctx["messages"]:
+            assert "[Story so far]" not in m.get("content", "")

--- a/projects/rp/tests/test_budget.py
+++ b/projects/rp/tests/test_budget.py
@@ -24,7 +24,7 @@ class TestBudgetReport:
             available=7168, overhead=500, messages_budget=6668,
             messages_kept=10, messages_dropped=0,
             summary_dropped=False, mes_example_truncated=False,
-            estimator_tokens=5000, actual_tokens=None, warnings=[],
+            estimator_tokens=5000, actual_tokens=None,
         )
         assert report.model == "m"
         assert report.warnings == []

--- a/projects/rp/tests/test_budget.py
+++ b/projects/rp/tests/test_budget.py
@@ -4,7 +4,7 @@ import asyncio
 import pytest
 
 from projects.rp import budget
-from projects.rp.budget import BudgetError, BudgetReport, _get_model_ctx
+from projects.rp.budget import BudgetError, BudgetReport, _get_model_ctx, _ollama_count_messages
 
 
 @pytest.fixture(autouse=True)
@@ -72,3 +72,24 @@ class TestGetModelCtx:
         assert await _get_model_ctx("A", stub) == 8192
         assert await _get_model_ctx("B", stub) == 32768
         assert stub.show_calls == {"A": 1, "B": 1}
+
+
+class TestOllamaCountMessages:
+    @pytest.mark.asyncio
+    async def test_returns_prompt_eval_count(self, stub_ollama_factory):
+        stub = stub_ollama_factory(count_map={"modelA": 1234})
+        messages = [
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "Hi"},
+        ]
+        count = await _ollama_count_messages(messages, "modelA", stub)
+        assert count == 1234
+        assert stub.chat_calls == 1
+
+    @pytest.mark.asyncio
+    async def test_returns_zero_when_missing(self, stub_ollama_factory):
+        """If Ollama doesn't return prompt_eval_count, return 0 and let caller
+        decide. Never silently inflate or deflate."""
+        stub = stub_ollama_factory(count_map={})  # default_count=0
+        count = await _ollama_count_messages([{"role": "user", "content": "x"}], "modelA", stub)
+        assert count == 0

--- a/projects/rp/tests/test_budget.py
+++ b/projects/rp/tests/test_budget.py
@@ -346,14 +346,6 @@ class TestFitPromptPriority5:
 
 
 class TestFitPromptGroundTruth:
-    def _render_messages_for_count(self, ctx):
-        """Build the messages list as it would be sent to Ollama."""
-        msgs = [{"role": "system", "content": ctx["system_prompt"]}]
-        msgs.extend(ctx["messages"])
-        if ctx.get("post_prompt"):
-            msgs.append({"role": "system", "content": ctx["post_prompt"]})
-        return msgs
-
     @pytest.mark.asyncio
     async def test_ground_truth_fits_first_try(self, stub_ollama_factory):
         """Estimator says fits, ground-truth confirms."""
@@ -432,3 +424,49 @@ class TestFitPromptGroundTruth:
                 ctx, model="m", ollama=stub, strategy=SlidingWindow(),
                 num_predict=100, ground_truth=True,
             )
+
+    @pytest.mark.asyncio
+    async def test_rendered_messages_match_routes_assembly(self, stub_ollama_factory):
+        """Regression: _render_for_count must produce the same shape as
+        routes.py `_build_chat_messages` — system, messages, optional
+        post_prompt, and the assistant priming anchor. A drift here would
+        make every ground-truth count systematically low."""
+        stub = stub_ollama_factory(num_ctx_map={"m": 8192}, default_count=100)
+        ctx = _build_ctx(
+            system_prompt="SYS",
+            post_prompt="POST",
+            messages=[
+                {"role": "assistant", "content": "greeting"},
+                {"role": "user", "content": "hello"},
+            ],
+            ai_card={"card_data": {"data": {"name": "Ada"}}},
+        )
+        await fit_prompt(
+            ctx, model="m", ollama=stub, strategy=SlidingWindow(),
+            num_predict=1024, ground_truth=True,
+        )
+        assert stub.last_chat_messages == [
+            {"role": "system", "content": "SYS"},
+            {"role": "assistant", "content": "greeting"},
+            {"role": "user", "content": "hello"},
+            {"role": "system", "content": "POST"},
+            {"role": "assistant", "content": "Ada "},
+        ]
+
+    @pytest.mark.asyncio
+    async def test_zero_prompt_eval_count_falls_back_to_estimator(
+        self, stub_ollama_factory
+    ):
+        """If Ollama returns 0 / missing prompt_eval_count, don't silently
+        declare success — fall back to the estimator and emit a warning."""
+        stub = stub_ollama_factory(num_ctx_map={"m": 8192}, default_count=0)
+        ctx = _build_ctx(
+            system_prompt="hi",
+            messages=[{"role": "user", "content": "hello"}],
+        )
+        report = await fit_prompt(
+            ctx, model="m", ollama=stub, strategy=SlidingWindow(),
+            num_predict=1024, ground_truth=True,
+        )
+        assert report.actual_tokens is None
+        assert any("non-positive prompt_eval_count" in w for w in report.warnings)

--- a/projects/rp/tests/test_budget.py
+++ b/projects/rp/tests/test_budget.py
@@ -262,20 +262,31 @@ class TestFitPromptPriority4:
         self, stub_ollama_factory
     ):
         """When system_prompt (which includes mes_example) exceeds the
-        available budget, truncate mes_example and re-render."""
+        available budget, truncate mes_example and re-render.
+
+        Uses a minimal template (system section only, no post) so that after
+        truncation the re-assembled overhead fits within available.
+        Budget math:
+          model_ctx=1000, num_predict=500 -> available=500
+          mes_example = "Example line.\\n" * 200 = 2800 chars = 700 tokens
+          template "## system\\n{{mes_example}}" -> system_prompt = mes_example (~700t)
+          initial overhead = 700 > 500 -> P4 fires
+          after truncation: target = max(700//4, 200) = 200 tokens -> ~800 chars
+          re-assembled overhead ~200t <= 500 -> P5 does not fire
+        """
         stub = stub_ollama_factory(num_ctx_map={"m": 1000})
 
         mes_example = "Example line.\n" * 200
-        system_prompt = "character intro\n\nExample dialogue:\n" + mes_example + "\n\nmore intro"
 
         ctx = _build_ctx(
-            system_prompt=system_prompt,
+            system_prompt=mes_example,  # initial system_prompt includes mes_example
             messages=[{"role": "user", "content": "hi"}],
             ai_card={"card_data": {"data": {"mes_example": mes_example}}},
         )
         ctx["user_card"] = {"card_data": {"data": {}}}
         ctx["scenario"] = {}
-        ctx["prompt_template"] = ""
+        # Minimal template: system section only, no post — keeps overhead low after re-assembly
+        ctx["prompt_template"] = "## system\n{{mes_example}}"
 
         report = await fit_prompt(
             ctx, model="m", ollama=stub, strategy=SlidingWindow(),
@@ -284,3 +295,50 @@ class TestFitPromptPriority4:
         assert report.mes_example_truncated is True
         truncated = ctx["ai_card"]["card_data"]["data"]["mes_example"]
         assert len(truncated) < len(mes_example)
+
+
+class TestFitPromptPriority5:
+    @pytest.mark.asyncio
+    async def test_budget_error_when_single_user_message_too_big(
+        self, stub_ollama_factory
+    ):
+        """A user message larger than model_ctx on its own can't be shrunk."""
+        stub = stub_ollama_factory(num_ctx_map={"m": 500})
+        huge = "X" * 20000  # ~5000 tokens
+        ctx = _build_ctx(
+            messages=[
+                {"role": "assistant", "content": "greeting"},
+                {"role": "user", "content": huge},
+            ],
+        )
+        with pytest.raises(BudgetError) as exc_info:
+            await fit_prompt(
+                ctx, model="m", ollama=stub, strategy=SlidingWindow(),
+                num_predict=100, ground_truth=False,
+            )
+        report = exc_info.value.report
+        assert report.model == "m"
+        assert report.model_ctx == 500
+        assert "fit" in str(exc_info.value).lower()
+
+    @pytest.mark.asyncio
+    async def test_budget_error_when_system_alone_exceeds_available(
+        self, stub_ollama_factory
+    ):
+        """Even after mes_example truncation, if the rest of the system
+        prompt exceeds available, we raise."""
+        stub = stub_ollama_factory(num_ctx_map={"m": 200})
+        ctx = _build_ctx(
+            system_prompt="X" * 4000,
+            messages=[{"role": "user", "content": "hi"}],
+            ai_card={"card_data": {"data": {"mes_example": ""}}},
+        )
+        ctx["user_card"] = {"card_data": {"data": {}}}
+        ctx["scenario"] = {}
+        ctx["prompt_template"] = ""
+
+        with pytest.raises(BudgetError):
+            await fit_prompt(
+                ctx, model="m", ollama=stub, strategy=SlidingWindow(),
+                num_predict=50, ground_truth=False,
+            )

--- a/projects/rp/tests/test_budget.py
+++ b/projects/rp/tests/test_budget.py
@@ -6,6 +6,7 @@ import pytest
 from projects.rp import budget
 from projects.rp.budget import BudgetError, BudgetReport, _get_model_ctx, _ollama_count_messages, fit_prompt
 from projects.rp.context import SlidingWindow, SummaryBuffer
+from projects.rp.tests.conftest import StubOllama
 
 
 @pytest.fixture(autouse=True)
@@ -341,4 +342,93 @@ class TestFitPromptPriority5:
             await fit_prompt(
                 ctx, model="m", ollama=stub, strategy=SlidingWindow(),
                 num_predict=50, ground_truth=False,
+            )
+
+
+class TestFitPromptGroundTruth:
+    def _render_messages_for_count(self, ctx):
+        """Build the messages list as it would be sent to Ollama."""
+        msgs = [{"role": "system", "content": ctx["system_prompt"]}]
+        msgs.extend(ctx["messages"])
+        if ctx.get("post_prompt"):
+            msgs.append({"role": "system", "content": ctx["post_prompt"]})
+        return msgs
+
+    @pytest.mark.asyncio
+    async def test_ground_truth_fits_first_try(self, stub_ollama_factory):
+        """Estimator says fits, ground-truth confirms."""
+        stub = stub_ollama_factory(
+            num_ctx_map={"m": 8192},
+            count_map={"m": 100},  # ground truth says 100 tokens
+            default_count=100,
+        )
+        ctx = _build_ctx(
+            system_prompt="hello",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+        report = await fit_prompt(
+            ctx, model="m", ollama=stub, strategy=SlidingWindow(),
+            num_predict=1024, ground_truth=True,
+        )
+        assert report.actual_tokens == 100
+        assert stub.chat_calls == 1
+
+    @pytest.mark.asyncio
+    async def test_ground_truth_triggers_one_more_shrink(self, stub_ollama_factory):
+        """Estimator said fits but ground truth says over -> shrink once more."""
+        class ShrinkingStub(StubOllama):
+            def __init__(self):
+                super().__init__(
+                    num_ctx_map={"m": 1000},
+                    default_count=2000,  # first call: over
+                )
+                self.counts = [2000, 400]  # decreasing per call
+                self.call_idx = 0
+
+            async def chat(self, model, messages, tools=None, think=False):
+                self.chat_calls += 1
+                idx = min(self.call_idx, len(self.counts) - 1)
+                self.call_idx += 1
+                return {"done": True, "prompt_eval_count": self.counts[idx]}
+
+        stub = ShrinkingStub()
+        ctx = _build_ctx(
+            messages=[
+                {"role": "assistant", "content": "g"},
+                {"role": "user", "content": "A" * 100},
+                {"role": "user", "content": "B" * 100},
+            ],
+        )
+        report = await fit_prompt(
+            ctx, model="m", ollama=stub, strategy=SlidingWindow(),
+            num_predict=100, ground_truth=True,
+        )
+        assert stub.chat_calls == 2  # first check + recount after shrink
+        assert report.actual_tokens == 400
+
+    @pytest.mark.asyncio
+    async def test_ground_truth_over_twice_raises(self, stub_ollama_factory):
+        """Ground truth still over after one more shrink -> BudgetError."""
+        class OverStub(StubOllama):
+            def __init__(self):
+                super().__init__(
+                    num_ctx_map={"m": 500},
+                    default_count=1000,  # always over
+                )
+
+            async def chat(self, model, messages, tools=None, think=False):
+                self.chat_calls += 1
+                return {"done": True, "prompt_eval_count": 1000}
+
+        stub = OverStub()
+        ctx = _build_ctx(
+            messages=[
+                {"role": "assistant", "content": "g"},
+                {"role": "user", "content": "hi"},
+            ],
+        )
+        with pytest.raises(BudgetError):
+            await fit_prompt(
+                ctx, model="m", ollama=stub, strategy=SlidingWindow(),
+                num_predict=100, ground_truth=True,
             )

--- a/projects/rp/tests/test_budget.py
+++ b/projects/rp/tests/test_budget.py
@@ -4,7 +4,8 @@ import asyncio
 import pytest
 
 from projects.rp import budget
-from projects.rp.budget import BudgetError, BudgetReport, _get_model_ctx, _ollama_count_messages
+from projects.rp.budget import BudgetError, BudgetReport, _get_model_ctx, _ollama_count_messages, fit_prompt
+from projects.rp.context import SlidingWindow
 
 
 @pytest.fixture(autouse=True)
@@ -93,3 +94,107 @@ class TestOllamaCountMessages:
         stub = stub_ollama_factory(count_map={})  # default_count=0
         count = await _ollama_count_messages([{"role": "user", "content": "x"}], "modelA", stub)
         assert count == 0
+
+
+def _build_ctx(system_prompt="", post_prompt="", messages=None, ai_card=None):
+    """Build a minimal ctx dict for fit_prompt tests."""
+    return {
+        "system_prompt": system_prompt,
+        "post_prompt": post_prompt,
+        "messages": messages or [],
+        "ai_card": ai_card or {"card_data": {"data": {"mes_example": ""}}},
+    }
+
+
+class TestFitPromptHappyPath:
+    @pytest.mark.asyncio
+    async def test_everything_fits_no_shrink(self, stub_ollama_factory):
+        stub = stub_ollama_factory(num_ctx_map={"m": 8192})
+        ctx = _build_ctx(
+            system_prompt="system",  # ~1 token
+            post_prompt="post",       # ~1 token
+            messages=[
+                {"role": "assistant", "content": "greeting"},
+                {"role": "user", "content": "hi"},
+                {"role": "assistant", "content": "hello"},
+            ],
+        )
+        report = await fit_prompt(
+            ctx, model="m", ollama=stub, strategy=SlidingWindow(),
+            num_predict=512, ground_truth=False,
+        )
+        assert len(ctx["messages"]) == 3
+        assert report.model == "m"
+        assert report.model_ctx == 8192
+        assert report.response_reserve == 512
+        assert report.available == 8192 - 512
+        assert report.messages_kept == 3
+        assert report.messages_dropped == 0
+        assert report.summary_dropped is False
+        assert report.mes_example_truncated is False
+        assert ctx["_num_ctx"] == 8192
+        assert ctx["_budget_report"] is report
+
+    @pytest.mark.asyncio
+    async def test_default_response_reserve_is_1024(self, stub_ollama_factory):
+        stub = stub_ollama_factory(num_ctx_map={"m": 8192})
+        ctx = _build_ctx(messages=[{"role": "user", "content": "hi"}])
+        report = await fit_prompt(
+            ctx, model="m", ollama=stub, strategy=SlidingWindow(),
+            num_predict=None, ground_truth=False,
+        )
+        assert report.response_reserve == 1024
+
+    @pytest.mark.asyncio
+    async def test_priority_2_drops_oldest_messages(self, stub_ollama_factory):
+        """When messages exceed budget, SlidingWindow drops oldest first.
+
+        Budget math:
+          available = 2048 - 1900 = 148 tokens
+          overhead = 0 (no system/post prompt)
+          messages_budget = 148
+          Each message = len("X"*100) // 4 = 25 tokens
+
+        SlidingWindow keeps greeting (25t) then fills from newest:
+          E(25), D(25), C(25), B(25) = 100t total -> 25+100=125 <= 148
+          A: 125+25=150 > 148 -> break
+        Result: G (greeting) + B, C, D, E kept; A (oldest) dropped.
+        """
+        stub = stub_ollama_factory(num_ctx_map={"m": 2048})
+        messages = [
+            {"role": "assistant", "content": "G" * 100},   # greeting (kept)
+            {"role": "user", "content": "A" * 100},        # oldest (droppable)
+            {"role": "assistant", "content": "B" * 100},
+            {"role": "user", "content": "C" * 100},
+            {"role": "assistant", "content": "D" * 100},
+            {"role": "user", "content": "E" * 100},        # most recent (kept)
+        ]
+        ctx = _build_ctx(messages=messages)
+        report = await fit_prompt(
+            ctx, model="m", ollama=stub, strategy=SlidingWindow(),
+            num_predict=1900, ground_truth=False,
+        )
+        contents = [m["content"] for m in ctx["messages"]]
+        assert "G" * 100 in contents  # greeting
+        assert "E" * 100 in contents  # most recent
+        assert "A" * 100 not in contents  # oldest dropped
+        assert report.messages_dropped > 0
+
+    @pytest.mark.asyncio
+    async def test_overhead_counted_against_budget(self, stub_ollama_factory):
+        """Large system_prompt should reduce messages_budget accordingly."""
+        stub = stub_ollama_factory(num_ctx_map={"m": 1000})
+        ctx = _build_ctx(
+            system_prompt="X" * 2000,
+            messages=[{"role": "user", "content": "hi"}],
+        )
+        report = await fit_prompt(
+            ctx, model="m", ollama=stub, strategy=SlidingWindow(),
+            num_predict=200, ground_truth=False,
+        )
+        # available = 1000 - 200 = 800
+        # overhead = len("X"*2000)//4 = 500 (system) + 0 (post) = 500
+        # messages_budget = 300
+        assert report.available == 800
+        assert report.overhead == 500
+        assert report.messages_budget == 300

--- a/projects/rp/tests/test_lora_generate_budget.py
+++ b/projects/rp/tests/test_lora_generate_budget.py
@@ -1,0 +1,66 @@
+"""Tests for lora_generate.py integration with budget.fit_raw_prompt."""
+
+import pytest
+from unittest.mock import AsyncMock
+
+from projects.rp import lora_generate
+from projects.rp.budget import BudgetError, BudgetReport
+
+
+def _report(model_ctx=8192):
+    return BudgetReport(
+        model="m", model_ctx=model_ctx, response_reserve=500,
+        available=model_ctx - 500, overhead=100, messages_budget=0,
+        messages_kept=0, messages_dropped=0,
+        summary_dropped=False, mes_example_truncated=False,
+        estimator_tokens=100, actual_tokens=100, warnings=[],
+    )
+
+
+class TestGenerateScenariosBudgetSkip:
+    @pytest.mark.asyncio
+    async def test_budget_error_skips_category(self, monkeypatch):
+        """If fit_raw_prompt raises for one category, that category is
+        skipped but generate_scenarios returns scenarios from the others."""
+        ollama = AsyncMock()
+        ollama.get_num_ctx = AsyncMock(return_value=8192)
+        ollama.generate = AsyncMock(return_value='["s1.", "s2.", "s3."]')
+        ollama.chat = AsyncMock(return_value={"prompt_eval_count": 100, "done": True})
+
+        call_count = {"n": 0}
+
+        async def _fake_fit_raw_prompt(**kwargs):
+            call_count["n"] += 1
+            if call_count["n"] == 2:
+                raise BudgetError("too big", _report(500))
+            return kwargs["prompt"], _report()
+
+        monkeypatch.setattr(lora_generate, "fit_raw_prompt", _fake_fit_raw_prompt)
+
+        ai_card = {"data": {"name": "Ann", "description": "x", "personality": "y"}}
+        user_card = {"data": {"name": "Bea", "description": "z"}}
+        scenarios = await lora_generate.generate_scenarios(
+            ollama, "m", ai_card, user_card, num_per_category=3
+        )
+        # 8 categories * 3 scenarios each = 24, minus 3 from skipped = 21
+        assert len(scenarios) == 21
+
+
+class TestGenerateUserMessageBudgetError:
+    @pytest.mark.asyncio
+    async def test_returns_empty_on_budget_error(self, monkeypatch):
+        """BudgetError in generate_user_message returns '' so the existing
+        'empty message' branch in generate_conversation stops the turn."""
+        ollama = AsyncMock()
+
+        async def _fake_fit(**kwargs):
+            raise BudgetError("too big", _report(500))
+
+        monkeypatch.setattr(lora_generate, "fit_raw_prompt", _fake_fit)
+
+        context = {
+            "char_name": "Ann", "user_name": "Bea",
+            "user_personality": "p", "scenario": "s", "history": [],
+        }
+        result = await lora_generate.generate_user_message(ollama, "m", context)
+        assert result == ""


### PR DESCRIPTION
## Summary

- **New `budget.py` module** with 5-priority shrink pipeline (strategy drop → summary drop → mes_example truncation → BudgetError) and ground-truth token verification via Ollama
- **Runtime budgeting**: `fit_prompt` wired into all 4 chat endpoints (send, regenerate, continue, auto-reply) with 413 error streaming on overflow
- **lora_generate budgeting**: `fit_raw_prompt` for single-shot prompts, skips category on BudgetError
- **`get_num_ctx` from `/api/show`**: cached per-model context window lookup, Protocol-based DI for testability
- **`num_ctx` passed explicitly** in Ollama options after budgeting, replacing implicit model defaults
- **Ground-truth counting**: `/api/chat` for message-based prompts, `/api/generate` for raw prompts (different templates produce different token counts)
- **Deleted `apply_context_strategy`** from pipeline — all call sites now use `fit_prompt`

## Files changed

| File | What |
|------|------|
| `projects/rp/budget.py` | Core budgeting module (new) |
| `projects/rp/routes.py` | `_budget_ctx` helper + 4 call sites |
| `projects/rp/lora_generate.py` | `fit_raw_prompt` integration |
| `projects/rp/pipeline.py` | Removed dead `apply_context_strategy` |
| `projects/aiserver/ollama.py` | `get_num_ctx` + `count_generate_prompt` |
| `projects/rp/tests/test_budget.py` | 30+ tests for fit_prompt/fit_raw_prompt |
| `projects/rp/tests/test_lora_generate_budget.py` | Budget skip/error tests |
| `projects/rp/tests/conftest.py` | StubOllama with protocol methods |

## Migration notes

- `max_context_tokens` setting is now deprecated — budgeting reads `num_ctx` from Ollama's model config via `/api/show`
- Context strategy selection moved from pipeline pre-hook to `_budget_ctx` in routes

## Test plan

- [ ] `pytest projects/rp/tests/ projects/aiserver/tests/` — 210 tests pass
- [ ] Manual: start aiserver, send message with small model, verify `_budget_report` in debug prompt
- [ ] Manual: send very long message that exceeds context, verify 413 error response

🤖 Generated with [Claude Code](https://claude.com/claude-code)