### PR TITLE
refactor(rp): extract prompt_builder.py and eval_routes.py from routes.py

### DIFF
--- a/projects/rp/eval_routes.py
+++ b/projects/rp/eval_routes.py
@@ -1,0 +1,211 @@
+"""Compare / A/B eval endpoints extracted from routes.py."""
+
+import asyncio
+import copy
+import logging
+from pathlib import Path
+from typing import Callable
+
+from fastapi import FastAPI, HTTPException
+
+from . import db
+from .models import CompareRequest, SelectCandidateRequest
+from .budget import BudgetError, allocate_injections
+from .research import research_dispatch
+from .fewshot import get_fewshot_messages
+from .prompt_builder import (
+    get_ai_name, get_user_name, get_ai_personality,
+    build_chat_messages, build_ollama_options, scale_num_predict,
+    budget_to_json, build_pipeline_ctx, budget_ctx,
+)
+from . import conv_log
+
+_log = logging.getLogger("rp.eval_routes")
+
+
+def setup_eval_routes(
+    app: FastAPI,
+    ollama,
+    pipeline,
+    resolve_model: Callable,
+    template_path: Path,
+    auto_update_scene_state: Callable,
+):
+    """Register compare/eval endpoints on the FastAPI app."""
+
+    async def _build_ctx(conv, messages):
+        return await build_pipeline_ctx(
+            conv, messages, pipeline=pipeline, template_path=template_path)
+
+    async def _budget(ctx, model, ollama_options):
+        return await budget_ctx(ctx, model, ollama_options, ollama=ollama)
+
+    @app.post("/rp/conversations/{conv_id}/compare")
+    async def compare_message(conv_id: int, req: CompareRequest):
+        conv = await db.get_conversation(conv_id)
+        if not conv:
+            raise HTTPException(404, "Conversation not found")
+
+        await db.add_message(conv_id, "user", req.content)
+        conv_log.log_response(conv_id, "user", req.content)
+
+        messages = await db.get_messages(conv_id)
+        next_seq = max((m["sequence"] for m in messages), default=0) + 1
+
+        eval_set = await db.create_eval_set(conv_id, next_seq)
+
+        base_ctx = await _build_ctx(conv, messages)
+        base_model = resolve_model(conv["model"])
+        scenario = base_ctx.get("scenario") or {}
+        settings = scenario.get("settings", {})
+        base_ollama_options = scale_num_predict(
+            build_ollama_options(settings), req.content)
+
+        research = await research_dispatch(ollama, req.content)
+        fewshot_msgs = await get_fewshot_messages(
+            ollama, base_ctx["messages"], card_id=conv["ai_card_id"],
+        )
+
+        alloc = await allocate_injections(
+            base_ctx, model=base_model, ollama=ollama,
+            num_predict=base_ollama_options.get("num_predict"),
+            research_text=research,
+            fewshot_msgs=fewshot_msgs if fewshot_msgs and base_ctx["messages"] else None,
+            model_ctx_override=base_ollama_options.get("num_ctx"),
+        )
+
+        if research and alloc.keep_research:
+            base_ctx["post_prompt"] = (
+                base_ctx.get("post_prompt", "")
+                + "\n\n[Research notes — weave these facts naturally if relevant, "
+                + "don't quote them verbatim or mention looking anything up]\n"
+                + research
+            )
+
+        if fewshot_msgs and base_ctx["messages"] and alloc.keep_fewshot:
+            base_ctx["messages"] = [base_ctx["messages"][0]] + fewshot_msgs + base_ctx["messages"][1:]
+
+        base_ctx["_injection_alloc"] = alloc
+
+        async def generate_candidate(cfg, candidate_row):
+            ctx = copy.deepcopy(base_ctx)
+            model = resolve_model(cfg.model) if cfg.model else base_model
+            ollama_options = dict(base_ollama_options)
+            if cfg.temperature is not None:
+                ollama_options["temperature"] = cfg.temperature
+            if cfg.num_predict is not None:
+                ollama_options["num_predict"] = cfg.num_predict
+
+            try:
+                await _budget(ctx, model, ollama_options)
+            except BudgetError as e:
+                await db.update_eval_candidate(
+                    candidate_row["id"],
+                    content=f"[budget error: {e}]",
+                )
+                return
+
+            ollama_options = {**ollama_options, "num_ctx": ctx["_num_ctx"]}
+            chat_messages = build_chat_messages(ctx)
+            user_name = get_user_name(ctx)
+
+            tokens = []
+            raw = {}
+            try:
+                async for chunk in ollama.chat_stream(
+                    model=model, messages=chat_messages,
+                    options=ollama_options, stop=[f"{user_name}:"],
+                ):
+                    if chunk.get("done"):
+                        raw = chunk
+                    elif not chunk.get("thinking"):
+                        tokens.append(chunk["token"])
+            except Exception as e:
+                await db.update_eval_candidate(
+                    candidate_row["id"],
+                    content=f"[generation error: {e}]",
+                )
+                return
+
+            response_text = "".join(tokens)
+            post_ctx = {"response": response_text, "ai_name": get_ai_name(ctx)}
+            post_ctx = await pipeline.run_post(post_ctx)
+            await db.update_eval_candidate(
+                candidate_row["id"],
+                content=post_ctx["response"],
+                raw_response=raw,
+                prompt_json=chat_messages,
+                budget_json=budget_to_json(ctx),
+            )
+
+        tasks = []
+        for cfg in req.configs:
+            label = cfg.label or cfg.model or "default"
+            model_name = cfg.model or conv["model"]
+            config_dict = cfg.model_dump(exclude_none=True)
+            candidate_row = await db.add_eval_candidate(
+                eval_set["id"], label, model_name, config_dict,
+            )
+            tasks.append(generate_candidate(cfg, candidate_row))
+
+        await asyncio.gather(*tasks)
+
+        candidates = await db.get_eval_candidates(eval_set["id"])
+        return {
+            "eval_set_id": eval_set["id"],
+            "conversation_id": conv_id,
+            "sequence": next_seq,
+            "candidates": candidates,
+        }
+
+    @app.post("/rp/eval-sets/{eval_set_id}/select")
+    async def select_candidate(eval_set_id: int, req: SelectCandidateRequest):
+        eval_set = await db.get_eval_set(eval_set_id)
+        if not eval_set:
+            raise HTTPException(404, "Eval set not found")
+
+        candidates = await db.get_eval_candidates(eval_set_id)
+        winner = next((c for c in candidates if c["id"] == req.candidate_id), None)
+        if not winner:
+            raise HTTPException(404, "Candidate not found in this eval set")
+
+        conv_id = eval_set["conversation_id"]
+        conv = await db.get_conversation(conv_id)
+
+        await db.add_message(
+            conv_id, "assistant", winner["content"],
+            raw_response=winner.get("raw_response"),
+            system_prompt=None,
+            scene_state=conv.get("scene_state", ""),
+            post_prompt=None,
+            budget_json=winner.get("budget_json"),
+            prompt_json=winner.get("prompt_json"),
+        )
+        await db.select_eval_candidate(eval_set_id, req.candidate_id)
+
+        asyncio.create_task(auto_update_scene_state(
+            conv_id, conv["model"],
+            get_ai_name({"ai_card": await db.get_card(conv["ai_card_id"])}),
+            get_user_name({"user_card": await db.get_card(conv["user_card_id"])}),
+            get_ai_personality({"ai_card": await db.get_card(conv["ai_card_id"])}),
+        ))
+
+        return {
+            "ok": True,
+            "eval_set_id": eval_set_id,
+            "selected_candidate_id": req.candidate_id,
+            "content": winner["content"],
+        }
+
+    @app.get("/rp/eval-sets/{eval_set_id}")
+    async def get_eval_set_detail(eval_set_id: int):
+        eval_set = await db.get_eval_set(eval_set_id)
+        if not eval_set:
+            raise HTTPException(404, "Eval set not found")
+        candidates = await db.get_eval_candidates(eval_set_id)
+        return {"eval_set": eval_set, "candidates": candidates}
+
+    @app.get("/rp/conversations/{conv_id}/eval-sets")
+    async def list_eval_sets(conv_id: int):
+        sets = await db.get_eval_sets_for_conversation(conv_id)
+        return sets

--- a/projects/rp/prompt_builder.py
+++ b/projects/rp/prompt_builder.py
@@ -1,0 +1,133 @@
+"""Prompt assembly and context budgeting extracted from routes.py.
+
+Pure functions for building chat messages, extracting card data, and
+preparing the pipeline context. Functions that need external services
+(db, ollama, pipeline) take them as explicit parameters.
+"""
+
+import logging
+from dataclasses import asdict
+from pathlib import Path
+
+from . import db
+from .budget import fit_prompt, BudgetError, BudgetReport
+from .context import get_strategy
+from .tokenizer import count_tokens
+
+_log = logging.getLogger("rp.prompt_builder")
+
+CHAT_DEFAULTS = {
+    "num_predict": 768,
+    "num_ctx": 16384,
+    "temperature": 1.05,
+    "repeat_penalty": 1.08,
+    "min_p": 0.1,
+}
+
+
+def get_ai_name(ctx: dict) -> str:
+    ai_data = ctx.get("ai_card", {}).get("card_data", {}).get(
+        "data", ctx.get("ai_card", {}).get("card_data", {}))
+    return ai_data.get("name", "Character")
+
+
+def get_user_name(ctx: dict) -> str:
+    user_data = ctx.get("user_card", {}).get("card_data", {}).get(
+        "data", ctx.get("user_card", {}).get("card_data", {}))
+    return user_data.get("name", "User")
+
+
+def get_ai_personality(ctx: dict) -> str:
+    ai_data = ctx.get("ai_card", {}).get("card_data", {}).get(
+        "data", ctx.get("ai_card", {}).get("card_data", {}))
+    return ai_data.get("description", "")
+
+
+def build_ollama_options(settings: dict) -> dict:
+    opts = dict(CHAT_DEFAULTS)
+    for k, v in settings.items():
+        if k not in ("max_context_tokens", "model"):
+            opts[k] = v
+    return opts
+
+
+def scale_num_predict(opts: dict, user_message: str) -> dict:
+    user_tokens = count_tokens(user_message)
+    scaled = max(256, min(1024, user_tokens * 2))
+    return {**opts, "num_predict": scaled}
+
+
+def build_chat_messages(ctx: dict) -> list[dict]:
+    chat_messages = [{"role": "system", "content": ctx["system_prompt"]}]
+    chat_messages.extend(ctx["messages"])
+    if ctx.get("post_prompt"):
+        chat_messages.append({"role": "system", "content": ctx["post_prompt"]})
+    ai_name = get_ai_name(ctx)
+    chat_messages.append({"role": "assistant", "content": ai_name + " "})
+    return chat_messages
+
+
+def budget_to_json(ctx: dict) -> dict | None:
+    report = ctx.get("_budget_report")
+    if not isinstance(report, BudgetReport):
+        return None
+    result = asdict(report)
+    alloc = ctx.get("_injection_alloc")
+    if alloc is not None:
+        result["injection"] = asdict(alloc)
+    return result
+
+
+async def build_pipeline_ctx(conv, messages, *, pipeline, template_path: Path):
+    """Load cards, scenario, template and run pipeline pre-hooks."""
+    user_card = await db.get_card(conv["user_card_id"])
+    ai_card = await db.get_card(conv["ai_card_id"])
+    scenario = await db.get_scenario(conv["scenario_id"]) if conv["scenario_id"] else {}
+    scenario = scenario or {}
+
+    prompt_template = ""
+    if template_path.exists():
+        prompt_template = template_path.read_text()
+
+    msg_dicts = []
+    for m in messages:
+        d = {"role": m["role"], "content": m["content"]}
+        d["_sequence"] = m.get("sequence", 0)
+        msg_dicts.append(d)
+
+    ctx = {
+        "user_card": user_card,
+        "ai_card": ai_card,
+        "scenario": scenario,
+        "messages": msg_dicts,
+        "system_prompt": "",
+        "post_prompt": "",
+        "scene_state": conv.get("scene_state", ""),
+        "prompt_template": prompt_template,
+    }
+
+    summary_row = await db.get_latest_summary(conv["id"])
+    if summary_row:
+        ctx["_summary"] = summary_row["summary"]
+        ctx["_summary_through_sequence"] = summary_row["through_sequence"]
+
+    return await pipeline.run_pre(ctx)
+
+
+async def budget_ctx(ctx, model, ollama_options, *, ollama):
+    """Run fit_prompt with SummaryBuffer strategy.
+
+    Raises BudgetError on failure — callers handle the response.
+    """
+    strategy = get_strategy("summary_buffer")
+    num_predict = ollama_options.get("num_predict")
+    try:
+        return await fit_prompt(
+            ctx, model=model, ollama=ollama,
+            strategy=strategy, num_predict=num_predict,
+            ground_truth=True,
+            model_ctx_override=ollama_options.get("num_ctx"),
+        )
+    except BudgetError as e:
+        _log.warning("Budget error for model=%s: %s", model, e)
+        raise

--- a/projects/rp/routes.py
+++ b/projects/rp/routes.py
@@ -16,14 +16,16 @@ from .models import (
     CompareRequest, SelectCandidateRequest,
 )
 from .pipeline import create_default_pipeline
-from dataclasses import asdict
-from .budget import fit_prompt, BudgetError, BudgetReport, allocate_injections
-from .context import get_strategy
-from .tokenizer import count_tokens
+from .budget import BudgetError, allocate_injections
 from .mcp_client import get_router as get_mcp_router
 from .research import research_dispatch
 from .fewshot import get_fewshot_messages
 from .summarize import maybe_generate_summary
+from .prompt_builder import (
+    get_ai_name, get_user_name, get_ai_personality,
+    build_chat_messages, build_ollama_options, scale_num_predict,
+    budget_to_json, build_pipeline_ctx, budget_ctx,
+)
 from . import conv_log
 
 # Priority levels from aiserver's inference queue (lower = higher priority).
@@ -36,17 +38,6 @@ _log = logging.getLogger(__name__)
 _ollama = None
 _pipeline = None
 _resolve_model = None
-
-
-def _budget_to_json(ctx: dict) -> dict | None:
-    report = ctx.get("_budget_report")
-    if not isinstance(report, BudgetReport):
-        return None
-    result = asdict(report)
-    alloc = ctx.get("_injection_alloc")
-    if alloc is not None:
-        result["injection"] = asdict(alloc)
-    return result
 
 
 async def init_mcp():
@@ -460,85 +451,14 @@ def setup(app: FastAPI, ollama, resolve_model=None):
 
     # -- Chat --
 
-    _chat_defaults = {"num_predict": 768, "num_ctx": 16384, "temperature": 1.05, "repeat_penalty": 1.08, "min_p": 0.1}
-
-    def _build_ollama_options(settings: dict) -> dict:
-        """Build ollama options from scenario settings with sensible defaults."""
-        opts = dict(_chat_defaults)
-        for k, v in settings.items():
-            if k not in ("max_context_tokens", "model"):
-                opts[k] = v
-        return opts
-
-    def _scale_num_predict(opts: dict, user_message: str) -> dict:
-        """Scale num_predict based on user message length to match response to beat."""
-        user_tokens = count_tokens(user_message)
-        scaled = max(256, min(1024, user_tokens * 2))
-        return {**opts, "num_predict": scaled}
-
     _template_path = Path(__file__).parent / "prompt.md"
 
     async def _build_pipeline_ctx(conv, messages):
-        """Load cards, scenario, template file and run pipeline pre-hooks."""
-        user_card = await db.get_card(conv["user_card_id"])
-        ai_card = await db.get_card(conv["ai_card_id"])
-        scenario = await db.get_scenario(conv["scenario_id"]) if conv["scenario_id"] else {}
-        scenario = scenario or {}
-
-        # Read prompt template from file (re-read each time so edits take effect)
-        prompt_template = ""
-        if _template_path.exists():
-            prompt_template = _template_path.read_text()
-
-        # Attach _sequence to each message so SummaryBuffer can filter
-        msg_dicts = []
-        for m in messages:
-            d = {"role": m["role"], "content": m["content"]}
-            d["_sequence"] = m.get("sequence", 0)
-            msg_dicts.append(d)
-
-        ctx = {
-            "user_card": user_card,
-            "ai_card": ai_card,
-            "scenario": scenario,
-            "messages": msg_dicts,
-            "system_prompt": "",
-            "post_prompt": "",
-            "scene_state": conv.get("scene_state", ""),
-            "prompt_template": prompt_template,
-        }
-
-        # Load latest summary for SummaryBuffer context strategy
-        summary_row = await db.get_latest_summary(conv["id"])
-        if summary_row:
-            ctx["_summary"] = summary_row["summary"]
-            ctx["_summary_through_sequence"] = summary_row["through_sequence"]
-
-        return await _pipeline.run_pre(ctx)
+        return await build_pipeline_ctx(
+            conv, messages, pipeline=_pipeline, template_path=_template_path)
 
     async def _budget_ctx(ctx, model, ollama_options):
-        """Run fit_prompt against ctx using SummaryBuffer strategy.
-
-        On BudgetError, logs a WARNING and re-raises — callers handle the
-        response (HTTP 413, stream error chunk, etc.).
-        """
-        strategy = get_strategy("summary_buffer")
-        num_predict = ollama_options.get("num_predict")
-        try:
-            return await fit_prompt(
-                ctx, model=model, ollama=_ollama,
-                strategy=strategy, num_predict=num_predict,
-                ground_truth=True,
-                model_ctx_override=ollama_options.get("num_ctx"),
-            )
-        except BudgetError as e:
-            _log.warning("Budget error for model=%s: %s", model, e)
-            raise
-
-    def _get_ai_name(ctx):
-        """Extract AI character name for response prefixing."""
-        ai_data = ctx.get("ai_card", {}).get("card_data", {}).get("data", ctx.get("ai_card", {}).get("card_data", {}))
-        return ai_data.get("name", "Character")
+        return await budget_ctx(ctx, model, ollama_options, ollama=_ollama)
 
     async def _maybe_summarize(conv_id: int, model: str,
                                ai_name: str, user_name: str, ai_personality: str):
@@ -658,27 +578,6 @@ def setup(app: FastAPI, ollama, resolve_model=None):
             clean = clean[len(char_name) + 1:].strip()
         return clean
 
-    def _build_chat_messages(ctx):
-        """Assemble the messages array for chat_stream()."""
-        chat_messages = [{"role": "system", "content": ctx["system_prompt"]}]
-        chat_messages.extend(ctx["messages"])
-        if ctx.get("post_prompt"):
-            chat_messages.append({"role": "system", "content": ctx["post_prompt"]})
-        # Add partial assistant message to anchor the model's voice
-        ai_name = _get_ai_name(ctx)
-        chat_messages.append({"role": "assistant", "content": ai_name + " "})
-        return chat_messages
-
-    def _get_user_name(ctx):
-        """Extract user character name for stop sequences."""
-        user_data = ctx.get("user_card", {}).get("card_data", {}).get("data", ctx.get("user_card", {}).get("card_data", {}))
-        return user_data.get("name", "User")
-
-    def _get_ai_personality(ctx):
-        """Extract AI character personality description."""
-        ai_data = ctx.get("ai_card", {}).get("card_data", {}).get("data", ctx.get("ai_card", {}).get("card_data", {}))
-        return ai_data.get("description", "")
-
     _log = logging.getLogger("rp.routes")
 
     _scene_state_model = "q36"
@@ -792,8 +691,8 @@ def setup(app: FastAPI, ollama, resolve_model=None):
         model = _resolve_model(conv["model"])
         scenario = ctx.get("scenario") or {}
         settings = scenario.get("settings", {})
-        ollama_options = _scale_num_predict(
-            _build_ollama_options(settings), req.content)
+        ollama_options = scale_num_predict(
+            build_ollama_options(settings), req.content)
 
         # Gather optional injections (research + fewshot)
         research = await research_dispatch(_ollama, req.content)
@@ -844,8 +743,8 @@ def setup(app: FastAPI, ollama, resolve_model=None):
         # Tell Ollama to load the model with its real context window
         ollama_options = {**ollama_options, "num_ctx": ctx["_num_ctx"]}
 
-        chat_messages = _build_chat_messages(ctx)
-        user_name = _get_user_name(ctx)
+        chat_messages = build_chat_messages(ctx)
+        user_name = get_user_name(ctx)
         conv_log.log_prompt(conv_id, "send_message", model,
                             ctx["system_prompt"], ctx.get("post_prompt", ""),
                             ctx["messages"], ollama_options)
@@ -909,22 +808,22 @@ def setup(app: FastAPI, ollama, resolve_model=None):
                 cur_messages.append({"role": "user", "content": "\n".join(tool_results) + "\n\nContinue your response naturally, incorporating the information above. Do not use [TOOL:] again for the same query."})
 
             try:
-                post_ctx = {"response": final_text, "ai_name": _get_ai_name(ctx)}
+                post_ctx = {"response": final_text, "ai_name": get_ai_name(ctx)}
                 post_ctx = await _pipeline.run_post(post_ctx)
                 await db.add_message(
                     conv_id, "assistant", post_ctx["response"], raw_response=raw,
                     system_prompt=ctx.get("system_prompt", ""),
                     scene_state=conv.get("scene_state", ""),
                     post_prompt=ctx.get("post_prompt", ""),
-                    budget_json=_budget_to_json(ctx),
+                    budget_json=budget_to_json(ctx),
                     prompt_json=chat_messages,
                 )
                 conv_log.log_response(conv_id, "assistant", post_ctx["response"], raw)
                 # Update scene state and maybe generate summary in background
                 asyncio.create_task(_auto_update_scene_state(conv_id, model,
-                                                _get_ai_name(ctx), _get_user_name(ctx), _get_ai_personality(ctx)))
+                                                get_ai_name(ctx), get_user_name(ctx), get_ai_personality(ctx)))
                 asyncio.create_task(_maybe_summarize(conv_id, model,
-                                                _get_ai_name(ctx), _get_user_name(ctx), _get_ai_personality(ctx)))
+                                                get_ai_name(ctx), get_user_name(ctx), get_ai_personality(ctx)))
             except Exception as e:
                 yield json.dumps({"error": f"Failed to save response: {e}", "done": True}) + "\n"
 
@@ -972,7 +871,7 @@ def setup(app: FastAPI, ollama, resolve_model=None):
         model = _resolve_model(conv["model"])
         scenario = ctx.get("scenario") or {}
         settings = scenario.get("settings", {})
-        ollama_options = _build_ollama_options(settings)
+        ollama_options = build_ollama_options(settings)
 
         try:
             await _budget_ctx(ctx, model, ollama_options)
@@ -991,8 +890,8 @@ def setup(app: FastAPI, ollama, resolve_model=None):
         # Tell Ollama to load the model with its real context window
         ollama_options = {**ollama_options, "num_ctx": ctx["_num_ctx"]}
 
-        chat_messages = _build_chat_messages(ctx)
-        user_name = _get_user_name(ctx)
+        chat_messages = build_chat_messages(ctx)
+        user_name = get_user_name(ctx)
         conv_log.log_prompt(conv_id, "regenerate", model,
                             ctx["system_prompt"], ctx.get("post_prompt", ""),
                             ctx["messages"], ollama_options)
@@ -1025,22 +924,22 @@ def setup(app: FastAPI, ollama, resolve_model=None):
                 return
             try:
                 response_text = "".join(tokens)
-                post_ctx = {"response": response_text, "ai_name": _get_ai_name(ctx)}
+                post_ctx = {"response": response_text, "ai_name": get_ai_name(ctx)}
                 post_ctx = await _pipeline.run_post(post_ctx)
                 await db.add_message(
                     conv_id, "assistant", post_ctx["response"], raw_response=raw,
                     system_prompt=ctx.get("system_prompt", ""),
                     scene_state=conv.get("scene_state", ""),
                     post_prompt=ctx.get("post_prompt", ""),
-                    budget_json=_budget_to_json(ctx),
+                    budget_json=budget_to_json(ctx),
                     prompt_json=chat_messages,
                 )
                 conv_log.log_response(conv_id, "assistant", post_ctx["response"], raw)
                 # Update scene state and maybe generate summary in background
                 asyncio.create_task(_auto_update_scene_state(conv_id, model,
-                                                _get_ai_name(ctx), _get_user_name(ctx), _get_ai_personality(ctx)))
+                                                get_ai_name(ctx), get_user_name(ctx), get_ai_personality(ctx)))
                 asyncio.create_task(_maybe_summarize(conv_id, model,
-                                                _get_ai_name(ctx), _get_user_name(ctx), _get_ai_personality(ctx)))
+                                                get_ai_name(ctx), get_user_name(ctx), get_ai_personality(ctx)))
             except Exception as e:
                 yield json.dumps({"error": f"Failed to save response: {e}", "done": True}) + "\n"
 
@@ -1058,7 +957,7 @@ def setup(app: FastAPI, ollama, resolve_model=None):
         model = _resolve_model(conv["model"])
         scenario = ctx.get("scenario") or {}
         settings = scenario.get("settings", {})
-        ollama_options = _build_ollama_options(settings)
+        ollama_options = build_ollama_options(settings)
 
         try:
             await _budget_ctx(ctx, model, ollama_options)
@@ -1077,8 +976,8 @@ def setup(app: FastAPI, ollama, resolve_model=None):
         # Tell Ollama to load the model with its real context window
         ollama_options = {**ollama_options, "num_ctx": ctx["_num_ctx"]}
 
-        chat_messages = _build_chat_messages(ctx)
-        user_name = _get_user_name(ctx)
+        chat_messages = build_chat_messages(ctx)
+        user_name = get_user_name(ctx)
         conv_log.log_prompt(conv_id, "continue", model,
                             ctx["system_prompt"], ctx.get("post_prompt", ""),
                             ctx["messages"], ollama_options)
@@ -1111,22 +1010,22 @@ def setup(app: FastAPI, ollama, resolve_model=None):
                 return
             try:
                 response_text = "".join(tokens)
-                post_ctx = {"response": response_text, "ai_name": _get_ai_name(ctx)}
+                post_ctx = {"response": response_text, "ai_name": get_ai_name(ctx)}
                 post_ctx = await _pipeline.run_post(post_ctx)
                 await db.add_message(
                     conv_id, "assistant", post_ctx["response"], raw_response=raw,
                     system_prompt=ctx.get("system_prompt", ""),
                     scene_state=conv.get("scene_state", ""),
                     post_prompt=ctx.get("post_prompt", ""),
-                    budget_json=_budget_to_json(ctx),
+                    budget_json=budget_to_json(ctx),
                     prompt_json=chat_messages,
                 )
                 conv_log.log_response(conv_id, "assistant", post_ctx["response"], raw)
                 # Update scene state and maybe generate summary in background
                 asyncio.create_task(_auto_update_scene_state(conv_id, model,
-                                                _get_ai_name(ctx), _get_user_name(ctx), _get_ai_personality(ctx)))
+                                                get_ai_name(ctx), get_user_name(ctx), get_ai_personality(ctx)))
                 asyncio.create_task(_maybe_summarize(conv_id, model,
-                                                _get_ai_name(ctx), _get_user_name(ctx), _get_ai_personality(ctx)))
+                                                get_ai_name(ctx), get_user_name(ctx), get_ai_personality(ctx)))
             except Exception as e:
                 yield json.dumps({"error": f"Failed to save response: {e}", "done": True}) + "\n"
 
@@ -1188,7 +1087,7 @@ def setup(app: FastAPI, ollama, resolve_model=None):
             model = _resolve_model(conv["model"])
         scenario = ctx.get("scenario") or {}
         settings = scenario.get("settings", {})
-        ollama_options = _build_ollama_options(settings)
+        ollama_options = build_ollama_options(settings)
         if generating_as_user:
             # Instruct model: lower temperature, no thinking
             ollama_options = {"temperature": 0.7, "num_predict": 256, "think": False}
@@ -1210,8 +1109,8 @@ def setup(app: FastAPI, ollama, resolve_model=None):
         # Tell Ollama to load the model with its real context window
         ollama_options = {**ollama_options, "num_ctx": ctx["_num_ctx"]}
 
-        chat_messages = _build_chat_messages(ctx)
-        user_name = _get_user_name(ctx)
+        chat_messages = build_chat_messages(ctx)
+        user_name = get_user_name(ctx)
         conv_log.log_prompt(conv_id, "auto_reply", model,
                             ctx["system_prompt"], ctx.get("post_prompt", ""),
                             ctx["messages"], ollama_options)
@@ -1246,22 +1145,22 @@ def setup(app: FastAPI, ollama, resolve_model=None):
 
             try:
                 response_text = "".join(tokens)
-                post_ctx = {"response": response_text, "ai_name": _get_ai_name(ctx)}
+                post_ctx = {"response": response_text, "ai_name": get_ai_name(ctx)}
                 post_ctx = await _pipeline.run_post(post_ctx)
                 await db.add_message(
                     conv_id, save_role, post_ctx["response"], raw_response=raw,
                     system_prompt=ctx.get("system_prompt", ""),
                     scene_state=conv.get("scene_state", ""),
                     post_prompt=ctx.get("post_prompt", ""),
-                    budget_json=_budget_to_json(ctx),
+                    budget_json=budget_to_json(ctx),
                     prompt_json=chat_messages,
                 )
                 conv_log.log_response(conv_id, save_role, post_ctx["response"], raw)
                 # Update scene state and maybe generate summary in background
                 asyncio.create_task(_auto_update_scene_state(conv_id, model,
-                                                _get_ai_name(ctx), _get_user_name(ctx), _get_ai_personality(ctx)))
+                                                get_ai_name(ctx), get_user_name(ctx), get_ai_personality(ctx)))
                 asyncio.create_task(_maybe_summarize(conv_id, model,
-                                                _get_ai_name(ctx), _get_user_name(ctx), _get_ai_personality(ctx)))
+                                                get_ai_name(ctx), get_user_name(ctx), get_ai_personality(ctx)))
             except Exception as e:
                 yield json.dumps({"error": f"Failed to save response: {e}", "done": True}) + "\n"
 
@@ -1287,8 +1186,8 @@ def setup(app: FastAPI, ollama, resolve_model=None):
         base_model = _resolve_model(conv["model"])
         scenario = base_ctx.get("scenario") or {}
         settings = scenario.get("settings", {})
-        base_ollama_options = _scale_num_predict(
-            _build_ollama_options(settings), req.content)
+        base_ollama_options = scale_num_predict(
+            build_ollama_options(settings), req.content)
 
         research = await research_dispatch(_ollama, req.content)
         fewshot_msgs = await get_fewshot_messages(
@@ -1335,8 +1234,8 @@ def setup(app: FastAPI, ollama, resolve_model=None):
                 return
 
             ollama_options = {**ollama_options, "num_ctx": ctx["_num_ctx"]}
-            chat_messages = _build_chat_messages(ctx)
-            user_name = _get_user_name(ctx)
+            chat_messages = build_chat_messages(ctx)
+            user_name = get_user_name(ctx)
 
             tokens = []
             raw = {}
@@ -1357,14 +1256,14 @@ def setup(app: FastAPI, ollama, resolve_model=None):
                 return
 
             response_text = "".join(tokens)
-            post_ctx = {"response": response_text, "ai_name": _get_ai_name(ctx)}
+            post_ctx = {"response": response_text, "ai_name": get_ai_name(ctx)}
             post_ctx = await _pipeline.run_post(post_ctx)
             await db.update_eval_candidate(
                 candidate_row["id"],
                 content=post_ctx["response"],
                 raw_response=raw,
                 prompt_json=chat_messages,
-                budget_json=_budget_to_json(ctx),
+                budget_json=budget_to_json(ctx),
             )
 
         # Create candidate rows first, then generate in parallel
@@ -1415,9 +1314,9 @@ def setup(app: FastAPI, ollama, resolve_model=None):
 
         asyncio.create_task(_auto_update_scene_state(
             conv_id, conv["model"],
-            _get_ai_name({"ai_card": await db.get_card(conv["ai_card_id"])}),
-            _get_user_name({"user_card": await db.get_card(conv["user_card_id"])}),
-            _get_ai_personality({"ai_card": await db.get_card(conv["ai_card_id"])}),
+            get_ai_name({"ai_card": await db.get_card(conv["ai_card_id"])}),
+            get_user_name({"user_card": await db.get_card(conv["user_card_id"])}),
+            get_ai_personality({"ai_card": await db.get_card(conv["ai_card_id"])}),
         ))
 
         return {

--- a/projects/rp/routes.py
+++ b/projects/rp/routes.py
@@ -1,5 +1,4 @@
 import asyncio
-import copy
 import json
 import logging
 from fastapi import FastAPI, UploadFile, File, HTTPException, Request
@@ -13,7 +12,6 @@ from .models import (
     CardCreate, CardResponse, ScenarioCreate, ScenarioResponse,
     ConversationCreate, ConversationResponse, ConversationDetailResponse,
     MessageResponse, SendMessageRequest, EditMessageRequest, SceneStateRequest,
-    CompareRequest, SelectCandidateRequest,
 )
 from .pipeline import create_default_pipeline
 from .budget import BudgetError, allocate_injections
@@ -1167,177 +1165,11 @@ def setup(app: FastAPI, ollama, resolve_model=None):
         return StreamingResponse(stream(), media_type="application/x-ndjson")
 
     # -- Compare (A/B eval) --
-
-    @app.post("/rp/conversations/{conv_id}/compare")
-    async def compare_message(conv_id: int, req: CompareRequest):
-        conv = await db.get_conversation(conv_id)
-        if not conv:
-            raise HTTPException(404, "Conversation not found")
-
-        await db.add_message(conv_id, "user", req.content)
-        conv_log.log_response(conv_id, "user", req.content)
-
-        messages = await db.get_messages(conv_id)
-        next_seq = max((m["sequence"] for m in messages), default=0) + 1
-
-        eval_set = await db.create_eval_set(conv_id, next_seq)
-
-        base_ctx = await _build_pipeline_ctx(conv, messages)
-        base_model = _resolve_model(conv["model"])
-        scenario = base_ctx.get("scenario") or {}
-        settings = scenario.get("settings", {})
-        base_ollama_options = scale_num_predict(
-            build_ollama_options(settings), req.content)
-
-        research = await research_dispatch(_ollama, req.content)
-        fewshot_msgs = await get_fewshot_messages(
-            _ollama, base_ctx["messages"], card_id=conv["ai_card_id"],
-        )
-
-        alloc = await allocate_injections(
-            base_ctx, model=base_model, ollama=_ollama,
-            num_predict=base_ollama_options.get("num_predict"),
-            research_text=research,
-            fewshot_msgs=fewshot_msgs if fewshot_msgs and base_ctx["messages"] else None,
-            model_ctx_override=base_ollama_options.get("num_ctx"),
-        )
-
-        if research and alloc.keep_research:
-            base_ctx["post_prompt"] = (
-                base_ctx.get("post_prompt", "")
-                + "\n\n[Research notes — weave these facts naturally if relevant, "
-                + "don't quote them verbatim or mention looking anything up]\n"
-                + research
-            )
-
-        if fewshot_msgs and base_ctx["messages"] and alloc.keep_fewshot:
-            base_ctx["messages"] = [base_ctx["messages"][0]] + fewshot_msgs + base_ctx["messages"][1:]
-
-        base_ctx["_injection_alloc"] = alloc
-
-        async def generate_candidate(cfg, candidate_row):
-            ctx = copy.deepcopy(base_ctx)
-            model = _resolve_model(cfg.model) if cfg.model else base_model
-            ollama_options = dict(base_ollama_options)
-            if cfg.temperature is not None:
-                ollama_options["temperature"] = cfg.temperature
-            if cfg.num_predict is not None:
-                ollama_options["num_predict"] = cfg.num_predict
-
-            try:
-                await _budget_ctx(ctx, model, ollama_options)
-            except BudgetError as e:
-                await db.update_eval_candidate(
-                    candidate_row["id"],
-                    content=f"[budget error: {e}]",
-                )
-                return
-
-            ollama_options = {**ollama_options, "num_ctx": ctx["_num_ctx"]}
-            chat_messages = build_chat_messages(ctx)
-            user_name = get_user_name(ctx)
-
-            tokens = []
-            raw = {}
-            try:
-                async for chunk in _ollama.chat_stream(
-                    model=model, messages=chat_messages,
-                    options=ollama_options, stop=[f"{user_name}:"],
-                ):
-                    if chunk.get("done"):
-                        raw = chunk
-                    elif not chunk.get("thinking"):
-                        tokens.append(chunk["token"])
-            except Exception as e:
-                await db.update_eval_candidate(
-                    candidate_row["id"],
-                    content=f"[generation error: {e}]",
-                )
-                return
-
-            response_text = "".join(tokens)
-            post_ctx = {"response": response_text, "ai_name": get_ai_name(ctx)}
-            post_ctx = await _pipeline.run_post(post_ctx)
-            await db.update_eval_candidate(
-                candidate_row["id"],
-                content=post_ctx["response"],
-                raw_response=raw,
-                prompt_json=chat_messages,
-                budget_json=budget_to_json(ctx),
-            )
-
-        # Create candidate rows first, then generate in parallel
-        tasks = []
-        for cfg in req.configs:
-            label = cfg.label or cfg.model or "default"
-            model_name = cfg.model or conv["model"]
-            config_dict = cfg.model_dump(exclude_none=True)
-            candidate_row = await db.add_eval_candidate(
-                eval_set["id"], label, model_name, config_dict,
-            )
-            tasks.append(generate_candidate(cfg, candidate_row))
-
-        await asyncio.gather(*tasks)
-
-        candidates = await db.get_eval_candidates(eval_set["id"])
-        return {
-            "eval_set_id": eval_set["id"],
-            "conversation_id": conv_id,
-            "sequence": next_seq,
-            "candidates": candidates,
-        }
-
-    @app.post("/rp/eval-sets/{eval_set_id}/select")
-    async def select_candidate(eval_set_id: int, req: SelectCandidateRequest):
-        eval_set = await db.get_eval_set(eval_set_id)
-        if not eval_set:
-            raise HTTPException(404, "Eval set not found")
-
-        candidates = await db.get_eval_candidates(eval_set_id)
-        winner = next((c for c in candidates if c["id"] == req.candidate_id), None)
-        if not winner:
-            raise HTTPException(404, "Candidate not found in this eval set")
-
-        conv_id = eval_set["conversation_id"]
-        conv = await db.get_conversation(conv_id)
-
-        await db.add_message(
-            conv_id, "assistant", winner["content"],
-            raw_response=winner.get("raw_response"),
-            system_prompt=None,
-            scene_state=conv.get("scene_state", ""),
-            post_prompt=None,
-            budget_json=winner.get("budget_json"),
-            prompt_json=winner.get("prompt_json"),
-        )
-        await db.select_eval_candidate(eval_set_id, req.candidate_id)
-
-        asyncio.create_task(_auto_update_scene_state(
-            conv_id, conv["model"],
-            get_ai_name({"ai_card": await db.get_card(conv["ai_card_id"])}),
-            get_user_name({"user_card": await db.get_card(conv["user_card_id"])}),
-            get_ai_personality({"ai_card": await db.get_card(conv["ai_card_id"])}),
-        ))
-
-        return {
-            "ok": True,
-            "eval_set_id": eval_set_id,
-            "selected_candidate_id": req.candidate_id,
-            "content": winner["content"],
-        }
-
-    @app.get("/rp/eval-sets/{eval_set_id}")
-    async def get_eval_set_detail(eval_set_id: int):
-        eval_set = await db.get_eval_set(eval_set_id)
-        if not eval_set:
-            raise HTTPException(404, "Eval set not found")
-        candidates = await db.get_eval_candidates(eval_set_id)
-        return {"eval_set": eval_set, "candidates": candidates}
-
-    @app.get("/rp/conversations/{conv_id}/eval-sets")
-    async def list_eval_sets(conv_id: int):
-        sets = await db.get_eval_sets_for_conversation(conv_id)
-        return sets
+    from .eval_routes import setup_eval_routes
+    setup_eval_routes(
+        app, _ollama, _pipeline, _resolve_model, _template_path,
+        _auto_update_scene_state,
+    )
 
     # -- Static files --
     static_dir = Path(__file__).parent / "static"

--- a/projects/rp/tests/test_prompt_builder.py
+++ b/projects/rp/tests/test_prompt_builder.py
@@ -1,0 +1,118 @@
+from projects.rp.prompt_builder import (
+    get_ai_name, get_user_name, get_ai_personality,
+    build_chat_messages, build_ollama_options, scale_num_predict,
+    budget_to_json, CHAT_DEFAULTS,
+)
+
+
+def _card(name="Char", description="", personality=""):
+    return {"card_data": {"data": {
+        "name": name, "description": description, "personality": personality,
+    }}}
+
+
+def _ctx(ai_name="Char", user_name="User", ai_desc="", messages=None):
+    return {
+        "ai_card": _card(ai_name, description=ai_desc),
+        "user_card": _card(user_name),
+        "system_prompt": "System prompt",
+        "post_prompt": "Post prompt",
+        "messages": messages or [],
+    }
+
+
+class TestGetAiName:
+    def test_extracts_name(self):
+        assert get_ai_name(_ctx(ai_name="Jessica")) == "Jessica"
+
+    def test_default(self):
+        assert get_ai_name({}) == "Character"
+
+    def test_flat_card_data(self):
+        ctx = {"ai_card": {"card_data": {"name": "Sol"}}}
+        assert get_ai_name(ctx) == "Sol"
+
+
+class TestGetUserName:
+    def test_extracts_name(self):
+        assert get_user_name(_ctx(user_name="Val")) == "Val"
+
+    def test_default(self):
+        assert get_user_name({}) == "User"
+
+
+class TestGetAiPersonality:
+    def test_extracts_description(self):
+        assert get_ai_personality(_ctx(ai_desc="A painter")) == "A painter"
+
+    def test_default(self):
+        assert get_ai_personality({}) == ""
+
+
+class TestBuildChatMessages:
+    def test_structure(self):
+        ctx = _ctx(ai_name="Jess", messages=[
+            {"role": "user", "content": "Hi"},
+            {"role": "assistant", "content": "Hello"},
+        ])
+        msgs = build_chat_messages(ctx)
+        assert msgs[0] == {"role": "system", "content": "System prompt"}
+        assert msgs[1] == {"role": "user", "content": "Hi"}
+        assert msgs[2] == {"role": "assistant", "content": "Hello"}
+        assert msgs[3] == {"role": "system", "content": "Post prompt"}
+        assert msgs[4] == {"role": "assistant", "content": "Jess "}
+
+    def test_no_post_prompt(self):
+        ctx = _ctx(ai_name="Jess")
+        ctx["post_prompt"] = ""
+        msgs = build_chat_messages(ctx)
+        assert len(msgs) == 2
+        assert msgs[-1]["content"] == "Jess "
+
+    def test_empty_messages(self):
+        msgs = build_chat_messages(_ctx())
+        assert msgs[0]["role"] == "system"
+        assert msgs[-1]["role"] == "assistant"
+
+
+class TestBuildOllamaOptions:
+    def test_defaults(self):
+        opts = build_ollama_options({})
+        assert opts == CHAT_DEFAULTS
+
+    def test_overrides(self):
+        opts = build_ollama_options({"temperature": 0.5})
+        assert opts["temperature"] == 0.5
+        assert opts["num_predict"] == CHAT_DEFAULTS["num_predict"]
+
+    def test_ignores_model_key(self):
+        opts = build_ollama_options({"model": "something", "temperature": 0.8})
+        assert "model" not in opts
+        assert opts["temperature"] == 0.8
+
+    def test_ignores_max_context_tokens(self):
+        opts = build_ollama_options({"max_context_tokens": 4096})
+        assert "max_context_tokens" not in opts
+
+
+class TestScaleNumPredict:
+    def test_short_message(self):
+        opts = scale_num_predict({"num_predict": 768}, "hi")
+        assert opts["num_predict"] == 256
+
+    def test_long_message(self):
+        long_msg = "word " * 600
+        opts = scale_num_predict({"num_predict": 768}, long_msg)
+        assert opts["num_predict"] == 1024
+
+    def test_preserves_other_keys(self):
+        opts = scale_num_predict({"num_predict": 768, "temperature": 0.8}, "hello")
+        assert opts["temperature"] == 0.8
+
+
+class TestBudgetToJson:
+    def test_no_report(self):
+        assert budget_to_json({}) is None
+
+    def test_non_report_value(self):
+        assert budget_to_json({"_budget_report": "not a report"}) is None


### PR DESCRIPTION
## Summary

- Extract 9 prompt-building functions from routes.py into new `prompt_builder.py` module
- Pure functions (`get_ai_name`, `build_chat_messages`, `build_ollama_options`, etc.) move directly
- Functions with external deps (`build_pipeline_ctx`, `budget_ctx`) take deps as explicit parameters instead of closure capture
- Extract 4 compare/eval endpoints into new `eval_routes.py` module with `setup_eval_routes()` entry point
- Routes.py drops from 1446 to ~1175 lines (~270 lines extracted total)
- 19 new tests for the prompt builder module, 326 total pass

## Test plan

```bash
cd /mnt/d/prg/plum-rp-prompt-builder
python3 -m pytest projects/rp/tests/ -v
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)