### PR TITLE
feat(rp): double context window to 16384

### DIFF
--- a/projects/rp/budget.py
+++ b/projects/rp/budget.py
@@ -184,6 +184,7 @@ async def fit_prompt(
     strategy: "ContextStrategy",
     num_predict: int | None = None,
     ground_truth: bool = True,
+    model_ctx_override: int | None = None,
 ) -> BudgetReport:
     """Shrink ctx["messages"] (and, if needed, other prompt pieces) so the
     assembled prompt fits within model_ctx - response_reserve.
@@ -199,7 +200,7 @@ async def fit_prompt(
     Raises BudgetError with a populated report if the minimum viable
     prompt (system + greeting + most-recent user message) doesn't fit.
     """
-    model_ctx = await _get_model_ctx(model, ollama)
+    model_ctx = model_ctx_override or await _get_model_ctx(model, ollama)
     response_reserve = num_predict if num_predict is not None else 1024
     available = model_ctx - response_reserve
 

--- a/projects/rp/routes.py
+++ b/projects/rp/routes.py
@@ -455,7 +455,7 @@ def setup(app: FastAPI, ollama, resolve_model=None):
 
     # -- Chat --
 
-    _chat_defaults = {"num_predict": 768, "temperature": 1.05, "repeat_penalty": 1.08, "min_p": 0.1}
+    _chat_defaults = {"num_predict": 768, "num_ctx": 16384, "temperature": 1.05, "repeat_penalty": 1.08, "min_p": 0.1}
 
     def _build_ollama_options(settings: dict) -> dict:
         """Build ollama options from scenario settings with sensible defaults."""
@@ -524,6 +524,7 @@ def setup(app: FastAPI, ollama, resolve_model=None):
                 ctx, model=model, ollama=_ollama,
                 strategy=strategy, num_predict=num_predict,
                 ground_truth=True,
+                model_ctx_override=ollama_options.get("num_ctx"),
             )
         except BudgetError as e:
             _log.warning("Budget error for model=%s: %s", model, e)

--- a/projects/rp/tests/test_budget.py
+++ b/projects/rp/tests/test_budget.py
@@ -208,6 +208,24 @@ class TestFitPromptHappyPath:
         assert report.messages_budget == 300
 
 
+    @pytest.mark.asyncio
+    async def test_model_ctx_override_skips_ollama_query(self, stub_ollama_factory):
+        stub = stub_ollama_factory(num_ctx_map={"m": 8192})
+        ctx = _build_ctx(
+            system_prompt="system",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+        report = await fit_prompt(
+            ctx, model="m", ollama=stub, strategy=SlidingWindow(),
+            num_predict=512, ground_truth=False,
+            model_ctx_override=16384,
+        )
+        assert report.model_ctx == 16384
+        assert report.available == 16384 - 512
+        assert ctx["_num_ctx"] == 16384
+        assert stub.show_calls == {}
+
+
 class TestFitPromptPriority3:
     @pytest.mark.asyncio
     async def test_summary_kept_when_it_fits(self, stub_ollama_factory):


### PR DESCRIPTION
## Summary
- Adds `num_ctx: 16384` to `_chat_defaults` in routes.py (up from Ollama's model-native 8192)
- Adds `model_ctx_override` parameter to `fit_prompt()` so the budget system uses the configured window instead of querying Ollama
- Threads the override from `_budget_ctx` via `ollama_options.get("num_ctx")`

## Test plan
- [ ] `python3 -m pytest projects/rp/tests/test_budget.py -v` — new test `test_model_ctx_override_skips_ollama_query` verifies override is used and Ollama is not queried
- [ ] Start a conversation and check budget_json in the message — `model_ctx` should be 16384
```sql
SELECT budget_json->'model_ctx' FROM rp_messages WHERE conversation_id = (SELECT MAX(id) FROM rp_conversations) ORDER BY id DESC LIMIT 1;
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)