### PR TITLE
feat(rp): prompt storage, A/B compare, SummaryBuffer

### DIFF
--- a/.claude/skills/rp-report/SKILL.md
+++ b/.claude/skills/rp-report/SKILL.md
@@ -36,7 +36,7 @@ WHERE c.id = <ID>
 
 **Messages (with pipeline context):**
 ```sql
-SELECT id, role, content, sequence, system_prompt, scene_state, post_prompt, budget_json,
+SELECT id, role, content, sequence, system_prompt, scene_state, post_prompt, budget_json, prompt_json,
        created_at::text
 FROM rp_messages WHERE conversation_id = <ID> ORDER BY sequence
 ```
@@ -89,33 +89,38 @@ Write a detailed analysis covering:
 
 ### 4. Part 3 — Per-message prompt replay
 
-For each **assistant** message, print the prompt context that was used to generate it:
+For each **assistant** message, print the full raw prompt that was sent to the model.
+
+If `prompt_json` is stored (non-NULL), print it as the complete assembled prompt — this is the exact messages array sent to Ollama. Format each entry in the array:
 
 ```
 ---
-### Message [seq] (ID: [id]) — Prompt Context
-
-**System prompt** ([char count] chars):
-> [first 500 chars of system_prompt, or "(not stored)" if NULL]
-
-**Post prompt** ([char count] chars):
-> [first 500 chars of post_prompt, or "(not stored)" if NULL]
-
-**Scene state**:
-> [scene_state content, or "(not stored)" if NULL]
+### Message [seq] (ID: [id]) — Full Prompt
 
 **Budget**:
 [If budget_json is stored, show: model_ctx, response_reserve, available, overhead,
  messages_budget, messages_kept/dropped, estimator_tokens, actual_tokens, warnings]
-[If not stored, show "(not stored — conversation predates budget tracking)"]
+[If not stored, show "(not stored)"]
 
-**Messages in context window**: [messages_kept] of [total messages at this point]
-**Messages dropped**: [messages_dropped]
+**Assembled prompt** ([N] messages):
+
+**[1] role: system** ([char count] chars):
+> [full content]
+
+**[2] role: user** ([char count] chars):
+> [full content]
+
+**[3] role: assistant** ([char count] chars):
+> [full content]
+
+[...continue for all messages in the prompt_json array...]
 
 **AI response** ([char count] chars, [word count] words):
 > [first 200 chars]...
 ---
 ```
+
+If `prompt_json` is NULL, fall back to showing system_prompt, post_prompt, and scene_state separately (as stored), with a note "(prompt_json not stored — conversation predates full prompt tracking)".
 
 For user messages, just show:
 ```
@@ -128,6 +133,6 @@ For user messages, just show:
 ### Notes
 
 - If the output is very long, it's OK to split across multiple response messages
-- Use the stored pipeline data (system_prompt, scene_state, post_prompt, budget_json) when available
-- For older conversations without stored data, note "(not stored)" and skip reconstruction
+- Use prompt_json as the authoritative source when available — it contains the exact payload sent to the model
+- For older conversations without prompt_json, fall back to the individual stored fields (system_prompt, scene_state, post_prompt, budget_json)
 - The report is for the user's analysis — be honest about quality issues, don't sugarcoat

--- a/projects/rp/context.py
+++ b/projects/rp/context.py
@@ -99,6 +99,6 @@ STRATEGIES = {
 }
 
 
-def get_strategy(name: str = "sliding_window") -> ContextStrategy:
-    cls = STRATEGIES.get(name, SlidingWindow)
+def get_strategy(name: str = "summary_buffer") -> ContextStrategy:
+    cls = STRATEGIES.get(name, SummaryBuffer)
     return cls()

--- a/projects/rp/db.py
+++ b/projects/rp/db.py
@@ -577,6 +577,19 @@ async def get_latest_summary(conv_id: int) -> dict | None:
     return dict(row) if row else None
 
 
+async def list_summaries(conv_id: int) -> list[dict]:
+    pool = await get_pool()
+    rows = await pool.fetch(
+        "SELECT id, conversation_id, summary, through_msg_id, through_sequence, "
+        "msg_count, token_estimate, created_at::text "
+        "FROM rp_conversation_summaries "
+        "WHERE conversation_id = $1 "
+        "ORDER BY through_sequence ASC",
+        conv_id,
+    )
+    return [dict(r) for r in rows]
+
+
 async def get_latest_metrics(
     target_type: str, target_id: str, domain: str,
     pool: "asyncpg.Pool | None" = None,

--- a/projects/rp/db.py
+++ b/projects/rp/db.py
@@ -298,6 +298,79 @@ async def delete_message(msg_id: int) -> bool:
     return result == "DELETE 1"
 
 
+# -- Eval Compare --
+
+async def create_eval_set(conv_id: int, sequence: int) -> dict:
+    pool = await get_pool()
+    row = await pool.fetchrow(
+        "INSERT INTO rp_eval_sets (conversation_id, sequence) "
+        "VALUES ($1, $2) RETURNING *",
+        conv_id, sequence,
+    )
+    return dict(row)
+
+
+async def add_eval_candidate(eval_set_id: int, label: str, model: str,
+                             config: dict, prompt_json: list | None = None,
+                             budget_json: dict | None = None,
+                             content: str = "",
+                             raw_response: dict | None = None) -> dict:
+    pool = await get_pool()
+    row = await pool.fetchrow(
+        "INSERT INTO rp_eval_candidates "
+        "(eval_set_id, label, model, config, prompt_json, budget_json, content, raw_response) "
+        "VALUES ($1, $2, $3, $4, $5, $6, $7, $8) RETURNING *",
+        eval_set_id, label, model, config, prompt_json, budget_json, content, raw_response,
+    )
+    return dict(row)
+
+
+async def update_eval_candidate(candidate_id: int, content: str,
+                                raw_response: dict | None = None,
+                                prompt_json: list | None = None,
+                                budget_json: dict | None = None) -> dict:
+    pool = await get_pool()
+    row = await pool.fetchrow(
+        "UPDATE rp_eval_candidates SET content = $2, raw_response = $3, "
+        "prompt_json = $4, budget_json = $5 WHERE id = $1 RETURNING *",
+        candidate_id, content, raw_response, prompt_json, budget_json,
+    )
+    return dict(row)
+
+
+async def select_eval_candidate(eval_set_id: int, candidate_id: int) -> dict:
+    pool = await get_pool()
+    row = await pool.fetchrow(
+        "UPDATE rp_eval_sets SET selected_id = $2 WHERE id = $1 RETURNING *",
+        eval_set_id, candidate_id,
+    )
+    return dict(row)
+
+
+async def get_eval_set(eval_set_id: int) -> dict | None:
+    pool = await get_pool()
+    row = await pool.fetchrow("SELECT * FROM rp_eval_sets WHERE id = $1", eval_set_id)
+    return dict(row) if row else None
+
+
+async def get_eval_candidates(eval_set_id: int) -> list[dict]:
+    pool = await get_pool()
+    rows = await pool.fetch(
+        "SELECT * FROM rp_eval_candidates WHERE eval_set_id = $1 ORDER BY id",
+        eval_set_id,
+    )
+    return [dict(r) for r in rows]
+
+
+async def get_eval_sets_for_conversation(conv_id: int) -> list[dict]:
+    pool = await get_pool()
+    rows = await pool.fetch(
+        "SELECT * FROM rp_eval_sets WHERE conversation_id = $1 ORDER BY sequence",
+        conv_id,
+    )
+    return [dict(r) for r in rows]
+
+
 # -- First Message Cache --
 
 def _hash_data(data) -> str:

--- a/projects/rp/db.py
+++ b/projects/rp/db.py
@@ -252,7 +252,7 @@ async def get_messages(conv_id: int) -> list[dict]:
     pool = await get_pool()
     rows = await pool.fetch(
         "SELECT id, conversation_id, role, content, raw_response, sequence, "
-        "system_prompt, scene_state, post_prompt, budget_json, "
+        "system_prompt, scene_state, post_prompt, budget_json, prompt_json, "
         "created_at::text FROM rp_messages WHERE conversation_id = $1 ORDER BY sequence",
         conv_id,
     )
@@ -264,16 +264,17 @@ async def add_message(conv_id: int, role: str, content: str,
                       system_prompt: str | None = None,
                       scene_state: str | None = None,
                       post_prompt: str | None = None,
-                      budget_json: dict | None = None) -> dict:
+                      budget_json: dict | None = None,
+                      prompt_json: list | None = None) -> dict:
     pool = await get_pool()
     row = await pool.fetchrow(
         "INSERT INTO rp_messages (conversation_id, role, content, raw_response, "
-        "system_prompt, scene_state, post_prompt, budget_json, sequence) "
-        "VALUES ($1, $2, $3, $4, $5, $6, $7, $8, "
+        "system_prompt, scene_state, post_prompt, budget_json, prompt_json, sequence) "
+        "VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, "
         "(SELECT COALESCE(MAX(sequence), 0) + 1 FROM rp_messages WHERE conversation_id = $1)) "
         "RETURNING id, conversation_id, role, content, "
-        "raw_response, sequence, system_prompt, scene_state, post_prompt, budget_json, created_at::text",
-        conv_id, role, content, raw_response, system_prompt, scene_state, post_prompt, budget_json,
+        "raw_response, sequence, system_prompt, scene_state, post_prompt, budget_json, prompt_json, created_at::text",
+        conv_id, role, content, raw_response, system_prompt, scene_state, post_prompt, budget_json, prompt_json,
     )
     await pool.execute(
         "UPDATE rp_conversations SET updated_at = NOW() WHERE id = $1", conv_id

--- a/projects/rp/docs/improvements.md
+++ b/projects/rp/docs/improvements.md
@@ -57,19 +57,14 @@ gap with assumptions, causing scene coherence errors.
 - After the greeting, before the first kept message, inject a system message:
   `"[Messages 2-29 not shown. Key context: {scene_state}]"`
 - Reuse the already-computed scene state as the bridge content — it's the right shape.
-- This is "SummaryBuffer lite" without needing the full rolling summary infrastructure.
+- SlidingWindow is the only context strategy in use. SummaryBuffer exists in code but
+  is unused — don't build on it.
 
 ### Key files
 
 - `context.py` — `SlidingWindow.fit()` (line 12)
 - `scene_state.py` — already computes the data needed for the bridge
 - `routes.py` — `_build_pipeline_ctx()` sets up ctx with scene_state
-
-### Notes
-
-SummaryBuffer exists but isn't the default. Its summary threshold is 10 messages, so
-early conversations get no summary. The summary generation also uses the same 12B model
-at T=0.3 — a dedicated smaller model (like qwen3:8b used for research) would be better.
 
 ---
 

--- a/projects/rp/docs/improvements.md
+++ b/projects/rp/docs/improvements.md
@@ -1,0 +1,289 @@
+# RP Project — Improvement Plan
+
+Written 2026-04-23 after deep analysis of every module, the active prompt template,
+conv 97 report, and user quality/preference memories.
+
+---
+
+## 1. Post-prompt tiering
+
+**Priority: highest — biggest token savings, most quality improvement per effort**
+
+The post-prompt (`prompt.md ## post`) renders to ~1,142 tokens. On 8k context with
+1,024 response reserve, that's ~16% of total budget before the system prompt adds
+character descriptions. Conv 97: 36 of 86 messages dropped by the end. The model
+writes without seeing half the conversation.
+
+Many quality complaints (emotion arcs collapsing, stock phrases returning, voice
+degrading) are symptoms of the model literally forgetting what happened.
+
+### Plan
+
+- Split post-prompt into tiers:
+  - **Core** (every message): stay in character, don't write for `{{user}}`, correct
+    pronouns, physical constraints persist. ~300 tokens.
+  - **Style** (rotate 2-3 per turn): vary response length, ground in physical scene,
+    don't mirror, messy emotions, active participation. Selected based on scene state
+    or recent patterns.
+- Move banned-phrases list out of the prompt entirely (see #3).
+- Consider moving `mes_example` to dynamic fewshot injection instead of system prompt
+  — only inject when voice is drifting, saving tokens when it's not needed.
+
+### Key files
+
+- `pipeline.py` — `assemble_prompt()`, `DEFAULT_PROMPT_TEMPLATE`
+- `prompt.md` — active template
+- `budget.py` — overhead calculation treats post-prompt as immovable
+- `context.py` — strategies fit messages into whatever budget remains after overhead
+
+### Notes
+
+The budget system's 5-priority shrink cascade only shrinks messages and mes_example.
+The post-prompt is immovable overhead — correct architecturally, but means a fat
+post-prompt directly reduces message retention. Fix the post-prompt, not the budget.
+
+---
+
+## 2. SlidingWindow bridge message
+
+**Priority: high — low-effort, high-impact coherence fix**
+
+`SlidingWindow.fit()` drops oldest messages silently. Between the greeting (seq 1) and
+the next kept message (might be seq 30), there's a jarring gap. The model fills that
+gap with assumptions, causing scene coherence errors.
+
+### Plan
+
+- After the greeting, before the first kept message, inject a system message:
+  `"[Messages 2-29 not shown. Key context: {scene_state}]"`
+- Reuse the already-computed scene state as the bridge content — it's the right shape.
+- This is "SummaryBuffer lite" without needing the full rolling summary infrastructure.
+
+### Key files
+
+- `context.py` — `SlidingWindow.fit()` (line 12)
+- `scene_state.py` — already computes the data needed for the bridge
+- `routes.py` — `_build_pipeline_ctx()` sets up ctx with scene_state
+
+### Notes
+
+SummaryBuffer exists but isn't the default. Its summary threshold is 10 messages, so
+early conversations get no summary. The summary generation also uses the same 12B model
+at T=0.3 — a dedicated smaller model (like qwen3:8b used for research) would be better.
+
+---
+
+## 3. Stock phrase post-hook
+
+**Priority: high — mechanical fix for a frustrating recurring problem**
+
+The post-prompt bans specific phrases ("heart pounded", "breath caught", etc.) but
+conv 97 shows the model still uses them. Prompt-based bans are unreliable with 12B
+models — the instruction competes with the training distribution, and training wins.
+
+### Plan
+
+- Add a response post-hook in the pipeline that checks for stock phrases using
+  `lora_curate.STOCK_PHRASES` (already exists, 30+ phrases).
+- On detection, either:
+  - (a) Re-generate with explicit instruction: "Your response contained 'heart
+    pounded'. Rewrite, replacing that phrase with a character-specific physical detail."
+  - (b) Targeted edit via fast model call: "Replace 'her heart pounded' with a
+    character-specific physical reaction for [Amber]."
+- Track violations in response metadata (feeds into A/B compare analysis).
+- Remove the banned list from the post-prompt once the hook works — recovers ~200
+  tokens for conversation history.
+
+### Key files
+
+- `pipeline.py` — add post-hook after `clean_response`
+- `lora_curate.py` — `STOCK_PHRASES` list (line 7), `_count_stock_phrases()`
+- `prompt.md` — remove banned phrases section once hook is active
+
+---
+
+## 4. Dynamic response length
+
+**Priority: high — small change, noticeable quality improvement**
+
+Post-prompt says "Write 2-3 short paragraphs" but conv 97's first message was 509
+words. `num_predict` caps tokens but doesn't enforce structure. The model doesn't know
+what "short" means in this context.
+
+### Plan
+
+- Set `num_predict` dynamically based on user message length:
+  `num_predict = max(256, min(1024, user_msg_tokens * 2))`
+- Add a concrete word count to the post-prompt: "Write approximately 150-250 words"
+  instead of "2-3 short paragraphs." Adjust per turn.
+- This naturally varies response length to match the beat, which is what the prompt
+  asks for but doesn't enforce.
+
+### Key files
+
+- `routes.py` — `_budget_ctx()` where `num_predict` is set
+- `prompt.md` — replace vague length instruction with dynamic word count
+
+---
+
+## 5. Scene-state-driven prompt selection
+
+**Priority: medium — builds on #1 and #6**
+
+Scene state is computed and stored but only injected as flat text in the post-prompt.
+Not used for: validating response coherence, guiding which instructions to include,
+or fewshot retrieval.
+
+### Plan
+
+- Use scene state to select which tiered post-prompt instructions to include:
+  - `Restraints: wrists bound` → inject constraint persistence instruction
+  - `Mood: grieving` → inject "emotions don't reset" instruction
+  - `Voice: nonverbal` → inject sensory detail emphasis
+- Post-response scene state validation: compare response against scene state for
+  contradictions. Flag if character described as bound but freely gesturing.
+  Can be lightweight model call or regex for obvious violations.
+
+### Key files
+
+- `scene_state.py` — structured output with Location/Clothing/Restraints/Position/etc.
+- `pipeline.py` — post-prompt instruction selection logic
+- `routes.py` — wire scene state into prompt selection
+
+### Depends on
+
+- #1 (post-prompt tiering) — need tiered instructions before selecting among them
+- #6 (routes.py decomposition) — easier to implement with extracted prompt builder
+
+---
+
+## 6. routes.py decomposition
+
+**Priority: medium — enabler for everything else**
+
+routes.py is 1,363 lines handling CRUD, streaming, prompt assembly, scene state,
+research dispatch, fewshot injection, compare/eval, and auto-reply. Only file that
+knows how to wire the pipeline together.
+
+### Plan
+
+- Extract `_build_pipeline_ctx` + `_build_chat_messages` + `_budget_ctx` →
+  `prompt_builder.py`. Called from 4+ endpoints, don't need `_ollama`/`_pipeline`
+  globals — receive as parameters.
+- Extract streaming response generator → `streaming.py`. NDJSON protocol, chunked
+  token emission, done-chunk assembly.
+- Extract compare/eval endpoints → `eval_routes.py`. Self-contained feature with own
+  models and DB functions.
+
+No user-visible change. Unblocks testing prompt builder in isolation and adding
+endpoints without touching the main file.
+
+### Key files
+
+- `routes.py` — everything
+- New files: `prompt_builder.py`, `streaming.py`, `eval_routes.py`
+
+---
+
+## 7. Fewshot retrieval improvements
+
+**Priority: low — harder to measure impact**
+
+`fewshot.py` embeds `last_user + last_assistant` for vector similarity against stored
+examples. But mes_example examples are about voice and style, not topic. A bar scene
+might match a restaurant scene (similar topic) instead of a funeral scene that better
+demonstrates the character's deflection style.
+
+### Plan
+
+- Embed the assistant message only for retrieval (matching writing style, not topic).
+- Or embed a style descriptor: dialogue length, inner monologue ratio, sensory detail
+  density. Match on those rather than semantic similarity.
+- Weight recency: if last 3 messages show voice drift, increase fewshot injection.
+  If voice is strong, skip to save tokens.
+
+### Key files
+
+- `fewshot.py` — `get_fewshot_messages()`, embedding construction (line 31)
+- `db.py` — `search_fewshot_examples()`
+
+---
+
+## 8. A/B compare config defaults
+
+**Priority: low — refine the eval system**
+
+Current defaults are three temperature variants (0.6, 0.8, 1.0). Temperature affects
+randomness but doesn't test the quality dimensions that actually matter — voice
+consistency, stock phrase avoidance, response length, emotional depth.
+
+### Plan
+
+- Default configs should vary what's actually being evaluated:
+  - Config A: baseline (T=0.8, standard post-prompt)
+  - Config B: reduced post-prompt (core rules only, no style guidance) — tests
+    whether model's base behavior or instructions produce better writing
+  - Config C: higher response_reserve (512 vs 1024) — tests whether more history
+    but less response room improves coherence
+- Record structured preferences: tag selections with `voice_quality`, `length`,
+  `coherence`, `creativity` — makes preference data actionable for LoRA training.
+
+### Key files
+
+- `static/app.js` — `compareMessage()` default configs (currently T=0.6/0.8/1.0)
+- `models.py` — `CompareConfig`
+- `routes.py` — compare endpoint
+- `db.py` — eval CRUD
+
+---
+
+## 9. Quality auto-tagging and LoRA feedback loop
+
+**Priority: low — builds the long-term feedback loop**
+
+Live RP system and LoRA pipeline are separate worlds. A/B compare creates a bridge,
+but no automated feedback path from live quality observations to training decisions.
+
+### Plan
+
+- Auto-tag assistant messages with quality signals as a post-hook:
+  - Stock phrase count (reuse `lora_curate.STOCK_PHRASES`)
+  - Trigram overlap with recent messages (reuse `lora_curate._trigram_overlap`)
+  - Response/user length ratio
+  - Pronoun accuracy (check `${char_pronouns}` appear correctly)
+- Store in `quality_json JSONB` column on `rp_messages`.
+- Export A/B preferences as DPO training pairs: selected candidate = "preferred",
+  rejected = "dispreferred." Exactly what LoRA DPO training wants.
+- Run `lora_curate.filter_message()` on every live assistant response and store the
+  result. Builds a quality dashboard over time.
+
+### Key files
+
+- `lora_curate.py` — `filter_message()`, `STOCK_PHRASES`, `_trigram_overlap()`
+- `db.py` — new `quality_json` column on rp_messages
+- `schema.sql` — migration
+- `routes.py` — post-hook wiring
+- New file: `quality.py` — quality scoring logic
+
+---
+
+## 10. Pronoun enforcement post-hook
+
+**Priority: low — quick win but narrow scope**
+
+Conv 97 showed the model switching she/her → they/them despite explicit instructions.
+12B models default to they/them from training data, overwhelming the instruction.
+
+### Plan
+
+- Add a pronoun post-hook: check response for incorrect pronoun usage. If character's
+  pronouns are she/her and response uses "they" for the character (not genuinely
+  plural), rewrite. Simple regex pass — no model call needed.
+- Reinforce pronouns in assistant priming anchor. Currently `"{ai_name} "`. Change to
+  `"{ai_name} [she/her] "` — nudges first tokens toward correct pronouns, propagates.
+
+### Key files
+
+- `pipeline.py` — add post-hook
+- `budget.py` — `_render_for_count()` line 174, priming anchor
+- `routes.py` — `_build_chat_messages()` priming anchor construction

--- a/projects/rp/docs/improvements.md
+++ b/projects/rp/docs/improvements.md
@@ -48,23 +48,27 @@ post-prompt directly reduces message retention. Fix the post-prompt, not the bud
 
 **Priority: high — low-effort, high-impact coherence fix**
 
-`SlidingWindow.fit()` drops oldest messages silently. Between the greeting (seq 1) and
-the next kept message (might be seq 30), there's a jarring gap. The model fills that
-gap with assumptions, causing scene coherence errors.
+**Status: DONE** — SummaryBuffer is now fully wired up and active as the default
+context strategy. Uses dedicated lightweight model (q25), has API endpoints for
+viewing/triggering summaries, Summary tab in Under the Hood panel, and summary info
+in NDJSON debug chunks.
 
-### Plan
+`SlidingWindow.fit()` drops oldest messages silently. SummaryBuffer addresses this by
+injecting a rolling summary of dropped messages after the greeting, so the model has
+context about what happened before the window.
 
-- After the greeting, before the first kept message, inject a system message:
-  `"[Messages 2-29 not shown. Key context: {scene_state}]"`
-- Reuse the already-computed scene state as the bridge content — it's the right shape.
-- SlidingWindow is the only context strategy in use. SummaryBuffer exists in code but
-  is unused — don't build on it.
+### Remaining opportunity
+
+Even with SummaryBuffer active, a scene-state-based bridge message for conversations
+that haven't accumulated enough messages for a summary (< 10 messages) would help.
+The summary threshold means the first 10 messages get pure SlidingWindow behavior.
 
 ### Key files
 
-- `context.py` — `SlidingWindow.fit()` (line 12)
-- `scene_state.py` — already computes the data needed for the bridge
-- `routes.py` — `_build_pipeline_ctx()` sets up ctx with scene_state
+- `context.py` — `SummaryBuffer.fit()` — injects summary, filters covered messages
+- `summarize.py` — `maybe_generate_summary()` with dedicated model support
+- `routes.py` — endpoints: GET/POST summaries, debug chunk includes summary info
+- `static/app.js` — Summary tab in Under the Hood panel
 
 ---
 

--- a/projects/rp/models.py
+++ b/projects/rp/models.py
@@ -78,3 +78,20 @@ class EditMessageRequest(BaseModel):
 
 class SceneStateRequest(BaseModel):
     scene_state: str
+
+
+class CompareConfig(BaseModel):
+    label: str = ""
+    model: str | None = None
+    temperature: float | None = None
+    num_predict: int | None = None
+    response_reserve: int | None = None
+
+
+class CompareRequest(BaseModel):
+    content: str
+    configs: list[CompareConfig]
+
+
+class SelectCandidateRequest(BaseModel):
+    candidate_id: int

--- a/projects/rp/routes.py
+++ b/projects/rp/routes.py
@@ -1,4 +1,5 @@
 import asyncio
+import copy
 import json
 import logging
 from fastapi import FastAPI, UploadFile, File, HTTPException, Request
@@ -12,6 +13,7 @@ from .models import (
     CardCreate, CardResponse, ScenarioCreate, ScenarioResponse,
     ConversationCreate, ConversationResponse, ConversationDetailResponse,
     MessageResponse, SendMessageRequest, EditMessageRequest, SceneStateRequest,
+    CompareRequest, SelectCandidateRequest,
 )
 from .pipeline import create_default_pipeline
 from dataclasses import asdict
@@ -1193,6 +1195,167 @@ def setup(app: FastAPI, ollama, resolve_model=None):
                 yield json.dumps({"error": f"Failed to save response: {e}", "done": True}) + "\n"
 
         return StreamingResponse(stream(), media_type="application/x-ndjson")
+
+    # -- Compare (A/B eval) --
+
+    @app.post("/rp/conversations/{conv_id}/compare")
+    async def compare_message(conv_id: int, req: CompareRequest):
+        conv = await db.get_conversation(conv_id)
+        if not conv:
+            raise HTTPException(404, "Conversation not found")
+
+        await db.add_message(conv_id, "user", req.content)
+        conv_log.log_response(conv_id, "user", req.content)
+
+        messages = await db.get_messages(conv_id)
+        next_seq = max((m["sequence"] for m in messages), default=0) + 1
+
+        eval_set = await db.create_eval_set(conv_id, next_seq)
+
+        base_ctx = await _build_pipeline_ctx(conv, messages)
+        base_model = _resolve_model(conv["model"])
+        scenario = base_ctx.get("scenario") or {}
+        settings = scenario.get("settings", {})
+        base_ollama_options = _build_ollama_options(settings)
+
+        research = await research_dispatch(_ollama, req.content)
+        if research:
+            base_ctx["post_prompt"] = (
+                base_ctx.get("post_prompt", "")
+                + "\n\n[Research notes — weave these facts naturally if relevant, "
+                + "don't quote them verbatim or mention looking anything up]\n"
+                + research
+            )
+
+        fewshot_msgs = await get_fewshot_messages(
+            _ollama, base_ctx["messages"], card_id=conv["ai_card_id"],
+        )
+        if fewshot_msgs and base_ctx["messages"]:
+            base_ctx["messages"] = [base_ctx["messages"][0]] + fewshot_msgs + base_ctx["messages"][1:]
+
+        async def generate_candidate(cfg, candidate_row):
+            ctx = copy.deepcopy(base_ctx)
+            model = _resolve_model(cfg.model) if cfg.model else base_model
+            ollama_options = dict(base_ollama_options)
+            if cfg.temperature is not None:
+                ollama_options["temperature"] = cfg.temperature
+            if cfg.num_predict is not None:
+                ollama_options["num_predict"] = cfg.num_predict
+
+            try:
+                await _budget_ctx(ctx, model, ollama_options)
+            except BudgetError as e:
+                await db.update_eval_candidate(
+                    candidate_row["id"],
+                    content=f"[budget error: {e}]",
+                )
+                return
+
+            ollama_options = {**ollama_options, "num_ctx": ctx["_num_ctx"]}
+            chat_messages = _build_chat_messages(ctx)
+            user_name = _get_user_name(ctx)
+
+            tokens = []
+            raw = {}
+            try:
+                async for chunk in _ollama.chat_stream(
+                    model=model, messages=chat_messages,
+                    options=ollama_options, stop=[f"{user_name}:"],
+                ):
+                    if chunk.get("done"):
+                        raw = chunk
+                    elif not chunk.get("thinking"):
+                        tokens.append(chunk["token"])
+            except Exception as e:
+                await db.update_eval_candidate(
+                    candidate_row["id"],
+                    content=f"[generation error: {e}]",
+                )
+                return
+
+            response_text = "".join(tokens)
+            post_ctx = {"response": response_text, "ai_name": _get_ai_name(ctx)}
+            post_ctx = await _pipeline.run_post(post_ctx)
+            await db.update_eval_candidate(
+                candidate_row["id"],
+                content=post_ctx["response"],
+                raw_response=raw,
+                prompt_json=chat_messages,
+                budget_json=_budget_to_json(ctx),
+            )
+
+        # Create candidate rows first, then generate in parallel
+        tasks = []
+        for cfg in req.configs:
+            label = cfg.label or cfg.model or "default"
+            model_name = cfg.model or conv["model"]
+            config_dict = cfg.model_dump(exclude_none=True)
+            candidate_row = await db.add_eval_candidate(
+                eval_set["id"], label, model_name, config_dict,
+            )
+            tasks.append(generate_candidate(cfg, candidate_row))
+
+        await asyncio.gather(*tasks)
+
+        candidates = await db.get_eval_candidates(eval_set["id"])
+        return {
+            "eval_set_id": eval_set["id"],
+            "conversation_id": conv_id,
+            "sequence": next_seq,
+            "candidates": candidates,
+        }
+
+    @app.post("/rp/eval-sets/{eval_set_id}/select")
+    async def select_candidate(eval_set_id: int, req: SelectCandidateRequest):
+        eval_set = await db.get_eval_set(eval_set_id)
+        if not eval_set:
+            raise HTTPException(404, "Eval set not found")
+
+        candidates = await db.get_eval_candidates(eval_set_id)
+        winner = next((c for c in candidates if c["id"] == req.candidate_id), None)
+        if not winner:
+            raise HTTPException(404, "Candidate not found in this eval set")
+
+        conv_id = eval_set["conversation_id"]
+        conv = await db.get_conversation(conv_id)
+
+        await db.add_message(
+            conv_id, "assistant", winner["content"],
+            raw_response=winner.get("raw_response"),
+            system_prompt=None,
+            scene_state=conv.get("scene_state", ""),
+            post_prompt=None,
+            budget_json=winner.get("budget_json"),
+            prompt_json=winner.get("prompt_json"),
+        )
+        await db.select_eval_candidate(eval_set_id, req.candidate_id)
+
+        asyncio.create_task(_auto_update_scene_state(
+            conv_id, conv["model"],
+            _get_ai_name({"ai_card": await db.get_card(conv["ai_card_id"])}),
+            _get_user_name({"user_card": await db.get_card(conv["user_card_id"])}),
+            _get_ai_personality({"ai_card": await db.get_card(conv["ai_card_id"])}),
+        ))
+
+        return {
+            "ok": True,
+            "eval_set_id": eval_set_id,
+            "selected_candidate_id": req.candidate_id,
+            "content": winner["content"],
+        }
+
+    @app.get("/rp/eval-sets/{eval_set_id}")
+    async def get_eval_set_detail(eval_set_id: int):
+        eval_set = await db.get_eval_set(eval_set_id)
+        if not eval_set:
+            raise HTTPException(404, "Eval set not found")
+        candidates = await db.get_eval_candidates(eval_set_id)
+        return {"eval_set": eval_set, "candidates": candidates}
+
+    @app.get("/rp/conversations/{conv_id}/eval-sets")
+    async def list_eval_sets(conv_id: int):
+        sets = await db.get_eval_sets_for_conversation(conv_id)
+        return sets
 
     # -- Static files --
     static_dir = Path(__file__).parent / "static"

--- a/projects/rp/routes.py
+++ b/projects/rp/routes.py
@@ -856,6 +856,7 @@ def setup(app: FastAPI, ollama, resolve_model=None):
                     scene_state=conv.get("scene_state", ""),
                     post_prompt=ctx.get("post_prompt", ""),
                     budget_json=_budget_to_json(ctx),
+                    prompt_json=chat_messages,
                 )
                 conv_log.log_response(conv_id, "assistant", post_ctx["response"], raw)
                 # Update scene state and maybe generate summary in background
@@ -967,6 +968,7 @@ def setup(app: FastAPI, ollama, resolve_model=None):
                     scene_state=conv.get("scene_state", ""),
                     post_prompt=ctx.get("post_prompt", ""),
                     budget_json=_budget_to_json(ctx),
+                    prompt_json=chat_messages,
                 )
                 conv_log.log_response(conv_id, "assistant", post_ctx["response"], raw)
                 # Update scene state and maybe generate summary in background
@@ -1048,6 +1050,7 @@ def setup(app: FastAPI, ollama, resolve_model=None):
                     scene_state=conv.get("scene_state", ""),
                     post_prompt=ctx.get("post_prompt", ""),
                     budget_json=_budget_to_json(ctx),
+                    prompt_json=chat_messages,
                 )
                 conv_log.log_response(conv_id, "assistant", post_ctx["response"], raw)
                 # Update scene state and maybe generate summary in background
@@ -1178,6 +1181,7 @@ def setup(app: FastAPI, ollama, resolve_model=None):
                     scene_state=conv.get("scene_state", ""),
                     post_prompt=ctx.get("post_prompt", ""),
                     budget_json=_budget_to_json(ctx),
+                    prompt_json=chat_messages,
                 )
                 conv_log.log_response(conv_id, save_role, post_ctx["response"], raw)
                 # Update scene state and maybe generate summary in background

--- a/projects/rp/routes.py
+++ b/projects/rp/routes.py
@@ -423,6 +423,36 @@ def setup(app: FastAPI, ollama, resolve_model=None):
         conv_log.log_scene_state(conv_id, previous_state, clean)
         return {"scene_state": clean}
 
+    # -- Summaries --
+
+    @app.get("/rp/conversations/{conv_id}/summaries")
+    async def list_summaries(conv_id: int):
+        conv = await db.get_conversation(conv_id)
+        if not conv:
+            raise HTTPException(404, "Conversation not found")
+        return await db.list_summaries(conv_id)
+
+    @app.post("/rp/conversations/{conv_id}/summarize")
+    async def trigger_summary(conv_id: int):
+        conv = await db.get_conversation(conv_id)
+        if not conv:
+            raise HTTPException(404, "Conversation not found")
+        ai_card = await db.get_card(conv["ai_card_id"])
+        user_card = await db.get_card(conv["user_card_id"])
+        ai_data = ai_card.get("card_data", {}).get("data", ai_card.get("card_data", {}))
+        user_data = user_card.get("card_data", {}).get("data", user_card.get("card_data", {}))
+        model = _resolve_model(conv["model"])
+        result = await maybe_generate_summary(
+            conv_id, _ollama, model,
+            char_name=ai_data.get("name", "Character"),
+            user_name=user_data.get("name", "User"),
+            ai_personality=ai_data.get("description", ""),
+            resolve_model=_resolve_model,
+        )
+        if result is None:
+            return {"ok": False, "reason": "not enough unsummarized messages"}
+        return {"ok": True, "summary": result}
+
     # -- Chat --
 
     _chat_defaults = {"num_predict": 768, "temperature": 1.05, "repeat_penalty": 1.08, "min_p": 0.1}
@@ -508,6 +538,7 @@ def setup(app: FastAPI, ollama, resolve_model=None):
                 conv_id, _ollama, model,
                 char_name=ai_name, user_name=user_name,
                 ai_personality=ai_personality,
+                resolve_model=_resolve_model,
             )
         except Exception as e:
             _log.warning("Summary generation failed for conv %d: %s", conv_id, e)
@@ -796,11 +827,15 @@ def setup(app: FastAPI, ollama, resolve_model=None):
                             ctx["messages"], ollama_options)
 
         async def stream():
-            yield json.dumps({
+            debug = {
                 "debug_prompt": ctx["system_prompt"],
                 "debug_user_prompt": ctx.get("post_prompt", ""),
                 "debug_messages": ctx["messages"],
-            }) + "\n"
+            }
+            if ctx.get("_summary"):
+                debug["debug_summary"] = ctx["_summary"]
+                debug["debug_summary_through"] = ctx.get("_summary_through_sequence", 0)
+            yield json.dumps(debug) + "\n"
 
             cur_messages = list(chat_messages)
             max_tool_rounds = 3
@@ -939,11 +974,15 @@ def setup(app: FastAPI, ollama, resolve_model=None):
                             ctx["messages"], ollama_options)
 
         async def stream():
-            yield json.dumps({
+            debug = {
                 "debug_prompt": ctx["system_prompt"],
                 "debug_user_prompt": ctx.get("post_prompt", ""),
                 "debug_messages": ctx["messages"],
-            }) + "\n"
+            }
+            if ctx.get("_summary"):
+                debug["debug_summary"] = ctx["_summary"]
+                debug["debug_summary_through"] = ctx.get("_summary_through_sequence", 0)
+            yield json.dumps(debug) + "\n"
 
             tokens = []
             raw = {}
@@ -1021,11 +1060,15 @@ def setup(app: FastAPI, ollama, resolve_model=None):
                             ctx["messages"], ollama_options)
 
         async def stream():
-            yield json.dumps({
+            debug = {
                 "debug_prompt": ctx["system_prompt"],
                 "debug_user_prompt": ctx.get("post_prompt", ""),
                 "debug_messages": ctx["messages"],
-            }) + "\n"
+            }
+            if ctx.get("_summary"):
+                debug["debug_summary"] = ctx["_summary"]
+                debug["debug_summary_through"] = ctx.get("_summary_through_sequence", 0)
+            yield json.dumps(debug) + "\n"
 
             tokens = []
             raw = {}
@@ -1150,12 +1193,16 @@ def setup(app: FastAPI, ollama, resolve_model=None):
                             ctx["messages"], ollama_options)
 
         async def stream():
-            yield json.dumps({
+            debug = {
                 "debug_prompt": ctx["system_prompt"],
                 "debug_user_prompt": ctx.get("post_prompt", ""),
                 "debug_messages": ctx["messages"],
                 "auto_role": save_role,
-            }) + "\n"
+            }
+            if ctx.get("_summary"):
+                debug["debug_summary"] = ctx["_summary"]
+                debug["debug_summary_through"] = ctx.get("_summary_through_sequence", 0)
+            yield json.dumps(debug) + "\n"
 
             tokens = []
             raw = {}

--- a/projects/rp/routes.py
+++ b/projects/rp/routes.py
@@ -461,7 +461,7 @@ def setup(app: FastAPI, ollama, resolve_model=None):
         """Build ollama options from scenario settings with sensible defaults."""
         opts = dict(_chat_defaults)
         for k, v in settings.items():
-            if k not in ("context_strategy", "max_context_tokens", "model"):
+            if k not in ("max_context_tokens", "model"):
                 opts[k] = v
         return opts
 
@@ -506,14 +506,12 @@ def setup(app: FastAPI, ollama, resolve_model=None):
         return await _pipeline.run_pre(ctx)
 
     async def _budget_ctx(ctx, model, ollama_options):
-        """Run fit_prompt against ctx, using scenario-configured strategy.
+        """Run fit_prompt against ctx using SummaryBuffer strategy.
 
         On BudgetError, logs a WARNING and re-raises — callers handle the
         response (HTTP 413, stream error chunk, etc.).
         """
-        scenario = ctx.get("scenario") or {}
-        settings = scenario.get("settings", {})
-        strategy = get_strategy(settings.get("context_strategy", "summary_buffer"))
+        strategy = get_strategy("summary_buffer")
         num_predict = ollama_options.get("num_predict")
         try:
             return await fit_prompt(

--- a/projects/rp/schema.sql
+++ b/projects/rp/schema.sql
@@ -148,6 +148,33 @@ CREATE TABLE IF NOT EXISTS rp_conversation_summaries (
 CREATE INDEX IF NOT EXISTS idx_rp_summaries_conv
     ON rp_conversation_summaries(conversation_id, through_sequence DESC);
 
+-- Eval compare: A/B test multiple generation configs for the same prompt
+CREATE TABLE IF NOT EXISTS rp_eval_sets (
+    id              SERIAL PRIMARY KEY,
+    conversation_id INTEGER NOT NULL REFERENCES rp_conversations(id) ON DELETE CASCADE,
+    sequence        INTEGER NOT NULL,
+    selected_id     INTEGER DEFAULT NULL,
+    created_at      TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS rp_eval_candidates (
+    id              SERIAL PRIMARY KEY,
+    eval_set_id     INTEGER NOT NULL REFERENCES rp_eval_sets(id) ON DELETE CASCADE,
+    label           TEXT NOT NULL DEFAULT '',
+    model           TEXT NOT NULL,
+    config          JSONB NOT NULL DEFAULT '{}',
+    prompt_json     JSONB,
+    budget_json     JSONB,
+    content         TEXT NOT NULL DEFAULT '',
+    raw_response    JSONB,
+    created_at      TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_rp_eval_sets_conv
+    ON rp_eval_sets(conversation_id, sequence);
+CREATE INDEX IF NOT EXISTS idx_rp_eval_candidates_set
+    ON rp_eval_candidates(eval_set_id);
+
 -- Migration: track which message the summary was last generated from
 DO $$ BEGIN
     ALTER TABLE rp_conversations ADD COLUMN summary_msg_id INTEGER DEFAULT NULL;

--- a/projects/rp/schema.sql
+++ b/projects/rp/schema.sql
@@ -87,6 +87,12 @@ DO $$ BEGIN
 EXCEPTION WHEN duplicate_column THEN NULL;
 END $$;
 
+-- Migration: add full assembled prompt to rp_messages
+DO $$ BEGIN
+    ALTER TABLE rp_messages ADD COLUMN prompt_json JSONB DEFAULT NULL;
+EXCEPTION WHEN duplicate_column THEN NULL;
+END $$;
+
 CREATE TABLE IF NOT EXISTS rp_first_message_cache (
     id              SERIAL PRIMARY KEY,
     combo_hash      TEXT NOT NULL UNIQUE,

--- a/projects/rp/static/app.js
+++ b/projects/rp/static/app.js
@@ -370,6 +370,19 @@
     } else {
       $("underHoodContent").textContent = "No data yet.";
     }
+
+    // Load latest summary for the Summary tab
+    api("GET", "/rp/conversations/" + id + "/summaries").then(function (summaries) {
+      if (summaries && summaries.length > 0) {
+        var latest = summaries[summaries.length - 1];
+        $("underHoodSummaryContent").textContent =
+          "[Through seq " + latest.through_sequence + ", " +
+          latest.msg_count + " msgs, ~" + latest.token_estimate + " tokens]\n\n" +
+          latest.summary;
+      } else {
+        $("underHoodSummaryContent").textContent = "No summary yet.";
+      }
+    });
   }
 
   function appendMessageBubble(container, msg, userCard, aiCard, msgIndex) {
@@ -593,6 +606,12 @@
           if (chunk.debug_prompt !== undefined) {
             $("underHoodPromptContent").textContent = chunk.debug_prompt || "(empty)";
             $("underHoodUserPromptContent").textContent = chunk.debug_user_prompt || "(empty)";
+            if (chunk.debug_summary) {
+              $("underHoodSummaryContent").textContent =
+                "[Through seq " + chunk.debug_summary_through + "]\n\n" + chunk.debug_summary;
+            } else {
+              $("underHoodSummaryContent").textContent = "No summary active.";
+            }
             // Update bubble side if auto_role differs
             if (chunk.auto_role && chunk.auto_role !== streamRole) {
               streamRole = chunk.auto_role;

--- a/projects/rp/static/app.js
+++ b/projects/rp/static/app.js
@@ -1579,13 +1579,6 @@
     $("scenarioModel").insertBefore(defaultOpt, $("scenarioModel").firstChild);
     if (!s || !s.settings || !s.settings.model) defaultOpt.selected = true;
 
-    // Context strategy
-    if (s && s.settings && s.settings.context_strategy) {
-      $("scenarioContext").value = s.settings.context_strategy;
-    } else {
-      $("scenarioContext").value = "sliding_window";
-    }
-
     // Think toggle
     $("scenarioThink").checked = !!(s && s.settings && s.settings.think);
     updateThinkHint($("scenarioModel"));
@@ -1618,9 +1611,7 @@
     const name = $("scenarioName").value.trim();
     if (!name) { alert("Name is required."); return; }
 
-    const settings = {
-      context_strategy: $("scenarioContext").value,
-    };
+    const settings = {};
     if ($("scenarioThink").checked) settings.think = true;
     const modelOverride = $("scenarioModel").value;
     if (modelOverride) settings.model = modelOverride;

--- a/projects/rp/static/app.js
+++ b/projects/rp/static/app.js
@@ -722,6 +722,98 @@
 
   $("continueBtn").addEventListener("click", continueConversation);
   $("regenerateBtn").addEventListener("click", regenerateResponse);
+
+  // -- Compare (A/B eval) --
+  $("compareBtn").addEventListener("click", compareMessage);
+  $("compareClose").addEventListener("click", () => {
+    $("compareModal").style.display = "none";
+  });
+
+  async function compareMessage() {
+    const input = $("chatInput");
+    const content = input.value.trim();
+    if (!content || !currentConvId || isStreaming) return;
+
+    const configs = [
+      { label: "T=0.6", temperature: 0.6 },
+      { label: "T=0.8 (default)", temperature: 0.8 },
+      { label: "T=1.0", temperature: 1.0 },
+    ];
+
+    input.value = "";
+    autoResizeInput();
+
+    const container = $("chatMessages");
+    appendMessageBubble(container, { id: null, role: "user", content },
+      currentConvDetail.user_card, currentConvDetail.ai_card);
+    container.scrollTop = container.scrollHeight;
+
+    const modal = $("compareModal");
+    const candidatesDiv = $("compareCandidates");
+    candidatesDiv.textContent = "";
+    candidatesDiv.appendChild(el("div", {
+      textContent: "Generating candidates...",
+      style: { color: "#8b949e", textAlign: "center", padding: "40px" },
+    }));
+    modal.style.display = "";
+
+    try {
+      const result = await api("POST", "/rp/conversations/" + currentConvId + "/compare", {
+        content, configs,
+      });
+
+      candidatesDiv.textContent = "";
+      for (const c of result.candidates) {
+        const card = el("div", {
+          style: {
+            border: "1px solid #30363d", borderRadius: "8px", padding: "16px",
+            marginBottom: "12px", background: "#0d1117",
+          },
+        });
+        const header = el("div", {
+          style: { display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "8px" },
+        });
+        header.appendChild(el("strong", {
+          textContent: c.label,
+          style: { color: "#58a6ff" },
+        }));
+        header.appendChild(el("span", {
+          textContent: c.model + " | " + JSON.stringify(c.config),
+          style: { color: "#8b949e", fontSize: "0.8em" },
+        }));
+        card.appendChild(header);
+
+        card.appendChild(el("div", {
+          textContent: c.content,
+          style: { color: "#c9d1d9", whiteSpace: "pre-wrap", fontSize: "0.9em", lineHeight: "1.5", marginBottom: "12px" },
+        }));
+
+        const pickBtn = el("button", {
+          textContent: "Pick this one",
+          style: { background: "#238636" },
+        });
+        pickBtn.addEventListener("click", async () => {
+          try {
+            await api("POST", "/rp/eval-sets/" + result.eval_set_id + "/select", {
+              candidate_id: c.id,
+            });
+            modal.style.display = "none";
+            openConversation(currentConvId);
+          } catch (e) {
+            alert("Failed to select: " + e.message);
+          }
+        });
+        card.appendChild(pickBtn);
+        candidatesDiv.appendChild(card);
+      }
+    } catch (e) {
+      candidatesDiv.textContent = "";
+      candidatesDiv.appendChild(el("div", {
+        textContent: "Error: " + e.message,
+        style: { color: "#f85149", padding: "20px" },
+      }));
+    }
+  }
   $("restartBtn").addEventListener("click", () => {
     if (!currentConvId || isStreaming) return;
     confirmAction($("restartBtn"), async () => {

--- a/projects/rp/static/index.html
+++ b/projects/rp/static/index.html
@@ -887,6 +887,7 @@
         <div class="under-hood-tabs">
           <div class="under-hood-tab active" data-pane="prompt">System Prompt</div>
           <div class="under-hood-tab" data-pane="user-prompt">User Prompt</div>
+          <div class="under-hood-tab" data-pane="summary">Summary</div>
           <div class="under-hood-tab" data-pane="raw">Raw Response</div>
         </div>
         <div class="under-hood-pane active" id="underHoodPrompt" data-pane="prompt">
@@ -894,6 +895,9 @@
         </div>
         <div class="under-hood-pane" id="underHoodUserPrompt" data-pane="user-prompt">
           <div class="under-hood-content" id="underHoodUserPromptContent">No data yet.</div>
+        </div>
+        <div class="under-hood-pane" id="underHoodSummary" data-pane="summary">
+          <div class="under-hood-content" id="underHoodSummaryContent">No summary active.</div>
         </div>
         <div class="under-hood-pane" id="underHoodRaw" data-pane="raw">
           <div class="under-hood-content" id="underHoodContent">No data yet.</div>

--- a/projects/rp/static/index.html
+++ b/projects/rp/static/index.html
@@ -902,11 +902,23 @@
       <div class="chat-input-area" id="chatInputArea" style="display:none">
         <textarea id="chatInput" placeholder="Type a message..." rows="1"></textarea>
         <button id="sendBtn">Send</button>
+        <button id="compareBtn" title="Generate multiple responses with different configs" style="background:#8957e5">A/B</button>
         <button id="stopBtn" style="display:none;background:#f85149">Stop</button>
         <div class="chat-input-avatars" id="chatInputAvatars">
           <img class="chat-input-avatar" id="chatInputAvatarUser" alt="">
           <img class="chat-input-avatar" id="chatInputAvatarAi" alt="">
         </div>
+      </div>
+    </div>
+
+    <!-- Compare Modal -->
+    <div id="compareModal" style="display:none;position:fixed;inset:0;background:rgba(0,0,0,0.7);z-index:1000;overflow-y:auto;padding:20px">
+      <div style="max-width:900px;margin:0 auto;background:#161b22;border:1px solid #30363d;border-radius:12px;padding:20px">
+        <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:16px">
+          <h3 style="margin:0;color:#c9d1d9">Compare Responses</h3>
+          <button id="compareClose" style="background:#f85149">Cancel</button>
+        </div>
+        <div id="compareCandidates"></div>
       </div>
     </div>
 

--- a/projects/rp/static/index.html
+++ b/projects/rp/static/index.html
@@ -1040,12 +1040,6 @@
             </select>
           </div>
           <div class="form-group">
-            <label for="scenarioContext">Context Strategy</label>
-            <select id="scenarioContext">
-              <option value="sliding_window">Sliding Window</option>
-            </select>
-          </div>
-          <div class="form-group">
             <label for="scenarioThink" style="display:inline">
               <input type="checkbox" id="scenarioThink" style="width:auto;margin-right:6px">
               Enable Thinking

--- a/projects/rp/summarize.py
+++ b/projects/rp/summarize.py
@@ -10,6 +10,7 @@ from . import db
 
 _log = logging.getLogger("rp.summarize")
 
+SUMMARY_MODEL = "q25"
 SUMMARY_THRESHOLD = 10  # unsummarized messages before triggering
 
 
@@ -65,8 +66,12 @@ async def maybe_generate_summary(
     char_name: str = "Character",
     user_name: str = "User",
     ai_personality: str = "",
+    resolve_model=None,
 ) -> dict | None:
     """Generate a summary if enough unsummarized messages have accumulated.
+
+    Uses SUMMARY_MODEL (a lighter model) for generation, falling back to
+    the conversation model if resolve_model is not provided.
 
     Returns the saved summary row, or None if no summary was needed.
     """
@@ -82,7 +87,6 @@ async def maybe_generate_summary(
         prev_summary = existing["summary"]
         prev_through_seq = existing["through_sequence"]
 
-    # Filter to messages after the last summary
     new_msgs = [m for m in messages if m["sequence"] > prev_through_seq]
     if len(new_msgs) < SUMMARY_THRESHOLD:
         return None
@@ -95,8 +99,9 @@ async def maybe_generate_summary(
         ai_personality=ai_personality,
     )
 
+    summary_model = resolve_model(SUMMARY_MODEL) if resolve_model else model
     raw = await ollama.generate(
-        model=model, prompt=prompt,
+        model=summary_model, prompt=prompt,
         system="Output only the summary. No thinking, no preamble.",
         options={"temperature": 0.3, "num_predict": 600, "think": False},
     )
@@ -116,6 +121,6 @@ async def maybe_generate_summary(
         msg_count=len(new_msgs),
         token_estimate=token_estimate,
     )
-    _log.info("Generated summary for conv %d (through seq %d, %d msgs, ~%d tokens)",
-              conv_id, last_msg["sequence"], len(new_msgs), token_estimate)
+    _log.info("Generated summary for conv %d (through seq %d, %d msgs, ~%d tokens, model=%s)",
+              conv_id, last_msg["sequence"], len(new_msgs), token_estimate, summary_model)
     return saved

--- a/projects/rp/tests/test_context.py
+++ b/projects/rp/tests/test_context.py
@@ -190,10 +190,10 @@ class TestGetStrategy:
         s = get_strategy("summary_buffer")
         assert isinstance(s, SummaryBuffer)
 
-    def test_unknown_falls_back_to_sliding_window(self):
+    def test_unknown_falls_back_to_summary_buffer(self):
         s = get_strategy("nonexistent_strategy")
-        assert isinstance(s, SlidingWindow)
+        assert isinstance(s, SummaryBuffer)
 
-    def test_default_is_sliding_window(self):
+    def test_default_is_summary_buffer(self):
         s = get_strategy()
-        assert isinstance(s, SlidingWindow)
+        assert isinstance(s, SummaryBuffer)

--- a/projects/rp/tests/test_summarize.py
+++ b/projects/rp/tests/test_summarize.py
@@ -232,3 +232,45 @@ class TestMaybeGenerateSummary:
                 result = await maybe_generate_summary(1, AsyncMock(), "test-model")
                 assert result is None
         asyncio.run(run())
+
+    def test_uses_dedicated_model_when_resolve_model_provided(self):
+        """When resolve_model is given, uses SUMMARY_MODEL instead of conv model."""
+        async def run():
+            msgs = _make_messages(6)
+            with patch("projects.rp.summarize.db") as mock_db:
+                mock_db.get_messages = AsyncMock(return_value=msgs)
+                mock_db.get_latest_summary = AsyncMock(return_value=None)
+                mock_db.save_summary = AsyncMock(return_value={"id": 1})
+
+                ollama = AsyncMock()
+                ollama.generate = AsyncMock(return_value="Summary text.")
+
+                def fake_resolve(m):
+                    return "resolved-" + m
+
+                await maybe_generate_summary(
+                    1, ollama, "conv-model",
+                    resolve_model=fake_resolve,
+                )
+
+                call_args = ollama.generate.call_args
+                assert call_args[1]["model"] == "resolved-q25"
+        asyncio.run(run())
+
+    def test_falls_back_to_conv_model_without_resolve(self):
+        """Without resolve_model, uses the conversation model directly."""
+        async def run():
+            msgs = _make_messages(6)
+            with patch("projects.rp.summarize.db") as mock_db:
+                mock_db.get_messages = AsyncMock(return_value=msgs)
+                mock_db.get_latest_summary = AsyncMock(return_value=None)
+                mock_db.save_summary = AsyncMock(return_value={"id": 1})
+
+                ollama = AsyncMock()
+                ollama.generate = AsyncMock(return_value="Summary text.")
+
+                await maybe_generate_summary(1, ollama, "conv-model")
+
+                call_args = ollama.generate.call_args
+                assert call_args[1]["model"] == "conv-model"
+        asyncio.run(run())


### PR DESCRIPTION
## Summary

- **Store full assembled prompt** (`prompt_json` JSONB) per assistant message for exact prompt replay in reports
- **A/B compare mode**: generate multiple responses with different configs (model, temperature, budget), pick a winner, record preferences for later analysis
- **Finish SummaryBuffer**: dedicated lightweight model (q25), API endpoints (GET/POST summaries), Summary tab in Under the Hood, make it the only context strategy (remove dropdown)
- **Improvement plan**: 10 prioritized items in `projects/rp/docs/improvements.md`

## Test plan

```bash
cd /mnt/d/prg/plum-rp-report
python3 -m pytest projects/rp/tests/ -x -q
# 213 passed

# Verify schema migration runs cleanly
set -a && source /mnt/d/prg/plum/.env && set +a
psql "$DATABASE_URL" -f projects/rp/schema.sql

# Restart aiserver, open http://localhost:8080/rp/
# 1. Send a message — check Under the Hood > Summary tab shows summary data
# 2. Click A/B button — verify compare modal with 3 candidates
# 3. Pick a candidate — verify conversation continues from selected response
# 4. Open scenario editor — verify no Context Strategy dropdown
# 5. GET /rp/conversations/{id}/summaries — returns summary list
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)