### PR TITLE
fix(rp): allow thinking in scene state generation

### DIFF
--- a/projects/rp/routes.py
+++ b/projects/rp/routes.py
@@ -742,7 +742,7 @@ def setup(app: FastAPI, ollama, resolve_model=None):
         result = await _ollama.generate(
             model=summary_model, prompt=prompt,
             system="Output only the scene state summary. No thinking, no preamble.",
-            options={"temperature": 0.2, "num_predict": 200, "think": False},
+            options={"temperature": 0.2, "num_predict": 800},
         )
         clean = clean_scene_state_response(result)
         return validate_scene_state(clean, previous_state, messages)


### PR DESCRIPTION
## Summary

- qwen3.6:35b defaults to thinking mode — `think: false` suppresses all output, producing empty scene state
- Removed `think: false` and increased `num_predict` from 200 to 800 to budget for thinking + response tokens
- `clean_scene_state_response` already strips `<think>` tags, so thinking content is never persisted

## Test plan

```bash
# Restart aiserver, then refresh scene state on conv 102:
curl -s -X POST http://localhost:8080/rp/conversations/102/refresh-scene-state | python3 -m json.tool
# Should return populated scene state instead of empty string
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)