### PR TITLE
fix: add q36 alias for qwen3.6:35b

### DIFF
--- a/projects/aiserver/config.json
+++ b/projects/aiserver/config.json
@@ -9,6 +9,7 @@
     "q4": "qwen3:4b",
     "q8": "qwen3:8b",
     "q25": "qwen2.5:7b-instruct-q3_K_M",
+    "q36": "qwen3.6:35b",
     "nemo": "mistral-nemo"
   },
   "default_options": {


### PR DESCRIPTION
## Summary

- Adds missing `q36` → `qwen3.6:35b` alias to aiserver config
- Scene state model was upgraded to `q36` in #124 but the alias mapping was not added, causing `resolve_model("q36")` to fail with Internal Server Error on scene state generation

## Test plan

```bash
# Restart aiserver, then:
curl -s http://localhost:8080/defaults | python3 -m json.tool | grep q36
# Should show: "q36": "qwen3.6:35b"

# Trigger scene state refresh on conv 102:
curl -s -X POST http://localhost:8080/rp/conversations/102/refresh-scene-state
# Should return scene state JSON instead of Internal Server Error
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)