### PR TITLE
feat(rp): add stock phrase rewrite post-hook

### DIFF
--- a/projects/rp/routes.py
+++ b/projects/rp/routes.py
@@ -57,6 +57,9 @@ def setup(app: FastAPI, ollama, resolve_model=None):
     _pipeline = create_default_pipeline()
     _resolve_model = resolve_model or (lambda m: m)
 
+    from .stock_phrases import make_stock_phrase_rewriter
+    _pipeline.add_post(make_stock_phrase_rewriter(_ollama, _resolve_model))
+
     # -- Cards --
 
     @app.get("/rp/cards", response_model=list[CardResponse])

--- a/projects/rp/stock_phrases.py
+++ b/projects/rp/stock_phrases.py
@@ -1,0 +1,62 @@
+"""Post-hook that rewrites stock phrases in AI responses via targeted model call."""
+
+import logging
+
+_log = logging.getLogger("rp.stock_phrases")
+
+REWRITE_MODEL = "q25"
+
+_REWRITE_PROMPT = """\
+The AI response below contains cliché stock phrases. Replace ONLY the listed \
+phrases with vivid, character-specific physical details for {ai_name}. Keep \
+everything else exactly the same — same structure, same length, same meaning.
+
+Stock phrases to replace:
+{phrase_list}
+
+Original response:
+{response}
+
+Rewritten response (change ONLY the stock phrases, nothing else):"""
+
+
+def make_stock_phrase_rewriter(ollama, resolve_model=None):
+    """Return an async post-hook that rewrites stock phrases via a fast model call."""
+
+    async def rewrite_stock_phrases(ctx: dict) -> dict:
+        violations = ctx.get("_stock_phrase_violations")
+        if not violations:
+            return ctx
+
+        response = ctx.get("response", "")
+        ai_name = ctx.get("ai_name", "Character")
+
+        phrase_list = "\n".join(f"- \"{v}\"" for v in violations)
+        prompt = _REWRITE_PROMPT.format(
+            ai_name=ai_name, phrase_list=phrase_list, response=response,
+        )
+
+        model = resolve_model(REWRITE_MODEL) if resolve_model else REWRITE_MODEL
+
+        try:
+            result = await ollama.chat(
+                model=model,
+                messages=[{"role": "user", "content": prompt}],
+                options={"temperature": 0.7, "num_predict": 2048},
+            )
+            rewritten = result.get("message", {}).get("content", "").strip()
+            if not rewritten or len(rewritten) < len(response) * 0.5:
+                _log.warning("Stock phrase rewrite too short, keeping original")
+                return ctx
+
+            ctx["response"] = rewritten
+            ctx["_stock_phrases_rewritten"] = True
+            _log.info(
+                "Rewrote %d stock phrase(s) for %s", len(violations), ai_name,
+            )
+        except Exception as e:
+            _log.warning("Stock phrase rewrite failed: %s", e)
+
+        return ctx
+
+    return rewrite_stock_phrases

--- a/projects/rp/tests/test_stock_phrases.py
+++ b/projects/rp/tests/test_stock_phrases.py
@@ -1,0 +1,144 @@
+import asyncio
+from unittest.mock import AsyncMock
+
+from projects.rp.stock_phrases import make_stock_phrase_rewriter, REWRITE_MODEL
+
+
+def _make_ollama(response_text="Rewritten response here."):
+    ollama = AsyncMock()
+    ollama.chat = AsyncMock(return_value={
+        "message": {"content": response_text},
+    })
+    return ollama
+
+
+class TestMakeStockPhraseRewriter:
+    def test_no_violations_passes_through(self):
+        ollama = _make_ollama()
+        hook = make_stock_phrase_rewriter(ollama)
+        ctx = {"response": "She smiled.", "ai_name": "Kasa"}
+        result = asyncio.run(hook(ctx))
+        assert result["response"] == "She smiled."
+        ollama.chat.assert_not_called()
+
+    def test_empty_violations_passes_through(self):
+        ollama = _make_ollama()
+        hook = make_stock_phrase_rewriter(ollama)
+        ctx = {
+            "response": "She smiled.",
+            "ai_name": "Kasa",
+            "_stock_phrase_violations": [],
+        }
+        result = asyncio.run(hook(ctx))
+        assert result["response"] == "She smiled."
+        ollama.chat.assert_not_called()
+
+    def test_calls_ollama_on_violations(self):
+        rewritten = "She felt her stomach drop as the door slammed."
+        ollama = _make_ollama(rewritten)
+        hook = make_stock_phrase_rewriter(ollama)
+        ctx = {
+            "response": "Her breath caught in her throat as the door slammed.",
+            "ai_name": "Kasa",
+            "_stock_phrase_violations": ["breath caught in"],
+        }
+        result = asyncio.run(hook(ctx))
+        assert result["response"] == rewritten
+        assert result["_stock_phrases_rewritten"] is True
+        ollama.chat.assert_called_once()
+
+    def test_prompt_contains_violations_and_response(self):
+        ollama = _make_ollama("Fixed response.")
+        hook = make_stock_phrase_rewriter(ollama)
+        original = "Her heart pounded in her chest."
+        ctx = {
+            "response": original,
+            "ai_name": "Jess",
+            "_stock_phrase_violations": ["heart pounded in"],
+        }
+        asyncio.run(hook(ctx))
+        call_args = ollama.chat.call_args
+        prompt = call_args[1]["messages"][0]["content"]
+        assert "heart pounded in" in prompt
+        assert original in prompt
+        assert "Jess" in prompt
+
+    def test_uses_resolve_model(self):
+        ollama = _make_ollama("Fixed.")
+        def resolve(m):
+            return f"resolved-{m}"
+        hook = make_stock_phrase_rewriter(ollama, resolve_model=resolve)
+        ctx = {
+            "response": "Her pulse quickened.",
+            "ai_name": "Kasa",
+            "_stock_phrase_violations": ["pulse quickened"],
+        }
+        asyncio.run(hook(ctx))
+        call_args = ollama.chat.call_args
+        assert call_args[1]["model"] == f"resolved-{REWRITE_MODEL}"
+
+    def test_uses_raw_model_without_resolver(self):
+        ollama = _make_ollama("Fixed.")
+        hook = make_stock_phrase_rewriter(ollama)
+        ctx = {
+            "response": "Her pulse quickened.",
+            "ai_name": "Kasa",
+            "_stock_phrase_violations": ["pulse quickened"],
+        }
+        asyncio.run(hook(ctx))
+        call_args = ollama.chat.call_args
+        assert call_args[1]["model"] == REWRITE_MODEL
+
+    def test_keeps_original_on_too_short_rewrite(self):
+        ollama = _make_ollama("Short.")
+        hook = make_stock_phrase_rewriter(ollama)
+        original = "Her breath caught in her throat as she watched the sunset paint the sky in brilliant oranges and deep purples."
+        ctx = {
+            "response": original,
+            "ai_name": "Kasa",
+            "_stock_phrase_violations": ["breath caught in"],
+        }
+        result = asyncio.run(hook(ctx))
+        assert result["response"] == original
+        assert "_stock_phrases_rewritten" not in result
+
+    def test_keeps_original_on_empty_rewrite(self):
+        ollama = _make_ollama("")
+        hook = make_stock_phrase_rewriter(ollama)
+        original = "Her heart pounded in her chest."
+        ctx = {
+            "response": original,
+            "ai_name": "Kasa",
+            "_stock_phrase_violations": ["heart pounded in"],
+        }
+        result = asyncio.run(hook(ctx))
+        assert result["response"] == original
+
+    def test_keeps_original_on_ollama_error(self):
+        ollama = AsyncMock()
+        ollama.chat = AsyncMock(side_effect=RuntimeError("Ollama down"))
+        hook = make_stock_phrase_rewriter(ollama)
+        original = "Her pulse raced as she ran."
+        ctx = {
+            "response": original,
+            "ai_name": "Kasa",
+            "_stock_phrase_violations": ["pulse raced"],
+        }
+        result = asyncio.run(hook(ctx))
+        assert result["response"] == original
+        assert "_stock_phrases_rewritten" not in result
+
+    def test_multiple_violations_listed(self):
+        ollama = _make_ollama("She felt her legs weaken and her hands shake.")
+        hook = make_stock_phrase_rewriter(ollama)
+        ctx = {
+            "response": "Her breath caught in her throat and her heart pounded in her chest.",
+            "ai_name": "Kasa",
+            "_stock_phrase_violations": ["breath caught in", "heart pounded in"],
+        }
+        result = asyncio.run(hook(ctx))
+        call_args = ollama.chat.call_args
+        prompt = call_args[1]["messages"][0]["content"]
+        assert "breath caught in" in prompt
+        assert "heart pounded in" in prompt
+        assert result["_stock_phrases_rewritten"] is True


### PR DESCRIPTION
## Summary

- New `stock_phrases.py` module with `make_stock_phrase_rewriter()` factory that creates an async pipeline post-hook
- When `check_stock_phrases` (existing detection hook) flags cliché phrases like "breath caught", "heart pounded", "pulse quickened", the rewriter calls a fast model (q25) to replace only those phrases with character-specific physical details
- Keeps original response if the rewrite fails, returns empty, or is suspiciously short (<50% of original length)
- Registered in `routes.py:setup()` after pipeline creation — runs automatically on every response
- 10 new tests covering: pass-through, rewrite call, model resolution, error handling, length guard

## Test plan

```bash
cd /mnt/d/prg/plum-rp-stock-phrase-rewrite
python3 -m pytest projects/rp/tests/ -v
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)