### PR TITLE
feat(rp): pronoun enforcement via priming anchor and post-hook

### DIFF
--- a/projects/rp/budget.py
+++ b/projects/rp/budget.py
@@ -242,7 +242,12 @@ def _render_for_count(ctx: dict) -> list[dict]:
         "data", ctx.get("ai_card", {}).get("card_data", {})
     )
     ai_name = ai_data.get("name", "Character")
-    msgs.append({"role": "assistant", "content": ai_name + " "})
+    pronouns = ai_data.get("pronouns", "")
+    if pronouns:
+        anchor = f"{ai_name} [{pronouns}] "
+    else:
+        anchor = ai_name + " "
+    msgs.append({"role": "assistant", "content": anchor})
     return msgs
 
 

--- a/projects/rp/eval_routes.py
+++ b/projects/rp/eval_routes.py
@@ -14,7 +14,7 @@ from .budget import BudgetError, allocate_injections
 from .research import research_dispatch
 from .fewshot import get_fewshot_messages
 from .prompt_builder import (
-    get_ai_name, get_user_name, get_ai_personality,
+    get_ai_name, get_user_name, get_ai_personality, get_ai_pronouns,
     build_chat_messages, build_ollama_options, scale_num_predict,
     budget_to_json, build_pipeline_ctx, budget_ctx,
 )
@@ -128,7 +128,7 @@ def setup_eval_routes(
                 return
 
             response_text = "".join(tokens)
-            post_ctx = {"response": response_text, "ai_name": get_ai_name(ctx)}
+            post_ctx = {"response": response_text, "ai_name": get_ai_name(ctx), "_char_pronouns": get_ai_pronouns(ctx)}
             post_ctx = await pipeline.run_post(post_ctx)
             await db.update_eval_candidate(
                 candidate_row["id"],

--- a/projects/rp/pipeline.py
+++ b/projects/rp/pipeline.py
@@ -261,6 +261,79 @@ def clean_response(ctx: dict) -> dict:
     return ctx
 
 
+_PRONOUN_MAP = {
+    "she/her": {
+        "they": "she", "them": "her", "their": "her",
+        "themselves": "herself", "themself": "herself",
+        "They": "She", "Them": "Her", "Their": "Her",
+        "Themselves": "Herself", "Themself": "Herself",
+    },
+    "he/him": {
+        "they": "he", "them": "him", "their": "his",
+        "themselves": "himself", "themself": "himself",
+        "They": "He", "Them": "Him", "Their": "His",
+        "Themselves": "Himself", "Themself": "Himself",
+    },
+}
+
+_PLURAL_SIGNALS = re.compile(
+    r'\b(both|all|together|each other|the two|the three|the group|everyone)\b',
+    re.IGNORECASE,
+)
+
+
+def _fix_pronouns_in_sentence(sentence: str, mapping: dict) -> str:
+    """Replace they/them/their with correct pronouns in a single sentence."""
+    result = sentence
+    for wrong, right in mapping.items():
+        result = re.sub(r'\b' + wrong + r'\b', right, result)
+    return result
+
+
+def enforce_pronouns(ctx: dict) -> dict:
+    """Fix they/them → she/her or he/him when the character has explicit pronouns."""
+    pronouns = ctx.get("_char_pronouns", "")
+    if not pronouns:
+        return ctx
+
+    mapping = _PRONOUN_MAP.get(pronouns.lower().strip())
+    if not mapping:
+        return ctx
+
+    ai_name = ctx.get("ai_name", "")
+    response = ctx.get("response", "")
+    if not ai_name or not response:
+        return ctx
+
+    sentences = re.split(r'(?<=[.!?…"])\s+', response)
+    fixed = []
+    name_recent = False
+    corrections = 0
+    for sent in sentences:
+        has_name = ai_name.lower() in sent.lower()
+        has_plural = bool(_PLURAL_SIGNALS.search(sent))
+        has_they = bool(re.search(r'\b[Tt]he(?:y|m|ir|msel(?:f|ves))\b', sent))
+
+        if has_they and not has_plural and (has_name or name_recent):
+            new_sent = _fix_pronouns_in_sentence(sent, mapping)
+            if new_sent != sent:
+                corrections += 1
+            fixed.append(new_sent)
+        else:
+            fixed.append(sent)
+
+        if has_name:
+            name_recent = True
+        elif re.search(r'\b[A-Z][a-z]+\b', sent) and not has_name:
+            name_recent = False
+
+    if corrections:
+        ctx["response"] = " ".join(fixed)
+        ctx["_pronoun_corrections"] = corrections
+        _log.info("Fixed %d pronoun(s) for %s (%s)", corrections, ai_name, pronouns)
+    return ctx
+
+
 def check_stock_phrases(ctx: dict) -> dict:
     """Flag stock phrase violations in the response."""
     from .lora_curate import STOCK_PHRASES
@@ -326,5 +399,6 @@ def create_default_pipeline() -> Pipeline:
     p.add_pre(select_style)
     p.add_pre(inject_tools)
     p.add_post(clean_response)
+    p.add_post(enforce_pronouns)
     p.add_post(check_stock_phrases)
     return p

--- a/projects/rp/prompt_builder.py
+++ b/projects/rp/prompt_builder.py
@@ -37,6 +37,12 @@ def get_user_name(ctx: dict) -> str:
     return user_data.get("name", "User")
 
 
+def get_ai_pronouns(ctx: dict) -> str:
+    ai_data = ctx.get("ai_card", {}).get("card_data", {}).get(
+        "data", ctx.get("ai_card", {}).get("card_data", {}))
+    return ai_data.get("pronouns", "")
+
+
 def get_ai_personality(ctx: dict) -> str:
     ai_data = ctx.get("ai_card", {}).get("card_data", {}).get(
         "data", ctx.get("ai_card", {}).get("card_data", {}))
@@ -63,7 +69,12 @@ def build_chat_messages(ctx: dict) -> list[dict]:
     if ctx.get("post_prompt"):
         chat_messages.append({"role": "system", "content": ctx["post_prompt"]})
     ai_name = get_ai_name(ctx)
-    chat_messages.append({"role": "assistant", "content": ai_name + " "})
+    pronouns = get_ai_pronouns(ctx)
+    if pronouns:
+        anchor = f"{ai_name} [{pronouns}] "
+    else:
+        anchor = ai_name + " "
+    chat_messages.append({"role": "assistant", "content": anchor})
     return chat_messages
 
 

--- a/projects/rp/routes.py
+++ b/projects/rp/routes.py
@@ -20,7 +20,7 @@ from .research import research_dispatch
 from .fewshot import get_fewshot_messages
 from .summarize import maybe_generate_summary
 from .prompt_builder import (
-    get_ai_name, get_user_name, get_ai_personality,
+    get_ai_name, get_user_name, get_ai_personality, get_ai_pronouns,
     build_chat_messages, build_ollama_options, scale_num_predict,
     budget_to_json, build_pipeline_ctx, budget_ctx,
 )
@@ -806,7 +806,7 @@ def setup(app: FastAPI, ollama, resolve_model=None):
                 cur_messages.append({"role": "user", "content": "\n".join(tool_results) + "\n\nContinue your response naturally, incorporating the information above. Do not use [TOOL:] again for the same query."})
 
             try:
-                post_ctx = {"response": final_text, "ai_name": get_ai_name(ctx)}
+                post_ctx = {"response": final_text, "ai_name": get_ai_name(ctx), "_char_pronouns": get_ai_pronouns(ctx)}
                 post_ctx = await _pipeline.run_post(post_ctx)
                 await db.add_message(
                     conv_id, "assistant", post_ctx["response"], raw_response=raw,
@@ -922,7 +922,7 @@ def setup(app: FastAPI, ollama, resolve_model=None):
                 return
             try:
                 response_text = "".join(tokens)
-                post_ctx = {"response": response_text, "ai_name": get_ai_name(ctx)}
+                post_ctx = {"response": response_text, "ai_name": get_ai_name(ctx), "_char_pronouns": get_ai_pronouns(ctx)}
                 post_ctx = await _pipeline.run_post(post_ctx)
                 await db.add_message(
                     conv_id, "assistant", post_ctx["response"], raw_response=raw,
@@ -1008,7 +1008,7 @@ def setup(app: FastAPI, ollama, resolve_model=None):
                 return
             try:
                 response_text = "".join(tokens)
-                post_ctx = {"response": response_text, "ai_name": get_ai_name(ctx)}
+                post_ctx = {"response": response_text, "ai_name": get_ai_name(ctx), "_char_pronouns": get_ai_pronouns(ctx)}
                 post_ctx = await _pipeline.run_post(post_ctx)
                 await db.add_message(
                     conv_id, "assistant", post_ctx["response"], raw_response=raw,
@@ -1143,7 +1143,7 @@ def setup(app: FastAPI, ollama, resolve_model=None):
 
             try:
                 response_text = "".join(tokens)
-                post_ctx = {"response": response_text, "ai_name": get_ai_name(ctx)}
+                post_ctx = {"response": response_text, "ai_name": get_ai_name(ctx), "_char_pronouns": get_ai_pronouns(ctx)}
                 post_ctx = await _pipeline.run_post(post_ctx)
                 await db.add_message(
                     conv_id, save_role, post_ctx["response"], raw_response=raw,

--- a/projects/rp/tests/test_pipeline.py
+++ b/projects/rp/tests/test_pipeline.py
@@ -81,7 +81,7 @@ def test_default_template_has_system_and_post():
 from projects.rp.pipeline import (  # noqa: E402
     _split_template, _parse_style_items, _parse_scene_style_items,
     _match_scene_condition, select_style, clean_response,
-    check_stock_phrases, Pipeline, STYLE_ITEMS_PER_TURN,
+    check_stock_phrases, enforce_pronouns, Pipeline, STYLE_ITEMS_PER_TURN,
 )
 import asyncio  # noqa: E402
 
@@ -519,6 +519,112 @@ class TestCheckStockPhrases:
         ctx = {"response": "Her HEART POUNDED IN her chest."}
         check_stock_phrases(ctx)
         assert len(ctx["_stock_phrase_violations"]) == 1
+
+
+class TestEnforcePronouns:
+    def test_fixes_they_to_she(self):
+        ctx = {
+            "response": "Kasa looked up. They smiled softly.",
+            "ai_name": "Kasa",
+            "_char_pronouns": "she/her",
+        }
+        result = enforce_pronouns(ctx)
+        assert "She smiled softly" in result["response"]
+        assert result["_pronoun_corrections"] == 1
+
+    def test_fixes_them_to_her(self):
+        ctx = {
+            "response": "Kasa stepped forward and Val reached for them.",
+            "ai_name": "Kasa",
+            "_char_pronouns": "she/her",
+        }
+        result = enforce_pronouns(ctx)
+        assert "reached for her" in result["response"]
+
+    def test_fixes_their_to_her(self):
+        ctx = {
+            "response": "Kasa tucked their hair behind their ear.",
+            "ai_name": "Kasa",
+            "_char_pronouns": "she/her",
+        }
+        result = enforce_pronouns(ctx)
+        assert "her hair" in result["response"]
+        assert "her ear" in result["response"]
+
+    def test_fixes_he_him(self):
+        ctx = {
+            "response": "Marcus crossed the room. They sat down heavily.",
+            "ai_name": "Marcus",
+            "_char_pronouns": "he/him",
+        }
+        result = enforce_pronouns(ctx)
+        assert "He sat down" in result["response"]
+
+    def test_no_fix_without_pronouns(self):
+        ctx = {
+            "response": "Kasa looked up. They smiled.",
+            "ai_name": "Kasa",
+            "_char_pronouns": "",
+        }
+        result = enforce_pronouns(ctx)
+        assert "They smiled" in result["response"]
+        assert "_pronoun_corrections" not in result
+
+    def test_no_fix_for_they_them_character(self):
+        ctx = {
+            "response": "River smiled. They waved goodbye.",
+            "ai_name": "River",
+            "_char_pronouns": "they/them",
+        }
+        result = enforce_pronouns(ctx)
+        assert "They waved" in result["response"]
+        assert "_pronoun_corrections" not in result
+
+    def test_skips_plural_context(self):
+        ctx = {
+            "response": "Kasa and Val looked at each other. They both laughed.",
+            "ai_name": "Kasa",
+            "_char_pronouns": "she/her",
+        }
+        result = enforce_pronouns(ctx)
+        assert "They both" in result["response"]
+
+    def test_skips_sentences_without_name_context(self):
+        ctx = {
+            "response": "The crowd dispersed. They headed home.",
+            "ai_name": "Kasa",
+            "_char_pronouns": "she/her",
+        }
+        result = enforce_pronouns(ctx)
+        assert "They headed home" in result["response"]
+
+    def test_fixes_continuation_after_name(self):
+        ctx = {
+            "response": "Kasa stood up slowly. They brushed off their jeans.",
+            "ai_name": "Kasa",
+            "_char_pronouns": "she/her",
+        }
+        result = enforce_pronouns(ctx)
+        assert "She brushed off her jeans" in result["response"]
+
+    def test_preserves_case_at_sentence_start(self):
+        ctx = {
+            "response": "Kasa waited. They fidgeted with the hem.",
+            "ai_name": "Kasa",
+            "_char_pronouns": "she/her",
+        }
+        result = enforce_pronouns(ctx)
+        assert "She fidgeted" in result["response"]
+
+    def test_no_change_when_no_misgendering(self):
+        ctx = {
+            "response": "Kasa smiled. She tucked her hair back.",
+            "ai_name": "Kasa",
+            "_char_pronouns": "she/her",
+        }
+        result = enforce_pronouns(ctx)
+        assert result["response"] == "Kasa smiled. She tucked her hair back."
+        assert "_pronoun_corrections" not in result
 
 
 class TestDefaultTemplate:

--- a/projects/rp/tests/test_prompt_builder.py
+++ b/projects/rp/tests/test_prompt_builder.py
@@ -1,19 +1,21 @@
 from projects.rp.prompt_builder import (
-    get_ai_name, get_user_name, get_ai_personality,
+    get_ai_name, get_user_name, get_ai_personality, get_ai_pronouns,
     build_chat_messages, build_ollama_options, scale_num_predict,
     budget_to_json, CHAT_DEFAULTS,
 )
 
 
-def _card(name="Char", description="", personality=""):
+def _card(name="Char", description="", personality="", pronouns=""):
     return {"card_data": {"data": {
         "name": name, "description": description, "personality": personality,
+        "pronouns": pronouns,
     }}}
 
 
-def _ctx(ai_name="Char", user_name="User", ai_desc="", messages=None):
+def _ctx(ai_name="Char", user_name="User", ai_desc="", messages=None,
+         ai_pronouns=""):
     return {
-        "ai_card": _card(ai_name, description=ai_desc),
+        "ai_card": _card(ai_name, description=ai_desc, pronouns=ai_pronouns),
         "user_card": _card(user_name),
         "system_prompt": "System prompt",
         "post_prompt": "Post prompt",
@@ -108,6 +110,41 @@ class TestScaleNumPredict:
     def test_preserves_other_keys(self):
         opts = scale_num_predict({"num_predict": 768, "temperature": 0.8}, "hello")
         assert opts["temperature"] == 0.8
+
+
+class TestGetAiPronouns:
+    def test_extracts_pronouns(self):
+        ctx = {"ai_card": _card("Kasa", pronouns="she/her")}
+        assert get_ai_pronouns(ctx) == "she/her"
+
+    def test_default_empty(self):
+        assert get_ai_pronouns({}) == ""
+
+    def test_no_pronouns_in_card(self):
+        ctx = {"ai_card": _card("Kasa")}
+        assert get_ai_pronouns(ctx) == ""
+
+
+class TestBuildChatMessagesWithPronouns:
+    def test_includes_pronouns_in_anchor(self):
+        ctx = _ctx(ai_name="Kasa", ai_pronouns="she/her")
+        msgs = build_chat_messages(ctx)
+        assert msgs[-1]["content"] == "Kasa [she/her] "
+
+    def test_no_pronouns_plain_anchor(self):
+        ctx = _ctx(ai_name="Kasa")
+        msgs = build_chat_messages(ctx)
+        assert msgs[-1]["content"] == "Kasa "
+
+    def test_he_him_pronouns(self):
+        ctx = _ctx(ai_name="Marcus", ai_pronouns="he/him")
+        msgs = build_chat_messages(ctx)
+        assert msgs[-1]["content"] == "Marcus [he/him] "
+
+    def test_they_them_pronouns(self):
+        ctx = _ctx(ai_name="River", ai_pronouns="they/them")
+        msgs = build_chat_messages(ctx)
+        assert msgs[-1]["content"] == "River [they/them] "
 
 
 class TestBudgetToJson:


### PR DESCRIPTION
## Summary

- Priming anchor now includes character pronouns (`"Kasa [she/her] "`) to bias the model's first tokens toward correct usage
- New `enforce_pronouns` pipeline post-hook corrects they/them → she/her or he/him via sentence-level regex
- Only corrects sentences where the AI character is clearly the subject (name present or continuation sentence); skips plural contexts ("they both", "each other", "together")
- Budget `_render_for_count` updated to match the new priming anchor for accurate token counting
- All post_ctx construction sites (4 in routes.py, 1 in eval_routes.py) pass `_char_pronouns`
- 18 new tests (11 for enforce_pronouns, 7 for get_ai_pronouns + priming anchor)

## Test plan

```bash
cd /mnt/d/prg/plum-rp-pronoun-enforcement
python3 -m pytest projects/rp/tests/ -v
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)