### PR TITLE
fix(ollama): lower context cap to 8192

### DIFF
--- a/projects/aiserver/ollama.py
+++ b/projects/aiserver/ollama.py
@@ -285,7 +285,7 @@ class OllamaClient:
             pass
         return []
 
-    _MAX_AUTO_CTX = 16384
+    _MAX_AUTO_CTX = 8192
 
     async def get_num_ctx(self, model: str) -> int:
         """Return effective context length for a model via /api/show.

--- a/projects/aiserver/tests/test_ollama_chat.py
+++ b/projects/aiserver/tests/test_ollama_chat.py
@@ -151,7 +151,7 @@ class TestGetNumCtx:
             mock_post.return_value.status_code = 200
             mock_post.return_value.json = lambda: show_response
             result = await client.get_num_ctx("mymodel")
-        assert result == 16384
+        assert result == 8192
 
     @pytest.mark.asyncio
     async def test_uses_context_length_when_small(self):
@@ -175,7 +175,7 @@ class TestGetNumCtx:
             mock_post.return_value.status_code = 200
             mock_post.return_value.json = lambda: show_response
             result = await client.get_num_ctx("mymodel")
-        assert result == 16384
+        assert result == 8192
 
     @pytest.mark.asyncio
     async def test_explicit_num_ctx_not_capped(self):


### PR DESCRIPTION
## Summary

- 16384 exceeds VRAM for 13B Q4 models, causing Ollama to hang on KV cache allocation
- Lowered `_MAX_AUTO_CTX` from 16384 to 8192

## Test plan

- [ ] 211 tests pass
- [ ] Send message in convo 87 — should respond within ~10s

🤖 Generated with [Claude Code](https://claude.com/claude-code)