### PR TITLE
feat(rp): add category column to conversations

### DIFF
--- a/projects/rp/db.py
+++ b/projects/rp/db.py
@@ -188,7 +188,7 @@ async def list_conversations() -> list[dict]:
     pool = await get_pool()
     rows = await pool.fetch(
         "SELECT c.id, c.user_card_id, c.ai_card_id, c.scenario_id, c.model, "
-        "c.created_at::text, c.updated_at::text, "
+        "c.category, c.created_at::text, c.updated_at::text, "
         "uc.name as user_name, ac.name as ai_name "
         "FROM rp_conversations c "
         "JOIN rp_character_cards uc ON c.user_card_id = uc.id "
@@ -199,13 +199,14 @@ async def list_conversations() -> list[dict]:
 
 
 async def create_conversation(user_card_id: int, ai_card_id: int,
-                               scenario_id: int | None, model: str) -> dict:
+                               scenario_id: int | None, model: str,
+                               category: str = "user") -> dict:
     pool = await get_pool()
     row = await pool.fetchrow(
-        "INSERT INTO rp_conversations (user_card_id, ai_card_id, scenario_id, model) "
-        "VALUES ($1, $2, $3, $4) RETURNING id, user_card_id, ai_card_id, scenario_id, "
-        "model, scene_state, scene_state_msg_id, created_at::text, updated_at::text",
-        user_card_id, ai_card_id, scenario_id, model,
+        "INSERT INTO rp_conversations (user_card_id, ai_card_id, scenario_id, model, category) "
+        "VALUES ($1, $2, $3, $4, $5) RETURNING id, user_card_id, ai_card_id, scenario_id, "
+        "model, category, scene_state, scene_state_msg_id, created_at::text, updated_at::text",
+        user_card_id, ai_card_id, scenario_id, model, category,
     )
     return dict(row)
 
@@ -213,7 +214,7 @@ async def create_conversation(user_card_id: int, ai_card_id: int,
 async def get_conversation(conv_id: int) -> dict | None:
     pool = await get_pool()
     row = await pool.fetchrow(
-        "SELECT id, user_card_id, ai_card_id, scenario_id, model, scene_state, scene_state_msg_id, "
+        "SELECT id, user_card_id, ai_card_id, scenario_id, model, category, scene_state, scene_state_msg_id, "
         "created_at::text, updated_at::text FROM rp_conversations WHERE id = $1",
         conv_id,
     )

--- a/projects/rp/lora_generate.py
+++ b/projects/rp/lora_generate.py
@@ -585,6 +585,7 @@ async def main():
                     ai_card_id=ai_card_id,
                     scenario_id=None,
                     model=args.model,
+                    category="lora",
                 )
                 system_prompt = result["conversations"][0]["value"]
                 for msg in result["conversations"][1:]:

--- a/projects/rp/models.py
+++ b/projects/rp/models.py
@@ -46,6 +46,7 @@ class ConversationResponse(BaseModel):
     scenario_id: int | None
     model: str
     scene_state: str = ""
+    category: str = "user"
     created_at: str
     updated_at: str
 

--- a/projects/rp/schema.sql
+++ b/projects/rp/schema.sql
@@ -53,6 +53,12 @@ DO $$ BEGIN
 EXCEPTION WHEN duplicate_column THEN NULL;
 END $$;
 
+-- Migration: add category (user vs lora-generated)
+DO $$ BEGIN
+    ALTER TABLE rp_conversations ADD COLUMN category TEXT NOT NULL DEFAULT 'user';
+EXCEPTION WHEN duplicate_column THEN NULL;
+END $$;
+
 CREATE TABLE IF NOT EXISTS rp_messages (
     id              SERIAL PRIMARY KEY,
     conversation_id INTEGER NOT NULL REFERENCES rp_conversations(id) ON DELETE CASCADE,


### PR DESCRIPTION
## Summary

- Adds `category` column to `rp_conversations` (default `'user'`, lora-generated convos get `'lora'`)
- Schema migration, db.py CRUD, models.py response, lora_generate.py all updated
- 211 tests pass

## Backfill

After merging, run against the DB to tag existing lora conversations:

```sql
UPDATE rp_conversations SET category = 'lora' WHERE id IN (83, 92, 93, 94, 95);
```

## Test plan

- [x] `pytest projects/rp/tests/` — 211 passed
- [ ] Start aiserver, create a conversation via UI — verify `category = 'user'`
- [ ] Run `lora_generate.py` — verify new convos get `category = 'lora'`
- [ ] Run backfill SQL for existing lora convos

🤖 Generated with [Claude Code](https://claude.com/claude-code)