### PR TITLE
docs: add agent debugging rules to reduce friction

### DIFF
--- a/.claude/rules/aiserver.md
+++ b/.claude/rules/aiserver.md
@@ -38,6 +38,14 @@ pytest tests/             # Unit tests (mocked)
 - `GET /stats` — Request stats (hourly, throughput, active streams)
 - `WS /ws/dashboard` — Real-time stats events
 
+## Debugging
+
+- **Log file:** redirect output with `python main.py 2>&1 | tee /tmp/aiserver.log` — read `/tmp/aiserver.log` instead of asking the user to paste errors
+- **Healthcheck:** `bash status.sh` or `curl http://127.0.0.1:8080/health` — always run this before assuming the server is working
+- **Ollama connectivity:** Ollama runs on Windows, accessed via WSL gateway. If `/health` returns but generation fails silently, check Ollama is reachable: `curl http://$(cat /etc/resolv.conf | grep nameserver | awk '{print $2}'):11434/api/tags`
+- **DB connectivity:** verify with `psql "$DATABASE_URL" -c "SELECT 1"` before debugging auth/connection errors in application code
+- **Silent failure pattern:** if a request returns empty with no error, the most common causes are: (1) Ollama unreachable, (2) prompt exceeds model context, (3) empty response swallowed by streaming code. Check in that order.
+
 ## Conventions
 
 - Model aliasing: short names (e.g. "q8") resolved via config to full Ollama model names

--- a/.claude/rules/joon.md
+++ b/.claude/rules/joon.md
@@ -1,0 +1,21 @@
+---
+paths:
+  - "projects/joon/**"
+---
+
+# Joon — Graphics DSL & Compute Framework
+
+See `projects/joon/CLAUDE.md` for build instructions, coding standards, and project structure.
+
+## Debugging
+
+- **Log file:** runtime output goes to `log.txt` in the working directory. Always read this file before asking the user about errors or behavior.
+- **Validation errors:** Vulkan validation messages route through `joon_log`. If you don't see expected errors, check that validation layers are enabled and logging is not filtered.
+- **Viewport not updating:** the most common cause is the eval→dispatch→present pipeline not being fully triggered. Before patching, trace the full path: parameter change → dirty flag → re-eval → descriptor rebind → dispatch → barrier → present. Identify which step is broken.
+- **Cross-queue sync:** compute and graphics may use different queue families. Barriers must match the queue ownership. Read the existing barrier code before adding new ones.
+
+## Fix Discipline
+
+- **No incremental guessing on rendering bugs.** The viewport/pipeline has multiple stages that must all agree. A fix that changes one barrier or one rebind without understanding the full flow will likely shift the bug rather than fix it.
+- **Write a CLI test** (`tests/`) that asserts the output actually changed before claiming a visual bug is fixed. Pixel diff or value comparison, not just "it compiles."
+- **Shader changes:** after modifying or adding shaders, verify they compile by running premake + build. Don't assume HLSL compiles just because GLSL did.

--- a/.claude/rules/rp.md
+++ b/.claude/rules/rp.md
@@ -38,6 +38,13 @@ pytest projects/rp/tests/
 - `schema.sql` — 5 tables: cards, scenarios, conversations, messages, first_message_cache
 - `DESIGN.md` — Architecture & API reference (read before major changes)
 
+## Debugging
+
+- **Runs as an aiserver plugin** — see aiserver rules for server startup and healthcheck
+- **DB schema:** auto-created by `init_schema()` on startup. If tables are missing, restart the server
+- **Empty generation:** if `/rp/conversations/{id}/messages` returns no AI response, check in order: (1) aiserver healthcheck, (2) Ollama model loaded, (3) prompt fits context window (check `budget_json` in the message row)
+- **Prompt budget:** each message stores `budget_json` — read it from DB to diagnose context overflow: `psql "$DATABASE_URL" -c "SELECT budget_json FROM rp_messages WHERE conversation_id=X ORDER BY id DESC LIMIT 1"`
+
 ## Conventions
 
 - Async/await throughout — all DB and HTTP calls are async

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,13 @@ Monorepo: sysadmin scripts (Windows/WSL2 + Linux VPS), side projects. Bash and P
 - Design specs and implementation plans live on the **feature branch**, never duplicated on main
 - Pre-commit hook runs project tests for any modified project — fix failures before committing
 
+## Debugging Rules (Non-Negotiable)
+
+- **Read logs before asking the user.** If a log file exists (log.txt, /tmp/*.log, console output redirected to file), read it yourself. Never ask the user to "check the output" when you can read the file.
+- **Verify before claiming success.** After applying a fix, run the test plan or read program output to confirm it actually works. "It should work now" without verification is not acceptable.
+- **Two-strike rule for fixes.** If the same symptom persists after 2 fix attempts, STOP patching. Instead: (1) trace the full execution path by reading the code, (2) write down what you expected vs what you observed vs what you tried, (3) only then propose a fix with a root-cause explanation.
+- **Never swallow empty responses.** When calling external services (Ollama, DB, HTTP APIs), always check for empty/null/missing responses and raise an error with context. "No error" is not "success" — verify positive output exists.
+
 ## Research
 
 - Add a reference to all statements, with links at the bottom. Also add a date


### PR DESCRIPTION
## Summary

- Add global debugging rules to CLAUDE.md (read logs first, verify before claiming success, two-strike fix rule, never swallow empty responses)
- Add debugging sections to `.claude/rules/aiserver.md` and `.claude/rules/rp.md` with triage checklists
- Create `.claude/rules/joon.md` with rendering pipeline fix discipline

Motivated by a 14-day agent audit: 17/175 prompts (10%) were friction from the agent not self-diagnosing, applying fix-on-fix patches, or asking the user to relay log output it could read itself.

## Test plan

- [ ] Start a new Claude Code session in the plum repo, verify CLAUDE.md debugging rules appear in context
- [ ] Touch a file in `projects/joon/` and verify joon.md rules load
- [ ] Touch a file in `projects/aiserver/` and verify debugging section loads
- [ ] Touch a file in `projects/rp/` and verify debugging section loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)