### PR TITLE
feat(rp): token budget allocator for context consumers (#87)

### DIFF
--- a/projects/rp/budget.py
+++ b/projects/rp/budget.py
@@ -60,6 +60,75 @@ def _estimate_tokens(text: str) -> int:
     return count_tokens(text)
 
 
+INJECTION_CAP = 0.30
+
+
+@dataclass
+class InjectionAllocation:
+    keep_research: bool
+    keep_fewshot: bool
+    research_tokens: int
+    fewshot_tokens: int
+    available_after_fixed: int
+    injection_cap: int
+
+
+async def allocate_injections(
+    ctx: dict,
+    *,
+    model: str,
+    ollama: _OllamaLike,
+    num_predict: int | None = None,
+    research_text: str | None = None,
+    fewshot_msgs: list[dict] | None = None,
+    model_ctx_override: int | None = None,
+) -> InjectionAllocation:
+    """Decide which optional injections fit within the token budget.
+
+    Measures fixed costs (system_prompt, post_prompt, num_predict) and caps
+    research + fewshot at INJECTION_CAP of remaining budget. Drops research
+    first (lowest priority), then fewshot.
+    """
+    model_ctx = model_ctx_override or await _get_model_ctx(model, ollama)
+    reserve = num_predict if num_predict is not None else 1024
+    available = model_ctx - reserve
+
+    fixed = _estimate_tokens(ctx.get("system_prompt", "")) + _estimate_tokens(
+        ctx.get("post_prompt", "")
+    )
+    remaining = max(0, available - fixed)
+    cap = int(remaining * INJECTION_CAP)
+
+    research_tokens = _estimate_tokens(research_text) if research_text else 0
+    fewshot_tokens = sum(
+        _estimate_tokens(m.get("content", "")) for m in (fewshot_msgs or [])
+    )
+
+    keep_research = True
+    keep_fewshot = True
+
+    if research_tokens + fewshot_tokens <= cap:
+        pass
+    elif fewshot_tokens <= cap:
+        keep_research = False
+        _log.info("Dropping research (%d tokens) — injection cap %d",
+                  research_tokens, cap)
+    else:
+        keep_research = False
+        keep_fewshot = False
+        _log.info("Dropping research (%d tokens) + fewshot (%d tokens) — "
+                  "injection cap %d", research_tokens, fewshot_tokens, cap)
+
+    return InjectionAllocation(
+        keep_research=keep_research,
+        keep_fewshot=keep_fewshot,
+        research_tokens=research_tokens if keep_research else 0,
+        fewshot_tokens=fewshot_tokens if keep_fewshot else 0,
+        available_after_fixed=remaining,
+        injection_cap=cap,
+    )
+
+
 async def _get_model_ctx(model: str, ollama: _OllamaLike) -> int:
     """Return cached num_ctx for `model`, fetching once on first use.
 

--- a/projects/rp/routes.py
+++ b/projects/rp/routes.py
@@ -17,7 +17,7 @@ from .models import (
 )
 from .pipeline import create_default_pipeline
 from dataclasses import asdict
-from .budget import fit_prompt, BudgetError, BudgetReport
+from .budget import fit_prompt, BudgetError, BudgetReport, allocate_injections
 from .context import get_strategy
 from .tokenizer import count_tokens
 from .mcp_client import get_router as get_mcp_router
@@ -42,7 +42,11 @@ def _budget_to_json(ctx: dict) -> dict | None:
     report = ctx.get("_budget_report")
     if not isinstance(report, BudgetReport):
         return None
-    return asdict(report)
+    result = asdict(report)
+    alloc = ctx.get("_injection_alloc")
+    if alloc is not None:
+        result["injection"] = asdict(alloc)
+    return result
 
 
 async def init_mcp():
@@ -790,9 +794,22 @@ def setup(app: FastAPI, ollama, resolve_model=None):
         ollama_options = _scale_num_predict(
             _build_ollama_options(settings), req.content)
 
-        # Two-model research dispatch: check if user message needs factual lookup
+        # Gather optional injections (research + fewshot)
         research = await research_dispatch(_ollama, req.content)
-        if research:
+        fewshot_msgs = await get_fewshot_messages(
+            _ollama, ctx["messages"], card_id=conv["ai_card_id"],
+        )
+
+        # Budget gate: cap injections so they don't starve conversation history
+        alloc = await allocate_injections(
+            ctx, model=model, ollama=_ollama,
+            num_predict=ollama_options.get("num_predict"),
+            research_text=research,
+            fewshot_msgs=fewshot_msgs if fewshot_msgs and ctx["messages"] else None,
+            model_ctx_override=ollama_options.get("num_ctx"),
+        )
+
+        if research and alloc.keep_research:
             _log.info("Injecting research into context (%d chars)", len(research))
             conv_log.log_research(conv_id, req.content, research)
             ctx["post_prompt"] = (
@@ -802,13 +819,12 @@ def setup(app: FastAPI, ollama, resolve_model=None):
                 + research
             )
 
-        # Vector-matched fewshot examples: inject style-similar examples
-        fewshot_msgs = await get_fewshot_messages(_ollama, ctx["messages"], card_id=conv["ai_card_id"])
-        if fewshot_msgs and ctx["messages"]:
+        if fewshot_msgs and ctx["messages"] and alloc.keep_fewshot:
             _log.info("Injecting %d fewshot examples (vector-matched)", len(fewshot_msgs) // 2)
             conv_log.log_fewshot(conv_id, len(fewshot_msgs) // 2, fewshot_msgs)
-            # Prepend after greeting (messages[0]), before real conversation
             ctx["messages"] = [ctx["messages"][0]] + fewshot_msgs + ctx["messages"][1:]
+
+        ctx["_injection_alloc"] = alloc
 
         try:
             await _budget_ctx(ctx, model, ollama_options)
@@ -1274,7 +1290,19 @@ def setup(app: FastAPI, ollama, resolve_model=None):
             _build_ollama_options(settings), req.content)
 
         research = await research_dispatch(_ollama, req.content)
-        if research:
+        fewshot_msgs = await get_fewshot_messages(
+            _ollama, base_ctx["messages"], card_id=conv["ai_card_id"],
+        )
+
+        alloc = await allocate_injections(
+            base_ctx, model=base_model, ollama=_ollama,
+            num_predict=base_ollama_options.get("num_predict"),
+            research_text=research,
+            fewshot_msgs=fewshot_msgs if fewshot_msgs and base_ctx["messages"] else None,
+            model_ctx_override=base_ollama_options.get("num_ctx"),
+        )
+
+        if research and alloc.keep_research:
             base_ctx["post_prompt"] = (
                 base_ctx.get("post_prompt", "")
                 + "\n\n[Research notes — weave these facts naturally if relevant, "
@@ -1282,11 +1310,10 @@ def setup(app: FastAPI, ollama, resolve_model=None):
                 + research
             )
 
-        fewshot_msgs = await get_fewshot_messages(
-            _ollama, base_ctx["messages"], card_id=conv["ai_card_id"],
-        )
-        if fewshot_msgs and base_ctx["messages"]:
+        if fewshot_msgs and base_ctx["messages"] and alloc.keep_fewshot:
             base_ctx["messages"] = [base_ctx["messages"][0]] + fewshot_msgs + base_ctx["messages"][1:]
+
+        base_ctx["_injection_alloc"] = alloc
 
         async def generate_candidate(cfg, candidate_row):
             ctx = copy.deepcopy(base_ctx)

--- a/projects/rp/tests/test_budget.py
+++ b/projects/rp/tests/test_budget.py
@@ -9,6 +9,7 @@ from projects.rp.budget import (
     BudgetReport,
     _get_model_ctx,
     _ollama_count_messages,
+    allocate_injections,
     fit_prompt,
     fit_raw_prompt,
 )
@@ -616,3 +617,86 @@ class TestEquivalenceWithOldBehavior:
             num_predict=500, ground_truth=False,
         )
         assert ctx["messages"] == expected
+
+
+class TestAllocateInjections:
+    @pytest.mark.asyncio
+    async def test_both_fit_within_cap(self, stub_ollama_factory):
+        """When research + fewshot fit within 30% cap, keep both."""
+        stub = stub_ollama_factory(num_ctx_map={"m": 8192})
+        ctx = _build_ctx(system_prompt="S" * 400, post_prompt="P" * 200)
+        alloc = await allocate_injections(
+            ctx, model="m", ollama=stub, num_predict=1024,
+            research_text="R" * 100,
+            fewshot_msgs=[{"content": "F" * 100}],
+        )
+        assert alloc.keep_research is True
+        assert alloc.keep_fewshot is True
+        assert alloc.research_tokens > 0
+        assert alloc.fewshot_tokens > 0
+
+    @pytest.mark.asyncio
+    async def test_research_dropped_fewshot_kept(self, stub_ollama_factory):
+        """When combined exceeds cap but fewshot alone fits, drop research.
+
+        Budget math (len//4 estimator):
+          model_ctx=2000, num_predict=500 → available=1500
+          system="S"*3000=750t, post="P"*1000=250t → fixed=1000
+          remaining=500, cap=150 (30%)
+          research="R"*800=200t, fewshot "F"*200=50t → combined=250 > 150
+          fewshot alone=50 ≤ 150 → drop research, keep fewshot
+        """
+        stub = stub_ollama_factory(num_ctx_map={"m": 2000})
+        ctx = _build_ctx(
+            system_prompt="S" * 3000,
+            post_prompt="P" * 1000,
+        )
+        alloc = await allocate_injections(
+            ctx, model="m", ollama=stub, num_predict=500,
+            research_text="R" * 800,
+            fewshot_msgs=[{"content": "F" * 200}],
+        )
+        assert alloc.keep_research is False
+        assert alloc.keep_fewshot is True
+
+    @pytest.mark.asyncio
+    async def test_both_dropped_when_cap_zero(self, stub_ollama_factory):
+        """When fixed costs exhaust the budget, drop both."""
+        stub = stub_ollama_factory(num_ctx_map={"m": 500})
+        ctx = _build_ctx(
+            system_prompt="S" * 2000,
+            post_prompt="",
+        )
+        alloc = await allocate_injections(
+            ctx, model="m", ollama=stub, num_predict=400,
+            research_text="R" * 100,
+            fewshot_msgs=[{"content": "F" * 100}],
+        )
+        assert alloc.keep_research is False
+        assert alloc.keep_fewshot is False
+
+    @pytest.mark.asyncio
+    async def test_no_injections(self, stub_ollama_factory):
+        """No research and no fewshot — both kept (vacuously)."""
+        stub = stub_ollama_factory(num_ctx_map={"m": 4096})
+        ctx = _build_ctx(system_prompt="S" * 100)
+        alloc = await allocate_injections(
+            ctx, model="m", ollama=stub, num_predict=512,
+            research_text=None, fewshot_msgs=None,
+        )
+        assert alloc.keep_research is True
+        assert alloc.keep_fewshot is True
+        assert alloc.research_tokens == 0
+        assert alloc.fewshot_tokens == 0
+
+    @pytest.mark.asyncio
+    async def test_model_ctx_override(self, stub_ollama_factory):
+        """model_ctx_override should be used instead of fetching from Ollama."""
+        stub = stub_ollama_factory(num_ctx_map={"m": 99999})
+        ctx = _build_ctx(system_prompt="S" * 400, post_prompt="P" * 200)
+        alloc = await allocate_injections(
+            ctx, model="m", ollama=stub, num_predict=1024,
+            research_text="R" * 100,
+            model_ctx_override=2000,
+        )
+        assert alloc.available_after_fixed < 99999 - 1024


### PR DESCRIPTION
## Summary
- Add `allocate_injections()` to `budget.py` — caps research + fewshot at 30% of available budget after fixed costs (system prompt, post prompt, num_predict)
- When budget is tight: drops research first (lowest priority), then fewshot, before `fit_prompt` handles message trimming
- Both injection sites (`send_message`, `compare_message`) now gather injections first, then gate on allocation before merging into ctx
- Allocation details stored in `budget_json` per message for debugging

## Changes
- **`budget.py`**: New `InjectionAllocation` dataclass and `allocate_injections()` function with 30% cap constant
- **`routes.py`**: Restructured `send_message` and `compare_message` injection flow to gather-then-check pattern; allocation stored in `ctx["_injection_alloc"]` and included in budget_json
- **`tests/test_budget.py`**: 5 new tests covering all allocation paths (both fit, research dropped, both dropped, no injections, model_ctx_override)

## Test plan
```bash
# Switch to worktree
cd /mnt/d/prg/plum-rp-budget-allocator

# Symlink venv
ln -sf /mnt/d/prg/plum/projects/aiserver/.venv projects/rp/.venv

# Run all RP tests
projects/rp/.venv/bin/python -m pytest projects/rp/tests/ -v
# Expected: 246 passed
```

Closes #87, closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)