### PR TITLE
fix(ollama): cap auto-detected context length at 16384

### DIFF
--- a/projects/aiserver/ollama.py
+++ b/projects/aiserver/ollama.py
@@ -285,18 +285,15 @@ class OllamaClient:
             pass
         return []
 
-    _OLLAMA_DEFAULT_CTX = 2048
+    _MAX_AUTO_CTX = 16384
 
     async def get_num_ctx(self, model: str) -> int:
         """Return effective context length for a model via /api/show.
 
         Prefers the runtime num_ctx from the parameters field (what Ollama
-        actually allocates). Falls back to Ollama's built-in default (2048).
-
-        Does NOT use model_info.<arch>.context_length — that is the
-        architectural maximum from the GGUF file (often 1M+), not the
-        runtime allocation. Passing it as num_ctx would force Ollama to
-        allocate an enormous KV cache.
+        actually allocates). Falls back to model_info.<arch>.context_length
+        capped at _MAX_AUTO_CTX to avoid allocating enormous KV caches for
+        models that report large architectural maximums (e.g. 1M).
         """
         try:
             async with httpx.AsyncClient(timeout=10.0) as client:
@@ -322,7 +319,12 @@ class OllamaClient:
                 except ValueError:
                     pass
 
-        return self._OLLAMA_DEFAULT_CTX
+        model_info = data.get("model_info", {}) or {}
+        for key, value in model_info.items():
+            if key.endswith(".context_length") and isinstance(value, int):
+                return min(value, self._MAX_AUTO_CTX)
+
+        return self._MAX_AUTO_CTX
 
     async def embed(self, model: str, text: str) -> list[float]:
         """Get embedding vector for text via Ollama /api/embed."""

--- a/projects/aiserver/tests/test_ollama_chat.py
+++ b/projects/aiserver/tests/test_ollama_chat.py
@@ -140,8 +140,8 @@ class TestGetNumCtx:
         assert result == 32768
 
     @pytest.mark.asyncio
-    async def test_no_num_ctx_returns_ollama_default(self):
-        """Models without explicit num_ctx get Ollama's default (2048)."""
+    async def test_caps_large_context_length(self):
+        """Architectural max (1M) gets capped to _MAX_AUTO_CTX."""
         client = OllamaClient("http://localhost:11434")
         show_response = {
             "parameters": "temperature                    0.8",
@@ -151,17 +151,45 @@ class TestGetNumCtx:
             mock_post.return_value.status_code = 200
             mock_post.return_value.json = lambda: show_response
             result = await client.get_num_ctx("mymodel")
-        assert result == 2048
+        assert result == 16384
 
     @pytest.mark.asyncio
-    async def test_no_parameters_returns_ollama_default(self):
+    async def test_uses_context_length_when_small(self):
+        """context_length below cap is used as-is."""
+        client = OllamaClient("http://localhost:11434")
+        show_response = {
+            "parameters": "",
+            "model_info": {"qwen2.context_length": 4096},
+        }
+        with patch("httpx.AsyncClient.post") as mock_post:
+            mock_post.return_value.status_code = 200
+            mock_post.return_value.json = lambda: show_response
+            result = await client.get_num_ctx("mymodel")
+        assert result == 4096
+
+    @pytest.mark.asyncio
+    async def test_no_context_info_returns_cap(self):
         client = OllamaClient("http://localhost:11434")
         show_response = {"parameters": "", "model_info": {}}
         with patch("httpx.AsyncClient.post") as mock_post:
             mock_post.return_value.status_code = 200
             mock_post.return_value.json = lambda: show_response
             result = await client.get_num_ctx("mymodel")
-        assert result == 2048
+        assert result == 16384
+
+    @pytest.mark.asyncio
+    async def test_explicit_num_ctx_not_capped(self):
+        """Explicit num_ctx in parameters is never capped."""
+        client = OllamaClient("http://localhost:11434")
+        show_response = {
+            "parameters": "num_ctx                        32768",
+            "model_info": {},
+        }
+        with patch("httpx.AsyncClient.post") as mock_post:
+            mock_post.return_value.status_code = 200
+            mock_post.return_value.json = lambda: show_response
+            result = await client.get_num_ctx("mymodel")
+        assert result == 32768
 
     @pytest.mark.asyncio
     async def test_raises_on_show_http_error(self):


### PR DESCRIPTION
## Summary

- Models without explicit `num_ctx` in parameters were getting either the architectural max (1M, hanging Ollama) or the bare default (2048, too small for a conversation)
- Now uses `model_info.context_length` capped at 16384 — large enough for conversations, safe for VRAM
- Explicit `num_ctx` in model parameters is still used uncapped

## Test plan

- [ ] `pytest projects/aiserver/tests/ projects/rp/tests/` — 211 pass
- [ ] Start server, send message in convo 87 (`mn-12b-mag-mell-r1`) — should respond normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)