### PR TITLE
feat(rp): add /rp-report skill + persist budget per message

### DIFF
--- a/.claude/skills/rp-report/SKILL.md
+++ b/.claude/skills/rp-report/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: rp-report
+description: Generate a detailed quality report for an RP conversation by ID
+---
+
+# RP Report
+
+Generate a comprehensive quality report for a roleplay conversation.
+
+## Arguments
+
+Takes a conversation ID as the argument (e.g., `/rp-report 89`).
+
+## Instructions
+
+### 1. Fetch conversation data
+
+Run these SQL queries via `bash -c 'set -a && source /mnt/d/prg/plum/.env && set +a && psql "$DATABASE_URL" ...'`:
+
+**Metadata:**
+```sql
+SELECT c.id, c.model, c.scene_state, c.category,
+       u.name as user_name, a.name as ai_name,
+       s.name as scenario_name, s.description as scenario_desc,
+       s.first_message
+FROM rp_conversations c
+JOIN rp_character_cards u ON c.user_card_id = u.id
+JOIN rp_character_cards a ON c.ai_card_id = a.id
+LEFT JOIN rp_scenarios s ON c.scenario_id = s.id
+WHERE c.id = <ID>
+```
+
+**Messages (with pipeline context):**
+```sql
+SELECT id, role, content, sequence, system_prompt, scene_state, post_prompt, budget_json,
+       created_at::text
+FROM rp_messages WHERE conversation_id = <ID> ORDER BY sequence
+```
+
+**Stats:**
+```sql
+SELECT COUNT(*) as total,
+  COUNT(*) FILTER (WHERE role = 'user') as user_msgs,
+  COUNT(*) FILTER (WHERE role = 'assistant') as ai_msgs,
+  SUM(length(content)) as total_chars,
+  SUM(length(content)) FILTER (WHERE role = 'user') as user_chars,
+  SUM(length(content)) FILTER (WHERE role = 'assistant') as ai_chars,
+  MIN(created_at)::date as started,
+  MAX(created_at)::date as ended
+FROM rp_messages WHERE conversation_id = <ID>
+```
+
+### 2. Part 1 — Conversation transcript
+
+Print each message in this format:
+
+```
+### [seq] [role] (msg ID: [id])
+[content]
+```
+
+Use `user` and `assistant` labels. Include the full content, untruncated.
+
+### 3. Part 2 — Quality analysis
+
+Write a detailed analysis covering:
+
+- **Header**: Characters, scenario, model, dates, message counts, char counts, user:AI ratio
+- **Arc structure**: Identify 2-4 acts with message ranges and brief descriptions
+- **Strengths**: What works well (character voice, pacing, emotional beats, user-AI dynamic)
+- **Recurring problems**: Table format with issue, example message numbers, severity (high/moderate/low). Look for:
+  - Repetitive physical tics or gestures
+  - Stock phrases recycled across messages
+  - Permission-asking loops ("you sure?", "this okay?")
+  - Overused adverbs or filler words ("absently", "hyperaware")
+  - Scene coherence errors (contradicting established facts)
+  - Voice collapse (character losing their distinctive voice)
+  - Emotional shortcuts (feelings resolving too fast)
+- **Voice consistency**: Does the AI character maintain a distinct voice throughout? Where does it degrade?
+- **NSFW quality** (if applicable): Does writing quality drop in intimate scenes?
+- **Emotional depth score**: Rate each act on a 1-10 scale with brief notes
+- **Key takeaways**: 3-5 bullet points summarizing what to improve
+
+**Important**: Valentina is always the user's character. Never evaluate Valentina's writing quality — she is the human player.
+
+### 4. Part 3 — Per-message prompt replay
+
+For each **assistant** message, print the prompt context that was used to generate it:
+
+```
+---
+### Message [seq] (ID: [id]) — Prompt Context
+
+**System prompt** ([char count] chars):
+> [first 500 chars of system_prompt, or "(not stored)" if NULL]
+
+**Post prompt** ([char count] chars):
+> [first 500 chars of post_prompt, or "(not stored)" if NULL]
+
+**Scene state**:
+> [scene_state content, or "(not stored)" if NULL]
+
+**Budget**:
+[If budget_json is stored, show: model_ctx, response_reserve, available, overhead,
+ messages_budget, messages_kept/dropped, estimator_tokens, actual_tokens, warnings]
+[If not stored, show "(not stored — conversation predates budget tracking)"]
+
+**Messages in context window**: [messages_kept] of [total messages at this point]
+**Messages dropped**: [messages_dropped]
+
+**AI response** ([char count] chars, [word count] words):
+> [first 200 chars]...
+---
+```
+
+For user messages, just show:
+```
+---
+### Message [seq] (ID: [id]) — User input
+> [first 200 chars]...
+---
+```
+
+### Notes
+
+- If the output is very long, it's OK to split across multiple response messages
+- Use the stored pipeline data (system_prompt, scene_state, post_prompt, budget_json) when available
+- For older conversations without stored data, note "(not stored)" and skip reconstruction
+- The report is for the user's analysis — be honest about quality issues, don't sugarcoat

--- a/projects/rp/db.py
+++ b/projects/rp/db.py
@@ -252,6 +252,7 @@ async def get_messages(conv_id: int) -> list[dict]:
     pool = await get_pool()
     rows = await pool.fetch(
         "SELECT id, conversation_id, role, content, raw_response, sequence, "
+        "system_prompt, scene_state, post_prompt, budget_json, "
         "created_at::text FROM rp_messages WHERE conversation_id = $1 ORDER BY sequence",
         conv_id,
     )
@@ -262,16 +263,17 @@ async def add_message(conv_id: int, role: str, content: str,
                       raw_response: dict | None = None,
                       system_prompt: str | None = None,
                       scene_state: str | None = None,
-                      post_prompt: str | None = None) -> dict:
+                      post_prompt: str | None = None,
+                      budget_json: dict | None = None) -> dict:
     pool = await get_pool()
     row = await pool.fetchrow(
         "INSERT INTO rp_messages (conversation_id, role, content, raw_response, "
-        "system_prompt, scene_state, post_prompt, sequence) "
-        "VALUES ($1, $2, $3, $4, $5, $6, $7, "
+        "system_prompt, scene_state, post_prompt, budget_json, sequence) "
+        "VALUES ($1, $2, $3, $4, $5, $6, $7, $8, "
         "(SELECT COALESCE(MAX(sequence), 0) + 1 FROM rp_messages WHERE conversation_id = $1)) "
         "RETURNING id, conversation_id, role, content, "
-        "raw_response, sequence, system_prompt, scene_state, post_prompt, created_at::text",
-        conv_id, role, content, raw_response, system_prompt, scene_state, post_prompt,
+        "raw_response, sequence, system_prompt, scene_state, post_prompt, budget_json, created_at::text",
+        conv_id, role, content, raw_response, system_prompt, scene_state, post_prompt, budget_json,
     )
     await pool.execute(
         "UPDATE rp_conversations SET updated_at = NOW() WHERE id = $1", conv_id

--- a/projects/rp/routes.py
+++ b/projects/rp/routes.py
@@ -14,7 +14,8 @@ from .models import (
     MessageResponse, SendMessageRequest, EditMessageRequest, SceneStateRequest,
 )
 from .pipeline import create_default_pipeline
-from .budget import fit_prompt, BudgetError
+from dataclasses import asdict
+from .budget import fit_prompt, BudgetError, BudgetReport
 from .context import get_strategy
 from .mcp_client import get_router as get_mcp_router
 from .research import research_dispatch
@@ -32,6 +33,13 @@ _log = logging.getLogger(__name__)
 _ollama = None
 _pipeline = None
 _resolve_model = None
+
+
+def _budget_to_json(ctx: dict) -> dict | None:
+    report = ctx.get("_budget_report")
+    if not isinstance(report, BudgetReport):
+        return None
+    return asdict(report)
 
 
 async def init_mcp():
@@ -847,6 +855,7 @@ def setup(app: FastAPI, ollama, resolve_model=None):
                     system_prompt=ctx.get("system_prompt", ""),
                     scene_state=conv.get("scene_state", ""),
                     post_prompt=ctx.get("post_prompt", ""),
+                    budget_json=_budget_to_json(ctx),
                 )
                 conv_log.log_response(conv_id, "assistant", post_ctx["response"], raw)
                 # Update scene state and maybe generate summary in background
@@ -957,6 +966,7 @@ def setup(app: FastAPI, ollama, resolve_model=None):
                     system_prompt=ctx.get("system_prompt", ""),
                     scene_state=conv.get("scene_state", ""),
                     post_prompt=ctx.get("post_prompt", ""),
+                    budget_json=_budget_to_json(ctx),
                 )
                 conv_log.log_response(conv_id, "assistant", post_ctx["response"], raw)
                 # Update scene state and maybe generate summary in background
@@ -1037,6 +1047,7 @@ def setup(app: FastAPI, ollama, resolve_model=None):
                     system_prompt=ctx.get("system_prompt", ""),
                     scene_state=conv.get("scene_state", ""),
                     post_prompt=ctx.get("post_prompt", ""),
+                    budget_json=_budget_to_json(ctx),
                 )
                 conv_log.log_response(conv_id, "assistant", post_ctx["response"], raw)
                 # Update scene state and maybe generate summary in background
@@ -1166,6 +1177,7 @@ def setup(app: FastAPI, ollama, resolve_model=None):
                     system_prompt=ctx.get("system_prompt", ""),
                     scene_state=conv.get("scene_state", ""),
                     post_prompt=ctx.get("post_prompt", ""),
+                    budget_json=_budget_to_json(ctx),
                 )
                 conv_log.log_response(conv_id, save_role, post_ctx["response"], raw)
                 # Update scene state and maybe generate summary in background

--- a/projects/rp/schema.sql
+++ b/projects/rp/schema.sql
@@ -81,6 +81,12 @@ DO $$ BEGIN
 EXCEPTION WHEN duplicate_column THEN NULL;
 END $$;
 
+-- Migration: add budget report JSON to rp_messages
+DO $$ BEGIN
+    ALTER TABLE rp_messages ADD COLUMN budget_json JSONB DEFAULT NULL;
+EXCEPTION WHEN duplicate_column THEN NULL;
+END $$;
+
 CREATE TABLE IF NOT EXISTS rp_first_message_cache (
     id              SERIAL PRIMARY KEY,
     combo_hash      TEXT NOT NULL UNIQUE,


### PR DESCRIPTION
## Summary

- Adds `/rp-report <id>` slash command that generates a 3-part quality report: transcript, analysis, and per-message prompt replay
- Adds `budget_json` JSONB column to `rp_messages` to store the BudgetReport alongside each assistant message
- `get_messages` now returns all pipeline context columns (system_prompt, scene_state, post_prompt, budget_json)
- All 4 assistant-message save paths in routes.py now persist the budget report

## Test plan

```bash
cd /mnt/d/prg/plum-rp-report
source /mnt/d/prg/plum/projects/aiserver/.venv/bin/activate
PYTHONPATH=/mnt/d/prg/plum-rp-report pytest projects/rp/tests/ -x -q
# 211 passed

# After merge — run the DB migration by restarting aiserver, then:
# 1. Send a message in any conversation
# 2. Check that budget_json is populated:
#    psql "$DATABASE_URL" -c "SELECT id, budget_json FROM rp_messages WHERE budget_json IS NOT NULL ORDER BY id DESC LIMIT 1"
# 3. Test the skill: /rp-report 89
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)