### PR TITLE
fix(aiserver): bump tokenization timeout to 600s

### DIFF
--- a/projects/aiserver/ollama.py
+++ b/projects/aiserver/ollama.py
@@ -194,7 +194,7 @@ class OllamaClient:
         if system:
             body["system"] = system
         try:
-            async with httpx.AsyncClient(timeout=300.0) as client:
+            async with httpx.AsyncClient(timeout=600.0) as client:
                 resp = await client.post(f"{self.base_url}/api/generate", json=body)
                 if resp.status_code != 200:
                     raise OllamaError(f"Ollama returned {resp.status_code}: {resp.text}")


### PR DESCRIPTION
## Summary
- Increases `count_generate_prompt` httpx timeout from 300s to 600s
- Long chat histories sent for tokenization on 70B CPU-offloaded models exceed 300s

## Test plan
```bash
pytest projects/aiserver/tests/   # 22 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)