### PR TITLE
fix(joon): resolve symbol kwargs at eval time for param propagation

### DIFF
--- a/projects/joon/gui/app.cpp
+++ b/projects/joon/gui/app.cpp
@@ -43,6 +43,8 @@ void App::shutdown() {
 
 void App::bind_viewport() {
     if (!eval || graph.has_errors() || graph.ir().outputs.empty()) {
+        joon_log::write("[BIND] skip: eval=%p errors=%d outputs=%zu\n",
+                        eval.get(), graph.has_errors(), graph.ir().outputs.size());
         if (viewport_desc) {
             ImGui_ImplVulkan_RemoveTexture(viewport_desc);
             viewport_desc = VK_NULL_HANDLE;
@@ -52,6 +54,8 @@ void App::bind_viewport() {
 
     auto result = eval->result("");
     auto* view = static_cast<VkImageView>(result.vk_image_view());
+    joon_log::write("[BIND] view=%p sampler=%p w=%u h=%u\n",
+                    view, sampler, result.width(), result.height());
     if (!view || !sampler) return;
 
     if (viewport_desc) {
@@ -59,6 +63,7 @@ void App::bind_viewport() {
         ImGui_ImplVulkan_RemoveTexture(viewport_desc);
     }
     viewport_desc = ImGui_ImplVulkan_AddTexture(sampler, view, VK_IMAGE_LAYOUT_GENERAL);
+    joon_log::write("[BIND] new descriptor=%p\n", viewport_desc);
 }
 
 void App::reparse() {

--- a/projects/joon/gui/panel_properties.cpp
+++ b/projects/joon/gui/panel_properties.cpp
@@ -1,4 +1,5 @@
 #include "app.h"
+#include "log.h"
 #include <imgui.h>
 
 void App::draw_properties() {
@@ -21,6 +22,7 @@ void App::draw_properties() {
                 param = val;
                 eval->evaluate();
                 viewport_dirty = true;
+                joon_log::write("[SLIDER] %s = %.3f\n", p.name.c_str(), val);
             }
         }
     } else {

--- a/projects/joon/src/interpreter/interpreter.cpp
+++ b/projects/joon/src/interpreter/interpreter.cpp
@@ -30,6 +30,11 @@ void Interpreter::evaluate(IRGraph& graph) {
             continue;
         }
 
+        for (auto& kw : node.kwargs) {
+            if (kw.source_node != UINT32_MAX && kw.source_node < graph.nodes.size())
+                kw.value = graph.nodes[kw.source_node].constant_value;
+        }
+
         auto* executor = m_registry.find(node.op);
         if (executor) {
             (*executor)(node, m_ctx);

--- a/projects/joon/src/ir/ir_graph.cpp
+++ b/projects/joon/src/ir/ir_graph.cpp
@@ -116,10 +116,14 @@ uint32_t IRGraph::resolve_expr(const AstNode& expr) {
             } else if (auto* kstr = std::get_if<StringNode>(&kw.value->data)) {
                 nodes[id].string_arg = kstr->value;
             } else if (auto* ksym = std::get_if<SymbolNode>(&kw.value->data)) {
-                // Keyword value is a symbol reference (e.g., :mode multiply)
-                // Store as string for now — node implementations interpret it
-                nodes[id].kwargs.push_back({ kw.name, 0.0f });
-                nodes[id].string_arg = ksym->name; // overloaded, but works for single-kwarg case
+                auto sym_it = m_nameToNode.find(ksym->name);
+                if (sym_it != m_nameToNode.end()) {
+                    auto& src = nodes[sym_it->second];
+                    nodes[id].kwargs.push_back({ kw.name, src.constant_value, sym_it->second });
+                } else {
+                    nodes[id].kwargs.push_back({ kw.name, 0.0f });
+                    nodes[id].string_arg = ksym->name;
+                }
             }
         }
 

--- a/projects/joon/src/ir/node.h
+++ b/projects/joon/src/ir/node.h
@@ -19,6 +19,7 @@ struct Edge {
 struct ResolvedKwarg {
     std::string name;
     Value value;
+    uint32_t source_node = UINT32_MAX;
 };
 
 struct Node {

--- a/projects/joon/tests/test_evaluator.cpp
+++ b/projects/joon/tests/test_evaluator.cpp
@@ -40,3 +40,68 @@ TEST_CASE("Evaluator runs a constant-output graph", "[evaluator][gpu]") {
         CHECK(std::abs(pixels[i + 3] - 1.0f) < 1e-5f);
     }
 }
+
+TEST_CASE("Param change produces different output after re-evaluate", "[evaluator][gpu]") {
+    auto ctx = Context::create();
+    auto graph = ctx->parse_string(R"(
+        (def base (noise :scale 4.0 :octaves 3))
+        (param contrast float 1.0 :min 0.0 :max 3.0)
+        (def result (levels base :contrast contrast))
+        (output result)
+    )");
+    REQUIRE_FALSE(graph.has_errors());
+
+    auto eval = ctx->create_evaluator(graph);
+    eval->evaluate();
+
+    auto r0 = eval->result("");
+    REQUIRE(r0.width() > 0);
+    auto pixels_before = r0.read_pixels();
+
+    auto param = eval->param<float>("contrast");
+    param = 0.0f;
+    eval->evaluate();
+
+    auto pixels_after = eval->result("").read_pixels();
+    REQUIRE(pixels_before.size() == pixels_after.size());
+
+    double diff = 0.0;
+    for (size_t i = 0; i < pixels_before.size(); i++)
+        diff += std::abs(pixels_before[i] - pixels_after[i]);
+    diff /= static_cast<double>(pixels_before.size());
+
+    CHECK(diff > 0.01);
+}
+
+TEST_CASE("Param kwarg updates propagate through levels node", "[evaluator][gpu]") {
+    auto ctx = Context::create();
+    auto graph = ctx->parse_string(R"(
+        (param val float 0.5 :min 0.0 :max 1.0)
+        (def result (levels val :contrast 1.0))
+        (output result)
+    )");
+    REQUIRE_FALSE(graph.has_errors());
+
+    auto eval = ctx->create_evaluator(graph);
+
+    float values[] = { 0.0f, 0.25f, 0.5f, 0.75f, 1.0f };
+    std::vector<float> prev_pixels;
+
+    for (float v : values) {
+        auto param = eval->param<float>("val");
+        param = v;
+        eval->evaluate();
+
+        auto pixels = eval->result("").read_pixels();
+        REQUIRE(pixels.size() > 0);
+
+        if (!prev_pixels.empty()) {
+            double diff = 0.0;
+            for (size_t i = 0; i < pixels.size(); i++)
+                diff += std::abs(pixels[i] - prev_pixels[i]);
+            diff /= static_cast<double>(pixels.size());
+            CHECK(diff > 0.001);
+        }
+        prev_pixels = pixels;
+    }
+}


### PR DESCRIPTION
## Summary

- Symbol kwargs like `:contrast contrast` were baked to `0.0f` at parse time with no back-reference to the param node — changing the slider had no effect on the viewport
- Added `source_node` field to `ResolvedKwarg` so symbol references link back to their source node
- Interpreter now re-reads `graph.nodes[source_node].constant_value` before dispatching each node
- Added two new evaluator tests covering param re-evaluation through the levels node pipeline
- Added debug logging to slider handler and bind_viewport

## Test plan

```bash
cd /mnt/d/prg/plum-joon-viewport-debug/projects/joon
premake5 vs2022
# Build and run tests in Visual Studio (Debug config)
# - "Param change produces different output after re-evaluate" should pass
# - "Param kwarg updates propagate through levels node" should pass
# Build and run joon-gui
# - Drag the contrast slider — viewport should update in real time
# - Check joon-gui.log for [SLIDER] and [BIND] messages confirming the pipeline
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)