### PR TITLE
fix(ollama): don't use architectural context_length as num_ctx

### DIFF
--- a/projects/aiserver/ollama.py
+++ b/projects/aiserver/ollama.py
@@ -285,13 +285,18 @@ class OllamaClient:
             pass
         return []
 
+    _OLLAMA_DEFAULT_CTX = 2048
+
     async def get_num_ctx(self, model: str) -> int:
         """Return effective context length for a model via /api/show.
 
-        Prefers the runtime-loaded num_ctx from the parameters field (a
-        whitespace-formatted string). Falls back to any <arch>.context_length
-        entry in model_info (the architectural max from the GGUF file).
-        Raises OllamaError if neither is present or the request fails.
+        Prefers the runtime num_ctx from the parameters field (what Ollama
+        actually allocates). Falls back to Ollama's built-in default (2048).
+
+        Does NOT use model_info.<arch>.context_length — that is the
+        architectural maximum from the GGUF file (often 1M+), not the
+        runtime allocation. Passing it as num_ctx would force Ollama to
+        allocate an enormous KV cache.
         """
         try:
             async with httpx.AsyncClient(timeout=10.0) as client:
@@ -308,7 +313,6 @@ class OllamaClient:
         except httpx.HTTPError as e:
             raise OllamaError(f"HTTP error from /api/show: {e}") from e
 
-        # Parse parameters for "num_ctx <value>"
         params_str = data.get("parameters", "") or ""
         for line in params_str.splitlines():
             parts = line.split()
@@ -318,16 +322,7 @@ class OllamaClient:
                 except ValueError:
                     pass
 
-        # Fall back to model_info[<arch>.context_length]
-        model_info = data.get("model_info", {}) or {}
-        for key, value in model_info.items():
-            if key.endswith(".context_length") and isinstance(value, int):
-                return value
-
-        raise OllamaError(
-            f"Could not determine context length for model {model!r}: "
-            f"no num_ctx in parameters and no <arch>.context_length in model_info"
-        )
+        return self._OLLAMA_DEFAULT_CTX
 
     async def embed(self, model: str, text: str) -> list[float]:
         """Get embedding vector for text via Ollama /api/embed."""

--- a/projects/aiserver/tests/test_ollama_chat.py
+++ b/projects/aiserver/tests/test_ollama_chat.py
@@ -140,41 +140,28 @@ class TestGetNumCtx:
         assert result == 32768
 
     @pytest.mark.asyncio
-    async def test_falls_back_to_model_info_context_length(self):
+    async def test_no_num_ctx_returns_ollama_default(self):
+        """Models without explicit num_ctx get Ollama's default (2048)."""
         client = OllamaClient("http://localhost:11434")
         show_response = {
             "parameters": "temperature                    0.8",
-            "model_info": {"llama.context_length": 8192},
+            "model_info": {"llama.context_length": 1024000},
         }
         with patch("httpx.AsyncClient.post") as mock_post:
             mock_post.return_value.status_code = 200
             mock_post.return_value.json = lambda: show_response
             result = await client.get_num_ctx("mymodel")
-        assert result == 8192
+        assert result == 2048
 
     @pytest.mark.asyncio
-    async def test_tries_any_arch_context_length(self):
-        """model_info keys look like <arch>.context_length — e.g. qwen2.context_length."""
+    async def test_no_parameters_returns_ollama_default(self):
         client = OllamaClient("http://localhost:11434")
-        show_response = {
-            "parameters": "",
-            "model_info": {"qwen2.context_length": 4096, "general.architecture": "qwen2"},
-        }
+        show_response = {"parameters": "", "model_info": {}}
         with patch("httpx.AsyncClient.post") as mock_post:
             mock_post.return_value.status_code = 200
             mock_post.return_value.json = lambda: show_response
             result = await client.get_num_ctx("mymodel")
-        assert result == 4096
-
-    @pytest.mark.asyncio
-    async def test_raises_when_neither_present(self):
-        client = OllamaClient("http://localhost:11434")
-        show_response = {"parameters": "temperature 0.8", "model_info": {}}
-        with patch("httpx.AsyncClient.post") as mock_post:
-            mock_post.return_value.status_code = 200
-            mock_post.return_value.json = lambda: show_response
-            with pytest.raises(OllamaError, match="context length"):
-                await client.get_num_ctx("mymodel")
+        assert result == 2048
 
     @pytest.mark.asyncio
     async def test_raises_on_show_http_error(self):


### PR DESCRIPTION
## Summary

- `get_num_ctx` was falling back to `model_info.<arch>.context_length` (the GGUF architectural max, e.g. 1M) when a model had no explicit `num_ctx` in its parameters
- This caused the budget code to pass `num_ctx: 1024000` to Ollama, which hung trying to allocate the KV cache
- Now falls back to Ollama's built-in default (2048) instead

## Test plan

- [ ] `pytest projects/aiserver/tests/ projects/rp/tests/` — 209 pass
- [ ] Start server, send message with `nchapman/mn-12b-mag-mell-r1` — should respond instead of hanging

🤖 Generated with [Claude Code](https://claude.com/claude-code)