### PR TITLE
feat(rp): assistant-only fewshot embedding and voice drift gating

### DIFF
--- a/projects/rp/fewshot.py
+++ b/projects/rp/fewshot.py
@@ -1,15 +1,41 @@
 import logging
 
 from . import db
+from .lora_curate import _count_stock_phrases, _trigram_overlap
 
 _log = logging.getLogger(__name__)
 
 EMBED_MODEL = "nomic-embed-text"
 
+DRIFT_STOCK_THRESHOLD = 1
+DRIFT_OVERLAP_THRESHOLD = 0.25
+
+
+def voice_is_drifting(messages: list[dict]) -> bool:
+    """Check whether recent assistant messages show voice quality degradation.
+
+    Returns True (inject fewshot) when stock phrases or self-repetition appear,
+    False (skip fewshot) when the voice is strong.
+    """
+    recent = [m["content"] for m in messages if m["role"] == "assistant"][-3:]
+    if len(recent) < 3:
+        return True
+
+    latest = recent[-1]
+    if _count_stock_phrases(latest) >= DRIFT_STOCK_THRESHOLD:
+        return True
+    if _trigram_overlap(latest, recent[:-1]) > DRIFT_OVERLAP_THRESHOLD:
+        return True
+    return False
+
 
 async def get_fewshot_messages(ollama, messages: list[dict],
                                card_id: int | None = None) -> list[dict]:
-    """Retrieve few-shot example messages based on vector similarity to the current conversation.
+    """Retrieve few-shot examples by writing-style similarity.
+
+    Embeds the last assistant message only (not user+assistant) so vector
+    similarity matches writing voice rather than scene topic.  Skips
+    retrieval entirely when recent messages show strong, consistent voice.
 
     Returns a flat list of alternating user/assistant message dicts, or [] on
     any failure (never blocks RP generation).
@@ -18,19 +44,17 @@ async def get_fewshot_messages(ollama, messages: list[dict],
         if len(messages) < 2 or card_id is None:
             return []
 
-        last_user = next(
-            (m["content"] for m in reversed(messages) if m["role"] == "user"), None
-        )
+        if not voice_is_drifting(messages):
+            _log.debug("Voice is strong — skipping fewshot injection")
+            return []
+
         last_assistant = next(
             (m["content"] for m in reversed(messages) if m["role"] == "assistant"), None
         )
-
-        if last_user is None or last_assistant is None:
+        if last_assistant is None:
             return []
 
-        scene_summary = f"{last_user}\n{last_assistant}"
-
-        embedding = await ollama.embed(EMBED_MODEL, scene_summary)
+        embedding = await ollama.embed(EMBED_MODEL, last_assistant)
 
         examples = await db.search_fewshot_examples(embedding, card_id, limit=2)
 

--- a/projects/rp/generate_examples.py
+++ b/projects/rp/generate_examples.py
@@ -271,6 +271,28 @@ async def deactivate_generic_examples(pool: asyncpg.Pool) -> int:
     return int(result.split()[-1])
 
 
+async def re_embed_examples(
+    pool: asyncpg.Pool, card_id: int, ollama_url: str,
+) -> None:
+    """Re-embed all active examples for a card using assistant-only text."""
+    rows = await pool.fetch(
+        "SELECT id, assistant_message FROM rp_fewshot_examples "
+        "WHERE card_id = $1 AND active = TRUE ORDER BY id",
+        card_id,
+    )
+    print(f"Re-embedding {len(rows)} examples with assistant-only text...")
+    async with httpx.AsyncClient() as client:
+        for i, row in enumerate(rows):
+            embedding = await embed_text(client, ollama_url, row["assistant_message"])
+            embedding_str = "[" + ",".join(str(f) for f in embedding) + "]"
+            await pool.execute(
+                "UPDATE rp_fewshot_examples SET embedding = $1::vector WHERE id = $2",
+                embedding_str, row["id"],
+            )
+            print(f"  [{i + 1}/{len(rows)}] id={row['id']}")
+    print("Done.")
+
+
 async def main() -> None:
     parser = argparse.ArgumentParser(
         description="Mine real conversations to generate per-card fewshot examples"
@@ -308,6 +330,10 @@ async def main() -> None:
         "--deactivate-generic", action="store_true",
         help="Deactivate card-agnostic (card_id=NULL) examples",
     )
+    parser.add_argument(
+        "--re-embed", action="store_true",
+        help="Re-embed existing examples with assistant-only text (no regeneration)",
+    )
     args = parser.parse_args()
     args.ollama_url = resolve_url(args.ollama_url)
 
@@ -344,6 +370,10 @@ async def main() -> None:
         if args.deactivate_old:
             n = await deactivate_old_examples(pool, args.card_id)
             print(f"Deactivated {n} existing examples for {char_name}")
+
+        if args.re_embed:
+            await re_embed_examples(pool, args.card_id, args.ollama_url)
+            return
 
         pairs = await get_conversation_pairs(
             pool, args.card_id, limit=0
@@ -443,7 +473,6 @@ async def main() -> None:
                     remaining = len(pairs) - (i + 1)
                     eta_mins = (avg_secs * remaining) / 60
 
-                    # Scene context for the embedding: user message + response
                     scene_context = (
                         pair["user_message"] + "\n" + response
                     )
@@ -452,7 +481,7 @@ async def main() -> None:
                     ) // 4
 
                     embedding = await embed_text(
-                        client, args.ollama_url, scene_context
+                        client, args.ollama_url, response
                     )
 
                     row_id = await insert_example(

--- a/projects/rp/tests/test_fewshot.py
+++ b/projects/rp/tests/test_fewshot.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from projects.aiserver.ollama import OllamaClient, OllamaError
 import projects.rp.db as db
-from projects.rp.fewshot import get_fewshot_messages
+from projects.rp.fewshot import get_fewshot_messages, voice_is_drifting
 
 
 def test_embed_returns_vector():
@@ -229,6 +229,70 @@ def test_count_fewshot_examples_zero():
     assert result == 0
 
 
+# -- voice_is_drifting --
+
+
+class TestVoiceIsDrifting:
+    def test_fewer_than_three_messages_assumes_drift(self):
+        msgs = [
+            {"role": "user", "content": "Hi"},
+            {"role": "assistant", "content": "Hello there"},
+        ]
+        assert voice_is_drifting(msgs) is True
+
+    def test_no_assistant_messages_assumes_drift(self):
+        msgs = [
+            {"role": "user", "content": "Hi"},
+            {"role": "user", "content": "Hello"},
+        ]
+        assert voice_is_drifting(msgs) is True
+
+    def test_clean_voice_returns_false(self):
+        msgs = [
+            {"role": "user", "content": "What are you doing?"},
+            {"role": "assistant", "content": "She glanced up from the workbench, wiping grease from her fingers."},
+            {"role": "user", "content": "Can I help?"},
+            {"role": "assistant", "content": "A small smile tugged at her lips as she handed over the wrench."},
+            {"role": "user", "content": "Like this?"},
+            {"role": "assistant", "content": "She watched his clumsy grip and stepped closer to adjust his hold."},
+        ]
+        assert voice_is_drifting(msgs) is False
+
+    def test_stock_phrase_triggers_drift(self):
+        msgs = [
+            {"role": "user", "content": "What happened?"},
+            {"role": "assistant", "content": "She looked away, uncertain."},
+            {"role": "user", "content": "Tell me."},
+            {"role": "assistant", "content": "A quiet sigh escaped her."},
+            {"role": "user", "content": "Please."},
+            {"role": "assistant", "content": "Her breath caught in her throat and her heart pounded in her chest."},
+        ]
+        assert voice_is_drifting(msgs) is True
+
+    def test_high_trigram_overlap_triggers_drift(self):
+        repeated = "She crossed her arms and leaned against the wall watching him carefully"
+        msgs = [
+            {"role": "user", "content": "A"},
+            {"role": "assistant", "content": repeated + " with narrow eyes."},
+            {"role": "user", "content": "B"},
+            {"role": "assistant", "content": repeated + " with a frown."},
+            {"role": "user", "content": "C"},
+            {"role": "assistant", "content": repeated + " with suspicion."},
+        ]
+        assert voice_is_drifting(msgs) is True
+
+    def test_only_counts_assistant_messages(self):
+        msgs = [
+            {"role": "user", "content": "Her breath caught in her throat"},
+            {"role": "assistant", "content": "She nodded slowly, considering the question."},
+            {"role": "user", "content": "Her heart pounded in her chest"},
+            {"role": "assistant", "content": "The rain drummed against the window as she spoke."},
+            {"role": "user", "content": "Electricity coursed through her veins"},
+            {"role": "assistant", "content": "She set down her cup and met his gaze steadily."},
+        ]
+        assert voice_is_drifting(msgs) is False
+
+
 # -- fewshot.py: get_fewshot_messages --
 
 
@@ -251,7 +315,8 @@ def test_get_fewshot_messages_returns_pairs():
         {"user_message": "Farewell", "assistant_message": "Until we meet again"},
     ]
 
-    with patch("projects.rp.db.search_fewshot_examples", AsyncMock(return_value=examples)):
+    with patch("projects.rp.fewshot.voice_is_drifting", return_value=True), \
+         patch("projects.rp.db.search_fewshot_examples", AsyncMock(return_value=examples)):
         result = asyncio.run(get_fewshot_messages(ollama, messages, card_id=5))
 
     assert result == [
@@ -296,7 +361,8 @@ def test_get_fewshot_messages_no_results():
         {"role": "assistant", "content": "Hi"},
     ]
 
-    with patch("projects.rp.db.search_fewshot_examples", AsyncMock(return_value=[])):
+    with patch("projects.rp.fewshot.voice_is_drifting", return_value=True), \
+         patch("projects.rp.db.search_fewshot_examples", AsyncMock(return_value=[])):
         result = asyncio.run(get_fewshot_messages(ollama, messages, card_id=5))
 
     assert result == []
@@ -311,13 +377,14 @@ def test_get_fewshot_messages_error_returns_empty():
         {"role": "assistant", "content": "Hi"},
     ]
 
-    result = asyncio.run(get_fewshot_messages(ollama, messages, card_id=5))
+    with patch("projects.rp.fewshot.voice_is_drifting", return_value=True):
+        result = asyncio.run(get_fewshot_messages(ollama, messages, card_id=5))
 
     assert result == []
 
 
-def test_get_fewshot_messages_extracts_correct_context():
-    """get_fewshot_messages() passes the last user + assistant messages to embed()."""
+def test_get_fewshot_messages_embeds_assistant_only():
+    """get_fewshot_messages() embeds only the last assistant message for style matching."""
     ollama = _make_ollama()
     messages = [
         {"role": "user", "content": "First user message"},
@@ -326,8 +393,42 @@ def test_get_fewshot_messages_extracts_correct_context():
         {"role": "assistant", "content": "Second assistant response"},
     ]
 
-    with patch("projects.rp.db.search_fewshot_examples", AsyncMock(return_value=[])):
+    with patch("projects.rp.fewshot.voice_is_drifting", return_value=True), \
+         patch("projects.rp.db.search_fewshot_examples", AsyncMock(return_value=[])):
         asyncio.run(get_fewshot_messages(ollama, messages, card_id=5))
 
-    expected_summary = "Second user message\nSecond assistant response"
-    ollama.embed.assert_called_once_with("nomic-embed-text", expected_summary)
+    ollama.embed.assert_called_once_with("nomic-embed-text", "Second assistant response")
+
+
+def test_get_fewshot_messages_skips_when_voice_strong():
+    """get_fewshot_messages() returns [] without calling embed when voice is strong."""
+    ollama = _make_ollama()
+    messages = [
+        {"role": "user", "content": "Hello"},
+        {"role": "assistant", "content": "Hi"},
+    ]
+
+    with patch("projects.rp.fewshot.voice_is_drifting", return_value=False):
+        result = asyncio.run(get_fewshot_messages(ollama, messages, card_id=5))
+
+    assert result == []
+    ollama.embed.assert_not_called()
+
+
+def test_get_fewshot_messages_proceeds_when_voice_drifting():
+    """get_fewshot_messages() proceeds to retrieval when voice is drifting."""
+    ollama = _make_ollama()
+    messages = [
+        {"role": "user", "content": "Hello"},
+        {"role": "assistant", "content": "Hi there"},
+    ]
+    examples = [
+        {"user_message": "Hey", "assistant_message": "Greetings"},
+    ]
+
+    with patch("projects.rp.fewshot.voice_is_drifting", return_value=True), \
+         patch("projects.rp.db.search_fewshot_examples", AsyncMock(return_value=examples)):
+        result = asyncio.run(get_fewshot_messages(ollama, messages, card_id=5))
+
+    assert len(result) == 2
+    ollama.embed.assert_called_once()


### PR DESCRIPTION
## Summary

- Fewshot retrieval now embeds only the last assistant message (was user+assistant), matching writing style instead of scene topic
- Adds voice drift gating via `voice_is_drifting()`: skips fewshot injection when recent messages have strong voice (no stock phrases, low trigram overlap), saving context tokens
- `generate_examples.py` embeds assistant-only for new examples
- New `--re-embed` flag on `generate_examples.py` to migrate existing examples to assistant-only embeddings

## Test plan

```bash
cd /mnt/d/prg/plum-rp-fewshot-retrieval
python3 -m pytest projects/rp/tests/ -v

# After merging, re-embed existing examples:
python3 projects/rp/generate_examples.py --card-id 2 --re-embed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)