### PR TITLE
fix(rp): correct aiserver import path in lora_generate

### DIFF
--- a/projects/rp/lora_generate.py
+++ b/projects/rp/lora_generate.py
@@ -460,7 +460,7 @@ class OllamaClient:
                 )
             except Exception:
                 ollama_url = "http://localhost:11434"
-        from aiserver.ollama import OllamaClient as _BudgetOllamaClient
+        from projects.aiserver.ollama import OllamaClient as _BudgetOllamaClient
         self._budget = _BudgetOllamaClient(ollama_url)
 
     async def get_num_ctx(self, model: str) -> int:


### PR DESCRIPTION
## Summary
- `lora_generate.py` imported `from aiserver.ollama` but the script runs with `PYTHONPATH=/mnt/d/prg/plum`, so the correct import is `from projects.aiserver.ollama`

## Test plan
```bash
cd /mnt/d/prg/plum-fix-lora-import
pytest projects/rp/tests/    # 189 passed
PYTHONPATH="/mnt/d/prg/plum-fix-lora-import" python -c "from projects.aiserver.ollama import OllamaClient"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)