### PR TITLE
fix(aiserver): increase tokenization timeout for large models

### DIFF
--- a/projects/aiserver/ollama.py
+++ b/projects/aiserver/ollama.py
@@ -194,7 +194,7 @@ class OllamaClient:
         if system:
             body["system"] = system
         try:
-            async with httpx.AsyncClient(timeout=120.0) as client:
+            async with httpx.AsyncClient(timeout=300.0) as client:
                 resp = await client.post(f"{self.base_url}/api/generate", json=body)
                 if resp.status_code != 200:
                     raise OllamaError(f"Ollama returned {resp.status_code}: {resp.text}")


### PR DESCRIPTION
## Summary
- Bumps `count_generate_prompt` timeout from 120s to 300s — the non-streaming tokenization call must wait for full model load + prompt processing, which exceeds 120s for 70B models on cold start

## Test plan
```bash
pytest projects/aiserver/tests/   # 22 passed
# Manual: run lora_generate with 70B model after Ollama keep-alive expires
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)