### PR TITLE
fix(joon): use BOTTOM_OF_PIPE for post-dispatch barrier

### DIFF
--- a/projects/joon/gui/app.cpp
+++ b/projects/joon/gui/app.cpp
@@ -5,6 +5,7 @@
 
 void App::init() {
     ctx = joon::Context::create();
+    ctx->device().log_fn = joon_log::write;
 
     dsl_source = R"(; Joon - edit this code
 (def base (noise :scale 4.0 :octaves 3))

--- a/projects/joon/src/nodes/gpu_dispatch.cpp
+++ b/projects/joon/src/nodes/gpu_dispatch.cpp
@@ -78,9 +78,9 @@ void gpu_dispatch(EvalContext& ctx,
     post_barrier.image = images.back()->image;
     post_barrier.subresourceRange = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1 };
     post_barrier.srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT;
-    post_barrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+    post_barrier.dstAccessMask = VK_ACCESS_MEMORY_READ_BIT;
     vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
-                         VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
+                         VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
                          0, 0, nullptr, 0, nullptr, 1, &post_barrier);
 
     ctx.device.end_single_command(cmd);

--- a/projects/joon/src/vulkan/device.cpp
+++ b/projects/joon/src/vulkan/device.cpp
@@ -1,9 +1,26 @@
 #define VMA_IMPLEMENTATION
 #include "vulkan/device.h"
+#include <cstdio>
 #include <stdexcept>
 #include <vector>
 
 namespace joon {
+
+static VKAPI_ATTR VkBool32 VKAPI_CALL debugCallback(
+    VkDebugUtilsMessageSeverityFlagBitsEXT severity,
+    VkDebugUtilsMessageTypeFlagsEXT,
+    const VkDebugUtilsMessengerCallbackDataEXT* data,
+    void* user_data) {
+    auto* dev = static_cast<Device*>(user_data);
+    const char* level = "INFO";
+    if (severity & VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT) level = "ERROR";
+    else if (severity & VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT) level = "WARN";
+    if (dev->log_fn)
+        dev->log_fn("[VK %s] %s\n", level, data->pMessage);
+    else
+        std::fprintf(stderr, "[VK %s] %s\n", level, data->pMessage);
+    return VK_FALSE;
+}
 
 std::unique_ptr<Device> Device::create(bool enable_validation) {
     auto dev = std::make_unique<Device>();
@@ -30,21 +47,39 @@ std::unique_ptr<Device> Device::create(bool enable_validation) {
 #endif
     };
 
+    std::vector<const char*> layers;
+    if (enable_validation) {
+        layers.push_back("VK_LAYER_KHRONOS_validation");
+        instance_extensions.push_back(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
+    }
+
     VkInstanceCreateInfo create_info{};
     create_info.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
     create_info.pApplicationInfo = &app_info;
     create_info.enabledExtensionCount = static_cast<uint32_t>(instance_extensions.size());
     create_info.ppEnabledExtensionNames = instance_extensions.data();
-
-    std::vector<const char*> layers;
-    if (enable_validation) {
-        layers.push_back("VK_LAYER_KHRONOS_validation");
-    }
     create_info.enabledLayerCount = static_cast<uint32_t>(layers.size());
     create_info.ppEnabledLayerNames = layers.data();
 
     if (vkCreateInstance(&create_info, nullptr, &dev->instance) != VK_SUCCESS) {
         throw std::runtime_error("Failed to create Vulkan instance");
+    }
+
+    if (enable_validation) {
+        VkDebugUtilsMessengerCreateInfoEXT dbg_info{};
+        dbg_info.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT;
+        dbg_info.messageSeverity = VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT |
+                                   VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT;
+        dbg_info.messageType = VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT |
+                               VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT |
+                               VK_DEBUG_UTILS_MESSAGE_TYPE_PERFORMANCE_BIT_EXT;
+        dbg_info.pfnUserCallback = debugCallback;
+        dbg_info.pUserData = dev.get();
+
+        auto createFn = reinterpret_cast<PFN_vkCreateDebugUtilsMessengerEXT>(
+            vkGetInstanceProcAddr(dev->instance, "vkCreateDebugUtilsMessengerEXT"));
+        if (createFn)
+            createFn(dev->instance, &dbg_info, nullptr, &dev->debug_messenger);
     }
 
     // Physical device — prefer discrete GPU
@@ -146,6 +181,11 @@ Device::~Device() {
     if (allocator) vmaDestroyAllocator(allocator);
     if (command_pool) vkDestroyCommandPool(device, command_pool, nullptr);
     if (device) vkDestroyDevice(device, nullptr);
+    if (debug_messenger) {
+        auto destroyFn = reinterpret_cast<PFN_vkDestroyDebugUtilsMessengerEXT>(
+            vkGetInstanceProcAddr(instance, "vkDestroyDebugUtilsMessengerEXT"));
+        if (destroyFn) destroyFn(instance, debug_messenger, nullptr);
+    }
     if (instance) vkDestroyInstance(instance, nullptr);
 }
 

--- a/projects/joon/src/vulkan/device.h
+++ b/projects/joon/src/vulkan/device.h
@@ -6,6 +6,8 @@
 
 namespace joon {
 
+using LogFn = void(*)(const char* fmt, ...);
+
 struct Device {
     VkInstance instance = VK_NULL_HANDLE;
     VkPhysicalDevice physical_device = VK_NULL_HANDLE;
@@ -16,6 +18,8 @@ struct Device {
     uint32_t graphics_family = UINT32_MAX;
     VkCommandPool command_pool = VK_NULL_HANDLE;
     VmaAllocator allocator = VK_NULL_HANDLE;
+    VkDebugUtilsMessengerEXT debug_messenger = VK_NULL_HANDLE;
+    LogFn log_fn = nullptr;
 
     Device() = default;
     ~Device();


### PR DESCRIPTION
## Summary
- Fixes validation error on dedicated compute queues: `FRAGMENT_SHADER_BIT` is not supported on compute-only queue families
- Uses `BOTTOM_OF_PIPE_BIT` + `MEMORY_READ_BIT` instead, which is universally supported and pairs with `vkQueueWaitIdle` for cross-queue visibility

## Test plan
```bash
# Build and run the GUI
# - Drag slider — no validation errors in log
# - Viewport updates in real time
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)