### PR TITLE
feat(rp): scene-state-driven style selection

### DIFF
--- a/projects/rp/pipeline.py
+++ b/projects/rp/pipeline.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import re
 from typing import Callable
 from .mcp_client import get_router
 
@@ -112,13 +113,13 @@ When {{user}} is vulnerable, {{char}} does NOT respond like a therapist. Real pe
 STYLE_ITEMS_PER_TURN = 3
 
 
-def _split_template(template: str) -> tuple[str, str, str]:
-    """Split a template into system, post, and style sections."""
-    import re
-    sections = re.split(r'^## +(system|post|style)\s*$', template, flags=re.MULTILINE)
+def _split_template(template: str) -> tuple[str, str, str, str]:
+    """Split a template into system, post, style, and scene-style sections."""
+    sections = re.split(r'^## +(system|post|scene-style|style)\s*$', template, flags=re.MULTILINE)
     system_part = ""
     post_part = ""
     style_part = ""
+    scene_style_part = ""
     i = 0
     while i < len(sections):
         if sections[i].strip() == "system" and i + 1 < len(sections):
@@ -127,6 +128,9 @@ def _split_template(template: str) -> tuple[str, str, str]:
         elif sections[i].strip() == "post" and i + 1 < len(sections):
             post_part = sections[i + 1]
             i += 2
+        elif sections[i].strip() == "scene-style" and i + 1 < len(sections):
+            scene_style_part = sections[i + 1]
+            i += 2
         elif sections[i].strip() == "style" and i + 1 < len(sections):
             style_part = sections[i + 1]
             i += 2
@@ -134,7 +138,7 @@ def _split_template(template: str) -> tuple[str, str, str]:
             if not system_part and not post_part:
                 system_part = sections[i]
             i += 1
-    return system_part, post_part, style_part
+    return system_part, post_part, style_part, scene_style_part
 
 
 def _parse_style_items(style_text: str) -> list[str]:
@@ -143,6 +147,48 @@ def _parse_style_items(style_text: str) -> list[str]:
         return []
     items = [item.strip() for item in style_text.split("\n---\n")]
     return [item for item in items if item]
+
+
+def _parse_scene_style_items(text: str) -> list[tuple[str, str, list[str]]]:
+    """Parse scene-style section into (category, text, keywords) tuples.
+
+    Each item starts with a condition line: [category] or [category=kw1,kw2].
+    Items are separated by --- lines. A bare [category] matches when that
+    category exists in scene state; [category=kw1,kw2] matches when the
+    category value contains any listed keyword.
+    """
+    if not text.strip():
+        return []
+    items = []
+    for block in text.split("\n---\n"):
+        block = block.strip()
+        if not block:
+            continue
+        lines = block.split("\n", 1)
+        m = re.match(r'\[(\w[\w-]*)(?:=([^\]]+))?\]', lines[0].strip())
+        if not m:
+            continue
+        category = m.group(1).lower()
+        keywords = [k.strip().lower() for k in m.group(2).split(",")] if m.group(2) else []
+        body = lines[1].strip() if len(lines) > 1 else ""
+        if body:
+            items.append((category, body, keywords))
+    return items
+
+
+def _match_scene_condition(category: str, keywords: list[str],
+                           scene_state: dict[str, str]) -> bool:
+    """Check if a scene-style condition matches the current scene state."""
+    value = ""
+    for k, v in scene_state.items():
+        if k.lower() == category:
+            value = v.lower()
+            break
+    if not value:
+        return False
+    if not keywords:
+        return True
+    return any(kw in value for kw in keywords)
 
 
 def assemble_prompt(ctx: dict) -> dict:
@@ -167,12 +213,18 @@ def assemble_prompt(ctx: dict) -> dict:
         "char_pronouns": ai_data.get("pronouns", ""),
     }
 
-    system_part, post_part, style_part = _split_template(template)
+    system_part, post_part, style_part, scene_style_part = _split_template(template)
     ctx["system_prompt"] = render_template(system_part, values)
     ctx["post_prompt"] = render_template(post_part, values) if post_part else ""
 
     raw_items = _parse_style_items(style_part)
     ctx["_style_pool"] = [render_template(item, values) for item in raw_items]
+
+    raw_scene_items = _parse_scene_style_items(scene_style_part)
+    ctx["_scene_style_pool"] = [
+        (cat, render_template(body, values), kws)
+        for cat, body, kws in raw_scene_items
+    ]
     return ctx
 
 
@@ -222,16 +274,33 @@ def check_stock_phrases(ctx: dict) -> dict:
 
 
 def select_style(ctx: dict) -> dict:
-    """Pick a rotating subset of style instructions and append to post_prompt."""
+    """Pick style instructions: scene-state conditionals + rotating general items."""
+    from .scene_state import parse_scene_state
+
     pool = ctx.get("_style_pool", [])
-    if not pool:
+    scene_pool = ctx.get("_scene_style_pool", [])
+
+    matched = []
+    if scene_pool:
+        scene_state = parse_scene_state(ctx.get("scene_state", ""))
+        for category, text, keywords in scene_pool:
+            if _match_scene_condition(category, keywords, scene_state):
+                matched.append(text)
+
+    selected_general = []
+    if pool:
+        n = min(STYLE_ITEMS_PER_TURN, len(pool))
+        msg_count = len(ctx.get("messages", []))
+        offset = msg_count % len(pool)
+        indices = [(offset + i) for i in range(n)]
+        selected_general = [pool[i % len(pool)] for i in indices]
+
+    all_selected = matched + selected_general
+    if not all_selected:
         return ctx
-    n = min(STYLE_ITEMS_PER_TURN, len(pool))
-    msg_count = len(ctx.get("messages", []))
-    offset = msg_count % len(pool)
-    indices = [(offset + i) for i in range(n)]
-    selected = [pool[i % len(pool)] for i in indices]
-    ctx["post_prompt"] += "\n\nVoice and style:\n- " + "\n- ".join(selected)
+
+    ctx["post_prompt"] += "\n\nVoice and style:\n- " + "\n- ".join(all_selected)
+    ctx["_matched_scene_styles"] = len(matched)
     return ctx
 
 

--- a/projects/rp/prompt.md
+++ b/projects/rp/prompt.md
@@ -34,7 +34,7 @@ HARD RULE: You write ONLY {{char}}. You NEVER write what {{user}} does, says, th
 Stop before {{user}} would act or speak. End on {{char}}'s action, thought, or dialogue.
 Write 2-3 short paragraphs. Leave space for {{user}} to respond.
 Use each character's correct pronouns. Never default to they/them unless a character's pronouns are explicitly they/them.
-Maintain physical constraints: if a character is bound, restrained, injured, or undressed, that persists until explicitly changed. Do not silently undo physical states. Physical restrictions must visibly affect every action — if hands are bound, show the awkwardness, the workaround, the limitation. Never write a bound character acting as if their hands are free.
+Maintain physical constraints: if a character is bound, restrained, injured, or undressed, that persists until explicitly changed. Do not silently undo physical states.
 
 ## style
 
@@ -61,3 +61,20 @@ Ground every response in the physical scene. Reference at least one specific obj
 {{char}} seeks affection physically — leans in, reaches for {{user}}'s hand, presses closer, nuzzles, adjusts position to maximize contact. Show this through small unprompted gestures, not declarations. {{char}} doesn't wait to be touched; they gravitate toward {{user}} like it's unconscious.
 ---
 When {{user}} is being vulnerable or confessional, {{char}} does NOT give a therapist-quality response. Real people fumble: they say the wrong thing, they project, they make it about themselves for a second before catching it, they sit in uncomfortable silence. Emotional conversations are messy, not eloquent.
+
+## scene-style
+
+[restraints]
+{{char}} is restrained — every physical action must account for this. Show the pull of bindings, the restricted range, the awkward compensation. Hands that can't reach, gestures that abort halfway, posture forced by the tie. Never write {{char}} moving as if unbound.
+---
+[mood=grieving,crying,distressed,panicking,trembling,shaking,sobbing]
+{{char}}'s emotional state is acute right now. Don't soften or skip past it. Show the physical residue: hitched breathing, swollen eyes, hands that won't stay still, voice cracking mid-word. Recovery doesn't happen in one exchange.
+---
+[voice=nonverbal,mute,quiet,silent,whisper,whispering]
+{{char}} is barely verbal right now. Lean into physical expression: touch, gesture, posture shifts, proximity, textures, sounds. A nod, a squeeze of the hand, pressing closer — these replace dialogue. Don't force speech where silence fits.
+---
+[clothing=naked,undressed,nude,bare,topless,shirtless,underwear]
+Describe {{char}}'s body naturally when the scene calls for it. Name what's visible: shape, skin, scars, muscle, softness, everything relevant. Avoidance reads as prudish, not tasteful. Treat anatomy as fact, not innuendo.
+---
+[position=lap,straddling,pinned,held,carrying,embrace,tangled]
+Physical contact is active — show the weight, warmth, and pressure points. Two bodies in contact create constant small sensations: shifting weight, skin sticking, breathing felt through ribs. Don't let them become furniture.

--- a/projects/rp/tests/test_pipeline.py
+++ b/projects/rp/tests/test_pipeline.py
@@ -25,6 +25,7 @@ def test_assemble_splits_system_and_post():
     assert result["system_prompt"] == "You are Jessica."
     assert result["post_prompt"] == "Stay in character."
     assert result["_style_pool"] == []
+    assert result["_scene_style_pool"] == []
 
 
 def test_assemble_with_style_section():
@@ -78,7 +79,8 @@ def test_default_template_has_system_and_post():
 
 
 from projects.rp.pipeline import (  # noqa: E402
-    _split_template, _parse_style_items, select_style, clean_response,
+    _split_template, _parse_style_items, _parse_scene_style_items,
+    _match_scene_condition, select_style, clean_response,
     check_stock_phrases, Pipeline, STYLE_ITEMS_PER_TURN,
 )
 import asyncio  # noqa: E402
@@ -127,45 +129,61 @@ class TestRenderTemplate:
 
 class TestSplitTemplate:
     def test_system_and_post(self):
-        sys, post, style = _split_template("## system\nSys content\n\n## post\nPost content")
+        sys, post, style, ss = _split_template("## system\nSys content\n\n## post\nPost content")
         assert "Sys content" in sys
         assert "Post content" in post
         assert style == ""
+        assert ss == ""
 
     def test_system_only(self):
-        sys, post, style = _split_template("## system\nOnly system")
+        sys, post, style, ss = _split_template("## system\nOnly system")
         assert "Only system" in sys
         assert post == ""
         assert style == ""
 
     def test_post_only(self):
-        sys, post, style = _split_template("## post\nOnly post")
+        sys, post, style, ss = _split_template("## post\nOnly post")
         assert sys == ""
         assert "Only post" in post
 
     def test_no_markers(self):
-        sys, post, style = _split_template("Just plain text")
+        sys, post, style, ss = _split_template("Just plain text")
         assert "Just plain text" in sys
         assert post == ""
 
     def test_extra_whitespace_in_markers(self):
-        sys, post, style = _split_template("##  system\nSys\n\n##  post\nPost")
+        sys, post, style, ss = _split_template("##  system\nSys\n\n##  post\nPost")
         assert "Sys" in sys
         assert "Post" in post
 
     def test_all_three_sections(self):
         tmpl = "## system\nSys\n\n## post\nPost\n\n## style\nStyle A\n---\nStyle B"
-        sys, post, style = _split_template(tmpl)
+        sys, post, style, ss = _split_template(tmpl)
         assert "Sys" in sys
         assert "Post" in post
         assert "Style A" in style
         assert "Style B" in style
 
     def test_style_without_post(self):
-        sys, post, style = _split_template("## system\nSys\n\n## style\nS1\n---\nS2")
+        sys, post, style, ss = _split_template("## system\nSys\n\n## style\nS1\n---\nS2")
         assert "Sys" in sys
         assert post == ""
         assert "S1" in style
+
+    def test_scene_style_section(self):
+        tmpl = "## system\nSys\n\n## style\nS1\n\n## scene-style\n[mood=sad]\nBe sad"
+        sys, post, style, ss = _split_template(tmpl)
+        assert "Sys" in sys
+        assert "S1" in style
+        assert "[mood=sad]" in ss
+
+    def test_all_four_sections(self):
+        tmpl = "## system\nS\n\n## post\nP\n\n## style\nSt\n\n## scene-style\nSS"
+        sys, post, style, ss = _split_template(tmpl)
+        assert "S" in sys
+        assert "P" in post
+        assert "St" in style
+        assert "SS" in ss
 
 
 class TestParseStyleItems:
@@ -232,6 +250,174 @@ class TestSelectStyle:
         ctx = {"post_prompt": "", "_style_pool": ["Only one"], "messages": []}
         select_style(ctx)
         assert "Only one" in ctx["post_prompt"]
+
+
+class TestParseSceneStyleItems:
+    def test_basic_condition(self):
+        items = _parse_scene_style_items("[restraints]\nShow the limitation.")
+        assert len(items) == 1
+        assert items[0] == ("restraints", "Show the limitation.", [])
+
+    def test_condition_with_keywords(self):
+        items = _parse_scene_style_items("[mood=grieving,crying]\nDon't soften it.")
+        assert len(items) == 1
+        assert items[0][0] == "mood"
+        assert items[0][2] == ["grieving", "crying"]
+
+    def test_multiple_items(self):
+        text = "[restraints]\nItem A\n---\n[mood=sad]\nItem B"
+        items = _parse_scene_style_items(text)
+        assert len(items) == 2
+        assert items[0][0] == "restraints"
+        assert items[1][0] == "mood"
+
+    def test_empty_string(self):
+        assert _parse_scene_style_items("") == []
+
+    def test_skips_items_without_condition(self):
+        text = "No condition here\n---\n[mood]\nHas condition"
+        items = _parse_scene_style_items(text)
+        assert len(items) == 1
+        assert items[0][0] == "mood"
+
+    def test_skips_condition_without_body(self):
+        items = _parse_scene_style_items("[restraints]")
+        assert items == []
+
+    def test_hyphenated_category(self):
+        items = _parse_scene_style_items("[scene-mood]\nText here")
+        assert items[0][0] == "scene-mood"
+
+
+class TestMatchSceneCondition:
+    def test_category_exists(self):
+        assert _match_scene_condition("restraints", [], {"Restraints": "wrists bound"})
+
+    def test_category_missing(self):
+        assert not _match_scene_condition("restraints", [], {"Location": "kitchen"})
+
+    def test_keyword_match(self):
+        assert _match_scene_condition("mood", ["grieving", "crying"],
+                                      {"Mood": "Amber is grieving silently"})
+
+    def test_keyword_no_match(self):
+        assert not _match_scene_condition("mood", ["grieving", "crying"],
+                                          {"Mood": "calm and relaxed"})
+
+    def test_case_insensitive_category(self):
+        assert _match_scene_condition("restraints", [], {"RESTRAINTS": "tied"})
+
+    def test_case_insensitive_value(self):
+        assert _match_scene_condition("mood", ["crying"],
+                                      {"Mood": "CRYING loudly"})
+
+    def test_empty_scene_state(self):
+        assert not _match_scene_condition("mood", [], {})
+
+    def test_partial_keyword_match(self):
+        assert _match_scene_condition("voice", ["whisper"],
+                                      {"Voice": "barely whispering"})
+
+
+class TestSelectStyleWithSceneState:
+    def test_scene_items_included_when_matching(self):
+        ctx = {
+            "post_prompt": "",
+            "_style_pool": ["General A", "General B", "General C"],
+            "_scene_style_pool": [("restraints", "Show limitation", [])],
+            "scene_state": "Restraints: wrists bound\nMood: calm",
+            "messages": [],
+        }
+        select_style(ctx)
+        assert "Show limitation" in ctx["post_prompt"]
+        assert ctx["_matched_scene_styles"] == 1
+
+    def test_scene_items_excluded_when_not_matching(self):
+        ctx = {
+            "post_prompt": "",
+            "_style_pool": ["General A", "General B", "General C"],
+            "_scene_style_pool": [("restraints", "Show limitation", [])],
+            "scene_state": "Location: kitchen\nMood: calm",
+            "messages": [],
+        }
+        select_style(ctx)
+        assert "Show limitation" not in ctx["post_prompt"]
+        assert ctx["_matched_scene_styles"] == 0
+
+    def test_keyword_filtered_scene_items(self):
+        ctx = {
+            "post_prompt": "",
+            "_style_pool": ["Gen"],
+            "_scene_style_pool": [("mood", "Acute distress", ["grieving", "crying"])],
+            "scene_state": "Mood: Amber is grieving",
+            "messages": [],
+        }
+        select_style(ctx)
+        assert "Acute distress" in ctx["post_prompt"]
+
+    def test_keyword_filtered_scene_items_no_match(self):
+        ctx = {
+            "post_prompt": "",
+            "_style_pool": ["Gen"],
+            "_scene_style_pool": [("mood", "Acute distress", ["grieving", "crying"])],
+            "scene_state": "Mood: calm",
+            "messages": [],
+        }
+        select_style(ctx)
+        assert "Acute distress" not in ctx["post_prompt"]
+
+    def test_scene_items_added_alongside_general(self):
+        ctx = {
+            "post_prompt": "",
+            "_style_pool": ["Gen A", "Gen B", "Gen C", "Gen D"],
+            "_scene_style_pool": [("restraints", "Restraint rule", [])],
+            "scene_state": "Restraints: tied",
+            "messages": [],
+        }
+        select_style(ctx)
+        assert "Restraint rule" in ctx["post_prompt"]
+        general_count = sum(1 for g in ["Gen A", "Gen B", "Gen C", "Gen D"]
+                           if g in ctx["post_prompt"])
+        assert general_count == STYLE_ITEMS_PER_TURN
+
+    def test_no_scene_pool_works_like_before(self):
+        ctx = {
+            "post_prompt": "",
+            "_style_pool": ["A", "B", "C"],
+            "scene_state": "Restraints: tied",
+            "messages": [],
+        }
+        select_style(ctx)
+        assert "Voice and style:" in ctx["post_prompt"]
+
+    def test_empty_scene_state_no_scene_items(self):
+        ctx = {
+            "post_prompt": "",
+            "_style_pool": ["Gen"],
+            "_scene_style_pool": [("restraints", "Show it", [])],
+            "scene_state": "",
+            "messages": [],
+        }
+        select_style(ctx)
+        assert "Show it" not in ctx["post_prompt"]
+
+    def test_multiple_scene_items_can_match(self):
+        ctx = {
+            "post_prompt": "",
+            "_style_pool": ["Gen"],
+            "_scene_style_pool": [
+                ("restraints", "Restraint rule", []),
+                ("mood", "Mood rule", ["crying"]),
+                ("voice", "Voice rule", ["mute"]),
+            ],
+            "scene_state": "Restraints: bound\nMood: crying\nVoice: soft",
+            "messages": [],
+        }
+        select_style(ctx)
+        assert "Restraint rule" in ctx["post_prompt"]
+        assert "Mood rule" in ctx["post_prompt"]
+        assert "Voice rule" not in ctx["post_prompt"]
+        assert ctx["_matched_scene_styles"] == 2
 
 
 class TestExpandVariables:


### PR DESCRIPTION
## Summary

- Add `## scene-style` template section with condition-tagged style items (`[category]` or `[category=keyword1,keyword2]`)
- Scene-style items are injected **in addition to** the regular 3-per-turn rotation when the scene state matches their condition
- 5 conditional items: restraints, acute mood, nonverbal voice, nudity/undress, active physical contact
- Shorten the always-on restraint paragraph in `## post` (specific reinforcement moves to conditional `[restraints]` item)
- Track `_matched_scene_styles` count in ctx for budget debug JSON

## How it works

Scene state categories (Location, Clothing, Restraints, Position, Props, Mood, Voice) are parsed and matched against conditions on scene-style items:
- `[restraints]` → fires when Restraints category exists in scene state
- `[mood=grieving,crying,distressed]` → fires when Mood value contains any keyword

Matched items appear first in the "Voice and style" block, followed by the regular rotation.

## Test plan

```bash
cd /mnt/d/prg/plum-rp-scene-style
python3 -m pytest projects/rp/tests/test_pipeline.py -v

# Verify scene-style parsing
python3 -c "
from projects.rp.pipeline import _parse_scene_style_items, _match_scene_condition
items = _parse_scene_style_items('[restraints]\nShow limit\n---\n[mood=crying]\nDont soften')
print('Parsed:', items)
print('Match restraints:', _match_scene_condition('restraints', [], {'Restraints': 'wrists bound'}))
print('Match mood:', _match_scene_condition('mood', ['crying'], {'Mood': 'calm'}))
print('Match mood:', _match_scene_condition('mood', ['crying'], {'Mood': 'crying hard'}))
"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)