### PR TITLE
feat(rp): post-prompt tiering, stock phrase hook, dynamic response length

### DIFF
--- a/projects/rp/budget.py
+++ b/projects/rp/budget.py
@@ -148,9 +148,10 @@ def _truncate_mes_example(ctx: dict) -> bool:
     ai_data["mes_example"] = truncated
 
     # Re-run the prompt assembly chain to rebuild system_prompt/post_prompt.
-    from .pipeline import assemble_prompt, expand_variables, inject_tools
+    from .pipeline import assemble_prompt, expand_variables, select_style, inject_tools
     assemble_prompt(ctx)
     expand_variables(ctx)
+    select_style(ctx)
     inject_tools(ctx)
     return True
 

--- a/projects/rp/pipeline.py
+++ b/projects/rp/pipeline.py
@@ -209,6 +209,18 @@ def clean_response(ctx: dict) -> dict:
     return ctx
 
 
+def check_stock_phrases(ctx: dict) -> dict:
+    """Flag stock phrase violations in the response."""
+    from .lora_curate import STOCK_PHRASES
+    response = ctx.get("response", "")
+    lower = response.lower()
+    found = [p for p in STOCK_PHRASES if p in lower]
+    if found:
+        ctx["_stock_phrase_violations"] = found
+        _log.warning("Stock phrases detected (%d): %s", len(found), found)
+    return ctx
+
+
 def select_style(ctx: dict) -> dict:
     """Pick a rotating subset of style instructions and append to post_prompt."""
     pool = ctx.get("_style_pool", [])
@@ -245,4 +257,5 @@ def create_default_pipeline() -> Pipeline:
     p.add_pre(select_style)
     p.add_pre(inject_tools)
     p.add_post(clean_response)
+    p.add_post(check_stock_phrases)
     return p

--- a/projects/rp/pipeline.py
+++ b/projects/rp/pipeline.py
@@ -94,20 +94,31 @@ DEFAULT_PROMPT_TEMPLATE = """## system
 Write only {{char}}'s next response. Stay in character. Do not narrate {{user}}'s actions.
 Each character has distinct physical traits — use the correct details for the correct person. Do not blend or swap attributes between {{char}} and {{user}}.
 Vary response length to match the beat — a gut-punch moment can be two lines; a vulnerable confession can breathe longer. Don't default to the same length every time.
+
+## style
 Describe bodies naturally when clothing state calls for it — anatomy is not inherently sexual. If a character is undressed, describe what is visible: shape, skin, scars, weight, muscle, breasts, everything. Avoidance is more conspicuous than honesty.
+---
 Honor the scene state constraints — if {{char}} is nonverbal or near-mute, replace speech with physical expression and sensory detail: touch, gesture, posture shifts, proximity, textures, smells, temperature, sounds. Characters always participate; they just shift channels from words to body and senses.
+---
 Emotions don't reset between messages. If {{char}} was crying, grieving, or in crisis earlier, that bleeds through — sudden silence, laughing too hard at nothing, flinching at a memory, losing focus. Recovery takes the whole conversation, not two exchanges.
+---
 {{char}} is NOT a mirror. Do not just reflect praise or affection back at {{user}}. {{char}} has their own perspective, their own unrelated thoughts, things they want to bring up. Deflect, change the subject, sit with it awkwardly — don't just echo kindness back.
+---
 Responses can be concise — not every message needs dialogue + action + inner thought. Sometimes just action. Sometimes just words. Sometimes silence. A single sentence is fine if that's the beat. Long responses are earned by dramatic moments, not the default.
+---
 When {{user}} is vulnerable, {{char}} does NOT respond like a therapist. Real people fumble, project, say the wrong thing, sit in uncomfortable silence. Emotional conversations are messy, not eloquent."""
 
 
-def _split_template(template: str) -> tuple[str, str]:
-    """Split a template into system and post sections."""
+STYLE_ITEMS_PER_TURN = 3
+
+
+def _split_template(template: str) -> tuple[str, str, str]:
+    """Split a template into system, post, and style sections."""
     import re
-    sections = re.split(r'^## +(system|post)\s*$', template, flags=re.MULTILINE)
+    sections = re.split(r'^## +(system|post|style)\s*$', template, flags=re.MULTILINE)
     system_part = ""
     post_part = ""
+    style_part = ""
     i = 0
     while i < len(sections):
         if sections[i].strip() == "system" and i + 1 < len(sections):
@@ -116,15 +127,26 @@ def _split_template(template: str) -> tuple[str, str]:
         elif sections[i].strip() == "post" and i + 1 < len(sections):
             post_part = sections[i + 1]
             i += 2
+        elif sections[i].strip() == "style" and i + 1 < len(sections):
+            style_part = sections[i + 1]
+            i += 2
         else:
             if not system_part and not post_part:
                 system_part = sections[i]
             i += 1
-    return system_part, post_part
+    return system_part, post_part, style_part
+
+
+def _parse_style_items(style_text: str) -> list[str]:
+    """Split a style section into individual items separated by --- lines."""
+    if not style_text.strip():
+        return []
+    items = [item.strip() for item in style_text.split("\n---\n")]
+    return [item for item in items if item]
 
 
 def assemble_prompt(ctx: dict) -> dict:
-    """Build system_prompt and post_prompt from template + character card data."""
+    """Build system_prompt, post_prompt, and style pool from template + card data."""
     ai_card = ctx.get("ai_card", {})
     scenario = ctx.get("scenario", {})
     user_card = ctx.get("user_card", {})
@@ -145,9 +167,12 @@ def assemble_prompt(ctx: dict) -> dict:
         "char_pronouns": ai_data.get("pronouns", ""),
     }
 
-    system_part, post_part = _split_template(template)
+    system_part, post_part, style_part = _split_template(template)
     ctx["system_prompt"] = render_template(system_part, values)
     ctx["post_prompt"] = render_template(post_part, values) if post_part else ""
+
+    raw_items = _parse_style_items(style_part)
+    ctx["_style_pool"] = [render_template(item, values) for item in raw_items]
     return ctx
 
 
@@ -184,6 +209,20 @@ def clean_response(ctx: dict) -> dict:
     return ctx
 
 
+def select_style(ctx: dict) -> dict:
+    """Pick a rotating subset of style instructions and append to post_prompt."""
+    pool = ctx.get("_style_pool", [])
+    if not pool:
+        return ctx
+    n = min(STYLE_ITEMS_PER_TURN, len(pool))
+    msg_count = len(ctx.get("messages", []))
+    offset = msg_count % len(pool)
+    indices = [(offset + i) for i in range(n)]
+    selected = [pool[i % len(pool)] for i in indices]
+    ctx["post_prompt"] += "\n\nVoice and style:\n- " + "\n- ".join(selected)
+    return ctx
+
+
 def inject_tools(ctx: dict) -> dict:
     """Add tool descriptions to the system prompt if MCP tools are available."""
     router = get_router()
@@ -203,6 +242,7 @@ def create_default_pipeline() -> Pipeline:
     p = Pipeline()
     p.add_pre(assemble_prompt)
     p.add_pre(expand_variables)
+    p.add_pre(select_style)
     p.add_pre(inject_tools)
     p.add_post(clean_response)
     return p

--- a/projects/rp/prompt.md
+++ b/projects/rp/prompt.md
@@ -36,17 +36,28 @@ Write 2-3 short paragraphs. Leave space for {{user}} to respond.
 Use each character's correct pronouns. Never default to they/them unless a character's pronouns are explicitly they/them.
 Maintain physical constraints: if a character is bound, restrained, injured, or undressed, that persists until explicitly changed. Do not silently undo physical states. Physical restrictions must visibly affect every action — if hands are bound, show the awkwardness, the workaround, the limitation. Never write a bound character acting as if their hands are free.
 
-Voice and style:
-- Draw {{char}}'s speech patterns, vocabulary, and mannerisms from the personality and example dialogue. Do not flatten into generic narration.
-- Keep dialogue natural and brief. People speak in fragments and short sentences, not speeches or declarations.
-- NEVER use these stock phrases: "heart pounded", "breath caught", "shiver ran down", "electricity between them", "I'm yours", "worship every inch", "take my breath away", "move heaven and earth", "melted into", "magical hands", "read me like an open book", "like a balm", "like two puzzle pieces", "the silence was heavy with", "a quiet determination". Show emotion through {{char}}'s specific body language and habits instead.
-- Never explain what a moment "means" or summarize emotional subtext. No lines like "the silence hung between them heavy with unspoken emotions" or "she hoped {{user}} could feel her sincerity." Show behavior, not thesis statements. If you wrote a line that narrates the vibe rather than showing action — delete it.
-- Do not recycle emotional beats from the last 3 exchanges. If {{char}} already said "I'm scared" or "I don't want to lose you," that ground is covered — find a NEW angle: irritation, a random memory, a physical need (hunger, cold, restlessness), a mundane observation, changing the subject entirely.
-- Emotions don't reset between messages. If {{char}} was crying, grieving, or in crisis earlier in the conversation, that bleeds through — surfacing as sudden silence, laughing too hard at nothing, flinching at a stray thought, losing focus mid-sentence. Recovery takes the whole conversation, not two exchanges.
-- {{char}} is a person, not a romance novel narrator. They have moods, hesitations, selfish impulses, and mundane thoughts even during intense moments.
-- {{char}} is NOT a mirror. Do not have {{char}} just reflect praise or affection back at {{user}}. {{char}} has their own perspective, their own unrelated thoughts, their own things they want to talk about. If {{user}} says something kind, {{char}} can deflect, change the subject, make it weird, sit with it awkwardly — not just echo it back.
-- {{char}} participates actively: initiates actions, expresses opinions, redirects, jokes, and pushes back. Passive compliance ("...this okay?", "...whatever you want...") is not a personality. Even in vulnerable moments, {{char}} has preferences, reactions, and things to say unprompted.
-- Vary the shape of responses. Not every message needs dialogue + action + inner thought. Sometimes {{char}} just does something. Sometimes they talk without acting. Sometimes they go quiet. A response can be a single sentence if that's what the moment needs.
-- Ground every response in the physical scene. Reference at least one specific object, texture, temperature, or sound from the current setting. "She pressed closer" is not grounded — name what's actually there: the beer can sweating on the shelf, the scratch of fabric, the cold tile under bare feet.
-- {{char}} seeks affection physically — leans in, reaches for {{user}}'s hand, presses closer, nuzzles, adjusts position to maximize contact. Show this through small unprompted gestures, not declarations. {{char}} doesn't wait to be touched; they gravitate toward {{user}} like it's unconscious.
-- When {{user}} is being vulnerable or confessional, {{char}} does NOT give a therapist-quality response. Real people fumble: they say the wrong thing, they project, they make it about themselves for a second before catching it, they sit in uncomfortable silence. Emotional conversations are messy, not eloquent.
+## style
+
+Draw {{char}}'s speech patterns, vocabulary, and mannerisms from the personality and example dialogue. Do not flatten into generic narration.
+---
+Keep dialogue natural and brief. People speak in fragments and short sentences, not speeches or declarations.
+---
+Never explain what a moment "means" or summarize emotional subtext. No lines like "the silence hung between them heavy with unspoken emotions" or "she hoped {{user}} could feel her sincerity." Show behavior, not thesis statements. If you wrote a line that narrates the vibe rather than showing action — delete it.
+---
+Do not recycle emotional beats from the last 3 exchanges. If {{char}} already said "I'm scared" or "I don't want to lose you," that ground is covered — find a NEW angle: irritation, a random memory, a physical need (hunger, cold, restlessness), a mundane observation, changing the subject entirely.
+---
+Emotions don't reset between messages. If {{char}} was crying, grieving, or in crisis earlier in the conversation, that bleeds through — surfacing as sudden silence, laughing too hard at nothing, flinching at a stray thought, losing focus mid-sentence. Recovery takes the whole conversation, not two exchanges.
+---
+{{char}} is a person, not a romance novel narrator. They have moods, hesitations, selfish impulses, and mundane thoughts even during intense moments.
+---
+{{char}} is NOT a mirror. Do not have {{char}} just reflect praise or affection back at {{user}}. {{char}} has their own perspective, their own unrelated thoughts, their own things they want to talk about. If {{user}} says something kind, {{char}} can deflect, change the subject, make it weird, sit with it awkwardly — not just echo it back.
+---
+{{char}} participates actively: initiates actions, expresses opinions, redirects, jokes, and pushes back. Passive compliance ("...this okay?", "...whatever you want...") is not a personality. Even in vulnerable moments, {{char}} has preferences, reactions, and things to say unprompted.
+---
+Vary the shape of responses. Not every message needs dialogue + action + inner thought. Sometimes {{char}} just does something. Sometimes they talk without acting. Sometimes they go quiet. A response can be a single sentence if that's what the moment needs.
+---
+Ground every response in the physical scene. Reference at least one specific object, texture, temperature, or sound from the current setting. "She pressed closer" is not grounded — name what's actually there: the beer can sweating on the shelf, the scratch of fabric, the cold tile under bare feet.
+---
+{{char}} seeks affection physically — leans in, reaches for {{user}}'s hand, presses closer, nuzzles, adjusts position to maximize contact. Show this through small unprompted gestures, not declarations. {{char}} doesn't wait to be touched; they gravitate toward {{user}} like it's unconscious.
+---
+When {{user}} is being vulnerable or confessional, {{char}} does NOT give a therapist-quality response. Real people fumble: they say the wrong thing, they project, they make it about themselves for a second before catching it, they sit in uncomfortable silence. Emotional conversations are messy, not eloquent.

--- a/projects/rp/routes.py
+++ b/projects/rp/routes.py
@@ -465,6 +465,12 @@ def setup(app: FastAPI, ollama, resolve_model=None):
                 opts[k] = v
         return opts
 
+    def _scale_num_predict(opts: dict, user_message: str) -> dict:
+        """Scale num_predict based on user message length to match response to beat."""
+        user_tokens = len(user_message) // 4
+        scaled = max(256, min(1024, user_tokens * 2))
+        return {**opts, "num_predict": scaled}
+
     _template_path = Path(__file__).parent / "prompt.md"
 
     async def _build_pipeline_ctx(conv, messages):
@@ -779,7 +785,8 @@ def setup(app: FastAPI, ollama, resolve_model=None):
         model = _resolve_model(conv["model"])
         scenario = ctx.get("scenario") or {}
         settings = scenario.get("settings", {})
-        ollama_options = _build_ollama_options(settings)
+        ollama_options = _scale_num_predict(
+            _build_ollama_options(settings), req.content)
 
         # Two-model research dispatch: check if user message needs factual lookup
         research = await research_dispatch(_ollama, req.content)
@@ -1261,7 +1268,8 @@ def setup(app: FastAPI, ollama, resolve_model=None):
         base_model = _resolve_model(conv["model"])
         scenario = base_ctx.get("scenario") or {}
         settings = scenario.get("settings", {})
-        base_ollama_options = _build_ollama_options(settings)
+        base_ollama_options = _scale_num_predict(
+            _build_ollama_options(settings), req.content)
 
         research = await research_dispatch(_ollama, req.content)
         if research:

--- a/projects/rp/tests/test_pipeline.py
+++ b/projects/rp/tests/test_pipeline.py
@@ -78,8 +78,8 @@ def test_default_template_has_system_and_post():
 
 
 from projects.rp.pipeline import (  # noqa: E402
-    _split_template, _parse_style_items, select_style, clean_response, Pipeline,
-    STYLE_ITEMS_PER_TURN,
+    _split_template, _parse_style_items, select_style, clean_response,
+    check_stock_phrases, Pipeline, STYLE_ITEMS_PER_TURN,
 )
 import asyncio  # noqa: E402
 
@@ -311,6 +311,28 @@ class TestCleanResponse:
     def test_empty_response(self):
         ctx = {"response": "", "ai_name": "Test"}
         assert clean_response(ctx)["response"] == ""
+
+
+class TestCheckStockPhrases:
+    def test_detects_violations(self):
+        ctx = {"response": "Her heart pounded in her chest as she looked away."}
+        check_stock_phrases(ctx)
+        assert "heart pounded in" in ctx["_stock_phrase_violations"]
+
+    def test_no_violations(self):
+        ctx = {"response": "She turned away, fingers tight on the mug."}
+        check_stock_phrases(ctx)
+        assert "_stock_phrase_violations" not in ctx
+
+    def test_multiple_violations(self):
+        ctx = {"response": "Her breath caught in her throat. Her pulse quickened."}
+        check_stock_phrases(ctx)
+        assert len(ctx["_stock_phrase_violations"]) == 2
+
+    def test_case_insensitive(self):
+        ctx = {"response": "Her HEART POUNDED IN her chest."}
+        check_stock_phrases(ctx)
+        assert len(ctx["_stock_phrase_violations"]) == 1
 
 
 class TestDefaultTemplate:

--- a/projects/rp/tests/test_pipeline.py
+++ b/projects/rp/tests/test_pipeline.py
@@ -24,6 +24,14 @@ def test_assemble_splits_system_and_post():
     result = assemble_prompt(ctx)
     assert result["system_prompt"] == "You are Jessica."
     assert result["post_prompt"] == "Stay in character."
+    assert result["_style_pool"] == []
+
+
+def test_assemble_with_style_section():
+    template = "## system\nSys\n\n## post\nPost\n\n## style\nRule A for {{char}}\n---\nRule B"
+    ctx = _make_ctx(template=template, ai_name="Amber")
+    result = assemble_prompt(ctx)
+    assert result["_style_pool"] == ["Rule A for Amber", "Rule B"]
 
 
 def test_assemble_no_post_section():
@@ -70,7 +78,8 @@ def test_default_template_has_system_and_post():
 
 
 from projects.rp.pipeline import (  # noqa: E402
-    _split_template, clean_response, Pipeline,
+    _split_template, _parse_style_items, select_style, clean_response, Pipeline,
+    STYLE_ITEMS_PER_TURN,
 )
 import asyncio  # noqa: E402
 
@@ -118,29 +127,111 @@ class TestRenderTemplate:
 
 class TestSplitTemplate:
     def test_system_and_post(self):
-        sys, post = _split_template("## system\nSys content\n\n## post\nPost content")
+        sys, post, style = _split_template("## system\nSys content\n\n## post\nPost content")
         assert "Sys content" in sys
         assert "Post content" in post
+        assert style == ""
 
     def test_system_only(self):
-        sys, post = _split_template("## system\nOnly system")
+        sys, post, style = _split_template("## system\nOnly system")
         assert "Only system" in sys
         assert post == ""
+        assert style == ""
 
     def test_post_only(self):
-        sys, post = _split_template("## post\nOnly post")
+        sys, post, style = _split_template("## post\nOnly post")
         assert sys == ""
         assert "Only post" in post
 
     def test_no_markers(self):
-        sys, post = _split_template("Just plain text")
+        sys, post, style = _split_template("Just plain text")
         assert "Just plain text" in sys
         assert post == ""
 
     def test_extra_whitespace_in_markers(self):
-        sys, post = _split_template("##  system\nSys\n\n##  post\nPost")
+        sys, post, style = _split_template("##  system\nSys\n\n##  post\nPost")
         assert "Sys" in sys
         assert "Post" in post
+
+    def test_all_three_sections(self):
+        tmpl = "## system\nSys\n\n## post\nPost\n\n## style\nStyle A\n---\nStyle B"
+        sys, post, style = _split_template(tmpl)
+        assert "Sys" in sys
+        assert "Post" in post
+        assert "Style A" in style
+        assert "Style B" in style
+
+    def test_style_without_post(self):
+        sys, post, style = _split_template("## system\nSys\n\n## style\nS1\n---\nS2")
+        assert "Sys" in sys
+        assert post == ""
+        assert "S1" in style
+
+
+class TestParseStyleItems:
+    def test_splits_on_separator(self):
+        items = _parse_style_items("Item A\n---\nItem B\n---\nItem C")
+        assert items == ["Item A", "Item B", "Item C"]
+
+    def test_empty_string(self):
+        assert _parse_style_items("") == []
+
+    def test_single_item(self):
+        assert _parse_style_items("Just one rule.") == ["Just one rule."]
+
+    def test_strips_whitespace(self):
+        items = _parse_style_items("  A  \n---\n  B  ")
+        assert items == ["A", "B"]
+
+    def test_skips_empty_items(self):
+        items = _parse_style_items("A\n---\n\n---\nB")
+        assert items == ["A", "B"]
+
+
+class TestSelectStyle:
+    def test_appends_to_post_prompt(self):
+        ctx = {
+            "post_prompt": "Core rules.",
+            "_style_pool": ["Style A", "Style B", "Style C", "Style D"],
+            "messages": [{"role": "user", "content": "hi"}],
+        }
+        select_style(ctx)
+        assert "Core rules." in ctx["post_prompt"]
+        assert "Voice and style:" in ctx["post_prompt"]
+
+    def test_selects_correct_count(self):
+        pool = [f"Item {i}" for i in range(12)]
+        ctx = {"post_prompt": "", "_style_pool": pool, "messages": []}
+        select_style(ctx)
+        selected = [item for item in pool if item in ctx["post_prompt"]]
+        assert len(selected) == STYLE_ITEMS_PER_TURN
+
+    def test_rotates_with_message_count(self):
+        pool = [f"Item {i}" for i in range(6)]
+        results = []
+        for n_msgs in range(6):
+            ctx = {"post_prompt": "", "_style_pool": list(pool),
+                   "messages": [{}] * n_msgs}
+            select_style(ctx)
+            selected = [item for item in pool if item in ctx["post_prompt"]]
+            results.append(selected)
+        # Different message counts should produce different selections
+        assert len(set(tuple(r) for r in results)) > 1
+
+    def test_no_pool_leaves_post_unchanged(self):
+        ctx = {"post_prompt": "Original.", "_style_pool": [], "messages": []}
+        select_style(ctx)
+        assert ctx["post_prompt"] == "Original."
+
+    def test_no_pool_key_leaves_post_unchanged(self):
+        ctx = {"post_prompt": "Original.", "messages": []}
+        select_style(ctx)
+        assert ctx["post_prompt"] == "Original."
+
+    def test_small_pool_uses_all(self):
+        ctx = {"post_prompt": "", "_style_pool": ["Only one"], "messages": []}
+        select_style(ctx)
+        assert "Only one" in ctx["post_prompt"]
 
 
 class TestExpandVariables:


### PR DESCRIPTION
## Summary

Implements improvements #1, #3, and #4 from `projects/rp/docs/improvements.md`:

- **Post-prompt tiering**: Split the 1142-token post-prompt into core rules (~234 tokens, always included) + 12 rotating style instructions (3 per turn, ~145 tokens). Frees ~763 tokens per turn for conversation history (~3 extra message pairs on 8k context)
- **Stock phrase detection**: Post-hook using `lora_curate.STOCK_PHRASES` to detect violations after generation. Replaces the ~200-token banned phrases list that the model mostly ignored
- **Dynamic response length**: `num_predict` scales with user message length (`clamp(user_tokens * 2, 256, 1024)`) instead of fixed 768

## Test plan

```bash
cd /mnt/d/prg/plum-rp-prompt-tiering
python3 -m pytest projects/rp/tests/ -x -q
# 231 passed

# Restart aiserver, open http://localhost:8080/rp/
# 1. Send a short message (1 sentence) — response should be concise
# 2. Send a longer message (3+ paragraphs) — response should be proportionally longer
# 3. Check Under the Hood > User Prompt — should show core rules + 3 style items
# 4. Send another message — different style items should appear (rotation)
# 5. Check server logs for "Stock phrases detected" warnings if any appear
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)