### PR TITLE
feat(joon): scene graph and hardcoded geometry pass

### DIFF
--- a/docs/superpowers/plans/2026-04-27-joon-scene-graph.md
+++ b/docs/superpowers/plans/2026-04-27-joon-scene-graph.md
@@ -1,0 +1,971 @@
+# Joon Scene Graph & Geometry Pass — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a 3D scene graph and a single hardcoded geometry pass to joon. Scenes (meshes, cameras, lights) are described in the DSL, rasterized to a render target via a Vulkan graphics pipeline, and the result feeds back into the existing compute graph as a `GpuImage`.
+
+**Architecture:** Two new IR tiers — `SCENE` (collected, not dispatched: meshes/lights/camera) and `RENDER` (executed once after compute setup: the `(pass ...)` node). Scene-tier executors mutate a `SceneCollection` on `EvalContext` rather than producing images. The `pass` executor allocates color + depth render-target images via an extended `ResourcePool`, builds a `VkRenderPass` and `VkGraphicsPipeline` (cached by `PipelineCache::get_graphics`), records draws for every collected mesh, and transitions outputs to `GENERAL` so downstream compute nodes can sample them. Vertex/fragment shaders are **hardcoded HLSL** for this sub-project; DSL-generated shaders are sub-project 3.
+
+**Tech Stack:** C++20, Vulkan, VMA, HLSL, DXC, Catch2, tinyobjloader (vendored single header).
+
+**Worktree:** `D:/prg/plum-joon-scene-graph` (branch `joon-scene-graph`)
+
+**Branch base:** `main` at `eb38067` (post PR #115 + #118 merge)
+
+---
+
+## File Map
+
+| Action | File | Purpose |
+|--------|------|---------|
+| Modify | `src/ir/node.h` | Add `Tier::SCENE`, `Tier::RENDER` |
+| Modify | `include/joon/types.h` | Add `Type::SCENE_OBJECT`, `Type::LIGHT`, `Type::CAMERA`, `Type::RENDER_TARGET` |
+| Modify | `src/ir/ir_graph.cpp` | Lower `cube`/`sphere`/`plane`/`cylinder`/`mesh`/`light`/`camera`/`pass` to correct tier + type |
+| Create | `include/joon/scene.h` | `Mesh`, `SceneObject`, `Light`, `Camera`, `SceneCollection` value types |
+| Create | `src/scene/scene_collection.cpp` | `SceneCollection::clear()`, `add_object()`, `add_light()`, `set_camera()` |
+| Create | `src/scene/primitives.h`, `primitives.cpp` | `gen_cube()`, `gen_sphere()`, `gen_plane()`, `gen_cylinder()` returning `Mesh` |
+| Create | `third_party/tinyobjloader/tiny_obj_loader.h` | Vendored single-header OBJ parser (v2.0.0-rc13) |
+| Create | `src/scene/obj_loader.h`, `obj_loader.cpp` | `Mesh load_obj(const std::string& path)` wrapper around tinyobjloader |
+| Modify | `src/nodes/node_registry.h` | Extend `EvalContext` with `SceneCollection& scene` + helpers |
+| Create | `src/scene/scene_executors.h`, `scene_executors.cpp` | Register `cube`/`sphere`/`plane`/`cylinder`/`mesh`/`light`/`camera`/`pass` executors |
+| Modify | `src/nodes/node_registry.cpp` | Call `register_scene_nodes()` in `create_default()` |
+| Modify | `src/interpreter/interpreter.cpp` | Walk SCENE nodes first to populate `SceneCollection`, then GPU+CPU, then RENDER |
+| Modify | `src/vulkan/resource_pool.h`, `resource_pool.cpp` | Add `alloc_render_target(node_id, w, h, format)`, `alloc_depth(node_id, w, h)`, format/usage tracking |
+| Create | `src/vulkan/buffer.h`, `buffer.cpp` | `VertexBuffer`, `IndexBuffer` thin wrappers over VMA |
+| Create | `src/vulkan/render_pass.h`, `render_pass.cpp` | `RenderPass` (VkRenderPass + framebuffer factory), color+depth attachment setup |
+| Modify | `src/vulkan/pipeline_cache.h`, `pipeline_cache.cpp` | Add `GraphicsPipeline` struct + `get_graphics(name, render_pass, vertex_layout)` |
+| Create | `shaders/scene_basic.vert.hlsl` | Hardcoded vertex shader — applies MVP, passes normal & uv |
+| Create | `shaders/scene_basic.frag.hlsl` | Hardcoded fragment shader — N·L lambert with first directional light |
+| Modify | `src/evaluator.cpp` | Allocate descriptor pool slots for uniform buffers; reset `SceneCollection` each `evaluate()` |
+| Modify | `premake5.lua` | Add new `src/scene/`, `src/vulkan/buffer.cpp`, `src/vulkan/render_pass.cpp` (already covered by `src/**.cpp` glob — verify only) |
+| Create | `tests/test_scene_ir.cpp` | IR tests: scene ops produce SCENE-tier, pass produces RENDER-tier |
+| Create | `tests/test_primitives.cpp` | Geometry tests: cube has 24 vertices (per-face normals) / 36 indices, sphere closed manifold |
+| Create | `tests/test_obj_loader.cpp` | Embedded OBJ string round-trips through loader |
+| Create | `tests/test_scene_collection.cpp` | Scene executors populate collection; eval clears between runs |
+| Create | `tests/test_geometry_pass.cpp` | Full GPU integration: scene + pass renders non-clear pixels; chained compute reads pass output |
+| Modify | `gui/app.cpp` | Default DSL becomes a minimal 3D scene (cube + camera + light + pass + levels) |
+
+---
+
+## Conventions for All Tasks
+
+- TDD: write the failing test first, run it, see the exact failure, then implement.
+- Each commit message starts with `feat(joon):`, `test(joon):`, or `fix(joon):` and is one imperative sentence.
+- After every task: build the full solution and run **all** tests. If anything regresses, stop and fix before moving on.
+- Co-author trailer on every commit:
+  ```
+  Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+  ```
+- Build command (Windows, from `projects/joon/build/`):
+  ```bash
+  "/c/Program Files/Microsoft Visual Studio/2022/Community/MSBuild/Current/Bin/MSBuild.exe" \
+    Joon.sln -p:Configuration=Debug -p:Platform=x64 -m -v:minimal
+  ```
+- Test command (from `projects/joon/`):
+  ```bash
+  ./build/bin/Debug/joon-tests.exe
+  ```
+
+---
+
+## Phase 1: IR Tier Extensions
+
+### Task 1: Add SCENE and RENDER tiers
+
+**Files:**
+- Modify: `projects/joon/src/ir/node.h`
+- Modify: `projects/joon/include/joon/types.h`
+- Modify: `projects/joon/src/ir/ir_graph.cpp`
+- Create: `projects/joon/tests/test_scene_ir.cpp`
+
+**Step 1: Write the failing test**
+
+```cpp
+// tests/test_scene_ir.cpp
+#include "catch_amalgamated.hpp"
+#include <joon/joon.h>
+using namespace joon;
+
+TEST_CASE("Scene ops are tagged with SCENE tier", "[scene][ir]") {
+    auto ctx = Context::create();
+    auto graph = ctx->parse_string(R"(
+        (cube :scale 1.0)
+        (sphere :radius 0.5)
+        (light :type directional :direction [0 -1 0])
+        (camera :fov 60 :position [0 0 5])
+    )");
+    REQUIRE_FALSE(graph.has_errors());
+
+    auto& ir = graph.ir();
+    int scene_count = 0;
+    for (auto& n : ir.nodes)
+        if (n.tier == Tier::SCENE) ++scene_count;
+    CHECK(scene_count == 4);
+}
+
+TEST_CASE("pass op is tagged with RENDER tier", "[scene][ir]") {
+    auto ctx = Context::create();
+    auto graph = ctx->parse_string(R"(
+        (cube)
+        (camera :position [0 0 5])
+        (def out (pass scene :outputs [albedo depth]))
+        (output out)
+    )");
+    REQUIRE_FALSE(graph.has_errors());
+
+    auto& ir = graph.ir();
+    bool found_render = false;
+    for (auto& n : ir.nodes)
+        if (n.tier == Tier::RENDER) { found_render = true; break; }
+    CHECK(found_render);
+}
+```
+
+**Step 2: Run to verify it fails**
+
+```bash
+./build/bin/Debug/joon-tests.exe "[scene][ir]"
+```
+Expected: compile error — `Tier::SCENE` undefined.
+
+**Step 3: Add tier values**
+
+In `src/ir/node.h`, extend the enum:
+```cpp
+enum class Tier { CPU, GPU, SCENE, RENDER };
+```
+
+In `include/joon/types.h`, extend `Type`:
+```cpp
+enum class Type {
+    /* existing... */
+    SCENE_OBJECT,
+    LIGHT,
+    CAMERA,
+    RENDER_TARGET,
+};
+```
+
+**Step 4: Lower scene/render ops to correct tier**
+
+In `src/ir/ir_graph.cpp` near line 99–104, replace the `if (op == "image" || ...)` block with:
+```cpp
+static const std::unordered_set<std::string> SCENE_OPS{
+    "cube", "sphere", "plane", "cylinder", "mesh", "light", "camera"
+};
+static const std::unordered_set<std::string> RENDER_OPS{ "pass" };
+static const std::unordered_set<std::string> CPU_OPS{ "image", "color", "save" };
+
+if (SCENE_OPS.count(op)) {
+    n.tier = Tier::SCENE;
+    n.output_type = (op == "light") ? Type::LIGHT
+                  : (op == "camera") ? Type::CAMERA
+                  : Type::SCENE_OBJECT;
+} else if (RENDER_OPS.count(op)) {
+    n.tier = Tier::RENDER;
+    n.output_type = Type::RENDER_TARGET;
+} else if (CPU_OPS.count(op)) {
+    n.tier = Tier::CPU;
+} else {
+    n.tier = Tier::GPU;
+}
+```
+
+**Step 5: Run tests, verify pass**
+
+```bash
+./build/bin/Debug/joon-tests.exe "[scene][ir]"
+```
+Expected: 2 cases pass.
+
+**Step 6: Run full suite**
+```bash
+./build/bin/Debug/joon-tests.exe
+```
+Expected: 38 + 2 = 40 cases pass, no regressions.
+
+**Step 7: Commit**
+```bash
+git add -A
+git commit -m "feat(joon): add SCENE and RENDER IR tiers for scene graph"
+```
+
+---
+
+## Phase 2: Scene Value Types & Primitives
+
+### Task 2: Define Mesh / SceneObject / Light / Camera value types
+
+**Files:**
+- Create: `projects/joon/include/joon/scene.h`
+- Create: `projects/joon/src/scene/scene_collection.cpp`
+
+**Step 1: Write failing test**
+
+```cpp
+// tests/test_scene_collection.cpp
+#include "catch_amalgamated.hpp"
+#include <joon/scene.h>
+
+using namespace joon;
+
+TEST_CASE("SceneCollection clear/add roundtrip", "[scene]") {
+    SceneCollection s;
+    s.add_object(SceneObject{Mesh{}, vec3{1,0,0}, vec3{0,0,0}, vec3{1,1,1}});
+    s.add_light(Light{LightType::Directional, {0,-1,0}, {1,1,1}, 1.0f});
+    s.set_camera(Camera{60.f, {0,0,5}, {0,0,0}});
+
+    CHECK(s.objects.size() == 1);
+    CHECK(s.lights.size() == 1);
+    CHECK(s.camera.fov_deg == Approx(60.f));
+
+    s.clear();
+    CHECK(s.objects.empty());
+    CHECK(s.lights.empty());
+}
+```
+
+**Step 2: Run to verify fail** — compile error, header missing.
+
+**Step 3: Create header**
+
+```cpp
+// include/joon/scene.h
+#pragma once
+#include <joon/types.h>
+#include <vector>
+#include <string>
+#include <cstdint>
+
+namespace joon {
+
+struct Vertex {
+    vec3 position;
+    vec3 normal;
+    vec2 uv;
+};
+
+struct Mesh {
+    std::vector<Vertex> vertices;
+    std::vector<uint32_t> indices;
+};
+
+struct SceneObject {
+    Mesh mesh;
+    vec3 position{0,0,0};
+    vec3 rotation{0,0,0};   // euler XYZ in radians
+    vec3 scale{1,1,1};
+    // material slot — wired to a node id when fragment shading is per-object.
+    // For sub-project 2 this is unused (single hardcoded fragment).
+    uint32_t material_node_id = 0;
+};
+
+enum class LightType { Directional, Point, Spot };
+
+struct Light {
+    LightType type = LightType::Directional;
+    vec3 direction{0,-1,0};   // for directional / spot
+    vec3 position{0,0,0};     // for point / spot
+    vec3 color{1,1,1};
+    float intensity = 1.0f;
+    float spot_angle_deg = 30.0f;
+};
+
+struct Camera {
+    float fov_deg = 60.0f;
+    vec3 position{0,0,5};
+    vec3 target{0,0,0};
+    vec3 up{0,1,0};
+    float near_z = 0.1f;
+    float far_z = 100.0f;
+};
+
+struct SceneCollection {
+    std::vector<SceneObject> objects;
+    std::vector<Light> lights;
+    Camera camera;
+
+    void clear();
+    void add_object(SceneObject obj);
+    void add_light(Light l);
+    void set_camera(Camera c);
+};
+
+} // namespace joon
+```
+
+**Step 4: Implement**
+
+```cpp
+// src/scene/scene_collection.cpp
+#include <joon/scene.h>
+
+namespace joon {
+
+void SceneCollection::clear() {
+    objects.clear();
+    lights.clear();
+    camera = Camera{};
+}
+void SceneCollection::add_object(SceneObject o) { objects.push_back(std::move(o)); }
+void SceneCollection::add_light(Light l) { lights.push_back(l); }
+void SceneCollection::set_camera(Camera c) { camera = c; }
+
+} // namespace joon
+```
+
+**Step 5: Run, verify pass.**
+
+**Step 6: Commit**
+```bash
+git commit -am "feat(joon): add Mesh / SceneObject / Light / Camera value types"
+```
+
+---
+
+### Task 3: Procedural primitive generators
+
+**Files:**
+- Create: `projects/joon/src/scene/primitives.h`, `primitives.cpp`
+- Create: `projects/joon/tests/test_primitives.cpp`
+
+**Step 1: Failing test**
+
+```cpp
+// tests/test_primitives.cpp
+#include "catch_amalgamated.hpp"
+#include "scene/primitives.h"
+using namespace joon;
+
+TEST_CASE("Cube has 24 vertices / 36 indices, axis-aligned bounds", "[primitives]") {
+    auto m = gen_cube(1.0f);
+    CHECK(m.vertices.size() == 24);   // 4 verts/face × 6 faces (so per-face normals)
+    CHECK(m.indices.size() == 36);    // 2 tris/face × 3 indices × 6 faces
+    float minc = 999, maxc = -999;
+    for (auto& v : m.vertices) {
+        minc = std::min({minc, v.position.x, v.position.y, v.position.z});
+        maxc = std::max({maxc, v.position.x, v.position.y, v.position.z});
+    }
+    CHECK(minc == Approx(-0.5f));
+    CHECK(maxc == Approx( 0.5f));
+}
+
+TEST_CASE("Sphere has consistent vertex/index counts for given segments", "[primitives]") {
+    auto m = gen_sphere(0.5f, /*lat=*/16, /*lon=*/32);
+    // (lat+1) * (lon+1) verts, lat*lon*6 indices
+    CHECK(m.vertices.size() == 17 * 33);
+    CHECK(m.indices.size()  == 16 * 32 * 6);
+}
+
+TEST_CASE("Plane is 4 verts / 6 indices, lies in XZ at y=0", "[primitives]") {
+    auto m = gen_plane(2.0f, 2.0f);
+    CHECK(m.vertices.size() == 4);
+    CHECK(m.indices.size() == 6);
+    for (auto& v : m.vertices) CHECK(v.position.y == Approx(0.f));
+}
+```
+
+**Step 2: Run, fail (header missing).**
+
+**Step 3: Implement primitives**
+
+`src/scene/primitives.h`:
+```cpp
+#pragma once
+#include <joon/scene.h>
+
+namespace joon {
+
+Mesh gen_cube(float size = 1.0f);
+Mesh gen_sphere(float radius = 0.5f, int lat = 16, int lon = 32);
+Mesh gen_plane(float w = 1.0f, float h = 1.0f);
+Mesh gen_cylinder(float radius = 0.5f, float height = 1.0f, int segments = 32);
+
+} // namespace joon
+```
+
+`src/scene/primitives.cpp` (cube fully shown — sphere/plane/cylinder analogous, write each one task-by-task or in bulk if pattern clear):
+```cpp
+#include "scene/primitives.h"
+#include <cmath>
+
+namespace joon {
+
+Mesh gen_cube(float size) {
+    const float h = size * 0.5f;
+    // 6 faces × 4 unique verts each (so normals are flat per-face)
+    const vec3 normals[6] = {
+        { 0, 0, 1}, { 0, 0,-1},   // +Z, -Z
+        { 1, 0, 0}, {-1, 0, 0},   // +X, -X
+        { 0, 1, 0}, { 0,-1, 0},   // +Y, -Y
+    };
+    const vec3 corners[6][4] = {
+        {{-h,-h, h},{ h,-h, h},{ h, h, h},{-h, h, h}},  // +Z
+        {{ h,-h,-h},{-h,-h,-h},{-h, h,-h},{ h, h,-h}},  // -Z
+        {{ h,-h, h},{ h,-h,-h},{ h, h,-h},{ h, h, h}},  // +X
+        {{-h,-h,-h},{-h,-h, h},{-h, h, h},{-h, h,-h}},  // -X
+        {{-h, h, h},{ h, h, h},{ h, h,-h},{-h, h,-h}},  // +Y
+        {{-h,-h,-h},{ h,-h,-h},{ h,-h, h},{-h,-h, h}},  // -Y
+    };
+    const vec2 uvs[4] = { {0,0},{1,0},{1,1},{0,1} };
+
+    Mesh m;
+    m.vertices.reserve(24);
+    m.indices.reserve(36);
+    for (int f = 0; f < 6; ++f) {
+        uint32_t base = static_cast<uint32_t>(m.vertices.size());
+        for (int c = 0; c < 4; ++c)
+            m.vertices.push_back({corners[f][c], normals[f], uvs[c]});
+        // two triangles per face: 0-1-2, 0-2-3
+        m.indices.insert(m.indices.end(), { base, base+1, base+2, base, base+2, base+3 });
+    }
+    return m;
+}
+
+// gen_sphere, gen_plane, gen_cylinder — implement following the same pattern.
+// Sphere: (lat+1) latitude rings × (lon+1) longitude verts; faces wind CCW.
+// Plane: 4 corners at (±w/2, 0, ±h/2), normal +Y.
+// Cylinder: top cap + bottom cap + side strip; segments around.
+
+} // namespace joon
+```
+
+**Step 4: Run primitives tests** (`[primitives]`), verify pass.
+
+**Step 5: Run full suite.**
+
+**Step 6: Commit**
+```bash
+git commit -am "feat(joon): procedural primitives (cube, sphere, plane, cylinder)"
+```
+
+---
+
+### Task 4: OBJ loader (vendored tinyobjloader)
+
+**Files:**
+- Create: `projects/joon/third_party/tinyobjloader/tiny_obj_loader.h`  (vendor v2.0.0-rc13)
+- Create: `projects/joon/src/scene/obj_loader.h`, `obj_loader.cpp`
+- Create: `projects/joon/tests/test_obj_loader.cpp`
+
+**Step 1: Failing test using an in-memory cube OBJ**
+
+```cpp
+// tests/test_obj_loader.cpp
+#include "catch_amalgamated.hpp"
+#include "scene/obj_loader.h"
+using namespace joon;
+
+static const char* CUBE_OBJ = R"(
+v -0.5 -0.5 -0.5
+v  0.5 -0.5 -0.5
+v  0.5  0.5 -0.5
+v -0.5  0.5 -0.5
+v -0.5 -0.5  0.5
+v  0.5 -0.5  0.5
+v  0.5  0.5  0.5
+v -0.5  0.5  0.5
+vn 0 0 -1
+vn 0 0  1
+f 1//1 2//1 3//1
+f 1//1 3//1 4//1
+f 5//2 6//2 7//2
+f 5//2 7//2 8//2
+)";
+
+TEST_CASE("OBJ loader parses positions and indices", "[obj]") {
+    auto mesh = load_obj_string(CUBE_OBJ);
+    REQUIRE(mesh.vertices.size() >= 12);   // 4 verts/face × 2 faces with split normals
+    REQUIRE(mesh.indices.size() == 12);    // 2 tris × 3 indices × 2 faces
+}
+```
+
+**Step 2: Run, fail — header missing.**
+
+**Step 3: Vendor tinyobjloader**
+
+Download `tiny_obj_loader.h` v2.0.0-rc13 from `https://github.com/tinyobjloader/tinyobjloader/blob/release/tiny_obj_loader.h` and place at `third_party/tinyobjloader/tiny_obj_loader.h`. Add a `LICENSE` file alongside.
+
+**Step 4: Implement loader**
+
+`src/scene/obj_loader.h`:
+```cpp
+#pragma once
+#include <joon/scene.h>
+#include <string>
+
+namespace joon {
+Mesh load_obj_string(const std::string& obj_text);
+Mesh load_obj_file(const std::string& path);
+} // namespace joon
+```
+
+`src/scene/obj_loader.cpp`:
+```cpp
+#define TINYOBJLOADER_IMPLEMENTATION
+#include "tinyobjloader/tiny_obj_loader.h"
+#include "scene/obj_loader.h"
+#include <sstream>
+#include <stdexcept>
+
+namespace joon {
+
+static Mesh build_mesh(const tinyobj::attrib_t& attrib,
+                        const std::vector<tinyobj::shape_t>& shapes) {
+    Mesh out;
+    for (auto& shape : shapes) {
+        for (auto& idx : shape.mesh.indices) {
+            Vertex v{};
+            v.position = {
+                attrib.vertices[3*idx.vertex_index + 0],
+                attrib.vertices[3*idx.vertex_index + 1],
+                attrib.vertices[3*idx.vertex_index + 2],
+            };
+            if (idx.normal_index >= 0) {
+                v.normal = {
+                    attrib.normals[3*idx.normal_index + 0],
+                    attrib.normals[3*idx.normal_index + 1],
+                    attrib.normals[3*idx.normal_index + 2],
+                };
+            }
+            if (idx.texcoord_index >= 0) {
+                v.uv = {
+                    attrib.texcoords[2*idx.texcoord_index + 0],
+                    attrib.texcoords[2*idx.texcoord_index + 1],
+                };
+            }
+            out.vertices.push_back(v);
+            out.indices.push_back(static_cast<uint32_t>(out.indices.size()));
+        }
+    }
+    return out;
+}
+
+Mesh load_obj_string(const std::string& obj_text) {
+    tinyobj::attrib_t attrib;
+    std::vector<tinyobj::shape_t> shapes;
+    std::vector<tinyobj::material_t> materials;
+    std::string warn, err;
+    std::istringstream iss(obj_text);
+    if (!tinyobj::LoadObj(&attrib, &shapes, &materials, &warn, &err, &iss))
+        throw std::runtime_error("OBJ parse failed: " + err);
+    return build_mesh(attrib, shapes);
+}
+
+Mesh load_obj_file(const std::string& path) {
+    tinyobj::attrib_t attrib;
+    std::vector<tinyobj::shape_t> shapes;
+    std::vector<tinyobj::material_t> materials;
+    std::string warn, err;
+    if (!tinyobj::LoadObj(&attrib, &shapes, &materials, &warn, &err, path.c_str()))
+        throw std::runtime_error("OBJ load failed: " + err);
+    return build_mesh(attrib, shapes);
+}
+
+} // namespace joon
+```
+
+**Step 5: Run, pass.**
+
+**Step 6: Commit**
+```bash
+git add third_party/tinyobjloader/ src/scene/obj_loader.* tests/test_obj_loader.cpp
+git commit -m "feat(joon): vendor tinyobjloader and add OBJ mesh loader"
+```
+
+---
+
+## Phase 3: Scene Collection in Evaluator
+
+### Task 5: Extend EvalContext with SceneCollection; register scene executors
+
+**Files:**
+- Modify: `projects/joon/src/nodes/node_registry.h`
+- Create: `projects/joon/src/scene/scene_executors.h`, `scene_executors.cpp`
+- Modify: `projects/joon/src/nodes/node_registry.cpp` (call `register_scene_nodes`)
+- Modify: `projects/joon/src/evaluator.cpp` (own a `SceneCollection`, expose to `EvalContext`, clear before each evaluate)
+- Modify: `projects/joon/src/interpreter/interpreter.cpp` (skip SCENE/RENDER for now, but call SCENE executors first; defer RENDER to after the GPU walk — see Task 8)
+
+**Step 1: Failing test**
+
+```cpp
+// tests/test_scene_collection.cpp (extend existing or new file)
+TEST_CASE("Evaluating a scene populates SceneCollection", "[scene][gpu]") {
+    auto ctx = Context::create();
+    auto graph = ctx->parse_string(R"(
+        (cube :scale 1.0 :position [0 0 0])
+        (sphere :radius 0.5 :position [2 0 0])
+        (light :type directional :direction [0 -1 0] :color [1 1 1])
+        (camera :fov 60 :position [0 2 5])
+        (output 0.5)
+    )");
+    auto eval = ctx->create_evaluator(graph);
+    eval->evaluate();
+
+    auto& scene = eval->scene_for_test();   // new debug-accessor
+    CHECK(scene.objects.size() == 2);
+    CHECK(scene.lights.size() == 1);
+    CHECK(scene.camera.fov_deg == Approx(60.0f));
+}
+```
+
+**Step 2-4: Implement (one logical commit per concern below — but write & test the whole task end-to-end)**
+
+a) `EvalContext` (in `src/nodes/node_registry.h`) gains a `SceneCollection& scene` reference.
+b) `Evaluator::Impl` owns `SceneCollection scene_;` and clears it at the top of `evaluate()`.
+c) `register_scene_nodes()` registers 7 executors (`cube`, `sphere`, `plane`, `cylinder`, `mesh`, `light`, `camera`). Each pulls kwargs (`:position`, `:scale`, `:radius`, `:fov`, etc.), builds the right value-type, and calls `ctx.scene.add_object(...)` / `add_light(...)` / `set_camera(...)`.
+d) `Interpreter::evaluate` walks the topo order: when it hits a `SCENE`-tier node, dispatch to its executor; when it hits a `RENDER`-tier node, defer (collected into a list) and execute after the compute walk completes.
+e) Add a debug accessor `Evaluator::scene_for_test()` (under `#ifdef JOON_TEST` or just always available — pragmatic over pure).
+
+Example executor (in `scene_executors.cpp`):
+```cpp
+static void exec_cube(const Node& n, EvalContext& ctx) {
+    SceneObject o;
+    o.mesh = gen_cube(get_kwarg_float(n, "scale", 1.0f));
+    o.position = get_kwarg_vec3(n, "position", {0,0,0});
+    o.rotation = get_kwarg_vec3(n, "rotation", {0,0,0});
+    ctx.scene.add_object(std::move(o));
+}
+```
+
+`get_kwarg_*` helpers live in a new tiny `src/scene/kwarg_helpers.h` (or extend an existing one if present).
+
+**Step 5: Run, verify pass.**
+
+**Step 6: Commit**
+```bash
+git commit -am "feat(joon): scene executors populate SceneCollection during evaluate"
+```
+
+---
+
+## Phase 4: Vulkan Graphics Pipeline Infrastructure
+
+### Task 6: Vertex / index buffer wrappers
+
+**Files:**
+- Create: `projects/joon/src/vulkan/buffer.h`, `buffer.cpp`
+
+`buffer.h`:
+```cpp
+#pragma once
+#include "vulkan/device.h"
+#include <cstdint>
+
+namespace joon {
+
+struct GpuBuffer {
+    VkBuffer buffer = VK_NULL_HANDLE;
+    VmaAllocation alloc = VK_NULL_HANDLE;
+    size_t size = 0;
+};
+
+GpuBuffer create_vertex_buffer(Device& dev, const void* data, size_t size_bytes);
+GpuBuffer create_index_buffer (Device& dev, const void* data, size_t size_bytes);
+GpuBuffer create_uniform_buffer(Device& dev, size_t size_bytes);  // host-visible
+void      update_uniform_buffer(Device& dev, GpuBuffer& buf, const void* data, size_t size);
+void      destroy_buffer(Device& dev, GpuBuffer& buf);
+
+} // namespace joon
+```
+
+Implement using VMA: vertex/index → DEVICE_LOCAL with staging upload via `begin_single_command`; uniform → CPU_TO_GPU mapped. Bookkeep allocations so the geometry-pass executor can dispose them at the end of an evaluate (or pool them — keep it simple for sub-project 2: create per-evaluate, free at end).
+
+**Test:** `[buffer]` tag, allocate a buffer, upload 64 bytes, read back via a host-visible roundtrip is overkill — assert `buffer != VK_NULL_HANDLE` and `size == 64`. Real exercise comes via the geometry pass.
+
+**Commit:** `feat(joon): vertex/index/uniform buffer wrappers (VMA)`
+
+---
+
+### Task 7: RenderPass + GraphicsPipeline
+
+**Files:**
+- Create: `projects/joon/src/vulkan/render_pass.h`, `render_pass.cpp`
+- Modify: `projects/joon/src/vulkan/pipeline_cache.h`, `pipeline_cache.cpp`
+- Create: `projects/joon/shaders/scene_basic.vert.hlsl`
+- Create: `projects/joon/shaders/scene_basic.frag.hlsl`
+
+**HLSL shaders (write first, simplest possible).**
+
+`shaders/scene_basic.vert.hlsl`:
+```hlsl
+struct UBO { float4x4 mvp; float4x4 model; };
+[[vk::binding(0, 0)]] ConstantBuffer<UBO> ubo;
+
+struct VSIn  { float3 pos : POSITION; float3 nrm : NORMAL; float2 uv : TEXCOORD0; };
+struct VSOut { float4 sv  : SV_POSITION; float3 normal : NORMAL; float2 uv : TEXCOORD0; };
+
+VSOut main(VSIn v) {
+    VSOut o;
+    o.sv = mul(ubo.mvp, float4(v.pos, 1.0));
+    o.normal = normalize(mul((float3x3)ubo.model, v.nrm));
+    o.uv = v.uv;
+    return o;
+}
+```
+
+`shaders/scene_basic.frag.hlsl`:
+```hlsl
+struct PushLight { float3 light_dir; float pad0; float3 light_color; float pad1; };
+[[vk::push_constant]] PushLight pc;
+
+struct PSIn { float4 sv : SV_POSITION; float3 normal : NORMAL; float2 uv : TEXCOORD0; };
+
+float4 main(PSIn i) : SV_TARGET {
+    float ndotl = saturate(dot(normalize(i.normal), -normalize(pc.light_dir)));
+    float3 col = pc.light_color * (0.1 + 0.9 * ndotl);   // ambient + diffuse
+    return float4(col, 1.0);
+}
+```
+
+**`render_pass.h`:**
+```cpp
+#pragma once
+#include "vulkan/device.h"
+#include <vector>
+
+namespace joon {
+
+struct RenderPass {
+    VkRenderPass pass = VK_NULL_HANDLE;
+    std::vector<VkFormat> color_formats;
+    VkFormat depth_format = VK_FORMAT_D32_SFLOAT;
+};
+
+RenderPass create_color_depth_renderpass(
+    Device& dev,
+    const std::vector<VkFormat>& color_formats,
+    VkFormat depth_format = VK_FORMAT_D32_SFLOAT);
+
+VkFramebuffer create_framebuffer(
+    Device& dev, const RenderPass& rp,
+    const std::vector<VkImageView>& color_views,
+    VkImageView depth_view, uint32_t w, uint32_t h);
+
+void destroy_renderpass(Device& dev, RenderPass& rp);
+
+} // namespace joon
+```
+
+Standard Vulkan boilerplate — color attachments load=`CLEAR`, store=`STORE`, finalLayout=`COLOR_ATTACHMENT_OPTIMAL` (we manually transition to `GENERAL` after end). Depth attachment load=`CLEAR`, finalLayout=`DEPTH_STENCIL_ATTACHMENT_OPTIMAL`.
+
+**PipelineCache extension:** add a parallel `m_graphics_pipelines` keyed by render-pass handle + shader name. `get_graphics(name, render_pass, vertex_layout)` compiles `name.vert.hlsl` and `name.frag.hlsl` via existing DXC path (factored helper), creates pipeline layout matching the shaders' bindings (1 UBO at set 0 binding 0; push constant range for fragment), then `vkCreateGraphicsPipelines` with the supplied vertex input description.
+
+**Test:** `[pipeline][gpu]` — compile both shaders, create a render pass, create a graphics pipeline, assert `pipeline != VK_NULL_HANDLE`. No drawing yet.
+
+**Commit:** `feat(joon): VkRenderPass + VkGraphicsPipeline via PipelineCache::get_graphics`
+
+---
+
+## Phase 5: Geometry Pass Executor
+
+### Task 8: pass executor — render scene to color/depth targets
+
+**Files:**
+- Modify: `projects/joon/src/vulkan/resource_pool.h`, `resource_pool.cpp` (add color-attachment-capable images + depth allocation)
+- Modify: `projects/joon/src/scene/scene_executors.cpp` (`exec_pass` + register `pass`)
+- Modify: `projects/joon/src/interpreter/interpreter.cpp` (defer RENDER nodes to a second walk after compute walk; see Task 5e)
+
+**Step 1: Failing test (full integration)**
+
+```cpp
+// tests/test_geometry_pass.cpp
+#include "catch_amalgamated.hpp"
+#include <joon/joon.h>
+using namespace joon;
+
+TEST_CASE("Geometry pass renders non-clear pixels", "[render][gpu]") {
+    auto ctx = Context::create();
+    auto graph = ctx->parse_string(R"(
+        (cube :scale 1.5 :position [0 0 0])
+        (camera :fov 60 :position [0 0 4] :target [0 0 0])
+        (light :type directional :direction [-1 -1 -1] :color [1 1 1])
+        (def gbuf (pass scene :outputs [albedo depth]))
+        (output gbuf)
+    )");
+    REQUIRE_FALSE(graph.has_errors());
+
+    auto eval = ctx->create_evaluator(graph);
+    eval->evaluate();
+
+    auto px = eval->result("").read_pixels();
+    // Expect *some* lit pixels (not all clear color {0,0,0,1})
+    int lit = 0;
+    for (size_t i = 0; i < px.size(); i += 4)
+        if (px[i] > 0.05f || px[i+1] > 0.05f || px[i+2] > 0.05f) ++lit;
+    CHECK(lit > 100);   // arbitrary, just "non-empty"
+}
+
+TEST_CASE("Compute can read geometry-pass output", "[render][gpu]") {
+    auto ctx = Context::create();
+    auto graph = ctx->parse_string(R"(
+        (cube :scale 1.0)
+        (camera :position [0 0 4])
+        (light :type directional :direction [0 -1 0])
+        (def gbuf (pass scene :outputs [albedo depth]))
+        (def adjusted (levels gbuf :contrast 1.5))
+        (output adjusted)
+    )");
+    auto eval = ctx->create_evaluator(graph);
+    eval->evaluate();
+
+    auto px = eval->result("").read_pixels();
+    // Just make sure it runs end-to-end without crashing and produces data.
+    REQUIRE(px.size() == 512 * 512 * 4);
+}
+```
+
+**Step 2-4: Implement**
+
+`resource_pool.h` extension:
+```cpp
+GpuImage* alloc_render_target(uint32_t node_id, uint32_t w, uint32_t h,
+                               VkFormat format = VK_FORMAT_R8G8B8A8_UNORM);
+GpuImage* alloc_depth(uint32_t node_id, uint32_t w, uint32_t h,
+                       VkFormat format = VK_FORMAT_D32_SFLOAT);
+```
+
+Implementations differ from `alloc_image` only in the `usage` flags (`COLOR_ATTACHMENT_BIT`, `DEPTH_STENCIL_ATTACHMENT_BIT`) and the aspect mask of the image view.
+
+`exec_pass` outline (write straight-through, no sub-extraction at first):
+```cpp
+static void exec_pass(const Node& n, EvalContext& ctx) {
+    // 1. Collect outputs from node kwargs (e.g. :outputs [albedo depth])
+    auto outputs = parse_outputs_kwarg(n);
+    auto albedo = ctx.pool.alloc_render_target(n.id /*color out node id*/, ctx.width, ctx.height);
+    auto depth  = ctx.pool.alloc_depth(n.id + 0x10000000, ctx.width, ctx.height);
+
+    // 2. Build render pass + framebuffer
+    static auto rp = create_color_depth_renderpass(ctx.device, {albedo->format});
+    auto fb = create_framebuffer(ctx.device, rp, {albedo->view}, depth->view, ctx.width, ctx.height);
+
+    // 3. Get/build graphics pipeline
+    VertexLayout layout = vertex_layout_for<Vertex>();
+    auto& gp = ctx.pipelines.get_graphics("scene_basic", rp, layout);
+
+    // 4. Build per-object UBOs (mvp, model) — one buffer + dynamic offsets,
+    //    OR (simpler) one buffer per object for sub-project 2.
+    auto view = look_at(ctx.scene.camera.position, ctx.scene.camera.target, ctx.scene.camera.up);
+    auto proj = perspective(ctx.scene.camera.fov_deg, float(ctx.width)/ctx.height,
+                            ctx.scene.camera.near_z, ctx.scene.camera.far_z);
+
+    // 5. Record one-shot command buffer:
+    auto cmd = ctx.device.begin_single_command();
+    VkClearValue clears[2] = { {.color = {{0,0,0,1}}}, {.depthStencil = {1.0f, 0}} };
+    VkRenderPassBeginInfo rpi{...};   // pass, framebuffer, render area, 2 clears
+    vkCmdBeginRenderPass(cmd, &rpi, VK_SUBPASS_CONTENTS_INLINE);
+    vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, gp.pipeline);
+
+    PushLight pc{normalize(ctx.scene.lights[0].direction), 0,
+                  ctx.scene.lights[0].color * ctx.scene.lights[0].intensity, 0};
+    vkCmdPushConstants(cmd, gp.layout, VK_SHADER_STAGE_FRAGMENT_BIT, 0, sizeof(pc), &pc);
+
+    for (auto& obj : ctx.scene.objects) {
+        // Upload geometry per-eval (free at end). Optimization later.
+        auto vb = create_vertex_buffer(ctx.device, obj.mesh.vertices.data(),
+                                        obj.mesh.vertices.size() * sizeof(Vertex));
+        auto ib = create_index_buffer (ctx.device, obj.mesh.indices.data(),
+                                        obj.mesh.indices.size() * sizeof(uint32_t));
+
+        auto model = compose(obj.position, obj.rotation, obj.scale);
+        auto mvp = proj * view * model;
+        UBO u{mvp, model};
+        auto ub = create_uniform_buffer(ctx.device, sizeof(UBO));
+        update_uniform_buffer(ctx.device, ub, &u, sizeof(UBO));
+
+        // Allocate descriptor set, write UBO, bind set, bind VB/IB, draw indexed
+        // ...
+        ctx.frame_buffers_to_free.push_back({vb, ib, ub});
+    }
+    vkCmdEndRenderPass(cmd);
+
+    // 6. Transition color attachment to GENERAL for downstream compute / viewport
+    image_barrier(cmd, albedo->image,
+        VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL, VK_IMAGE_LAYOUT_GENERAL,
+        VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT, VK_ACCESS_SHADER_READ_BIT);
+
+    ctx.device.end_single_command(cmd);
+
+    // 7. Free per-frame buffers + framebuffer (real pooling is a follow-up)
+    for (auto& f : ctx.frame_buffers_to_free) {
+        destroy_buffer(ctx.device, f.vb);
+        destroy_buffer(ctx.device, f.ib);
+        destroy_buffer(ctx.device, f.ub);
+    }
+    ctx.frame_buffers_to_free.clear();
+    vkDestroyFramebuffer(ctx.device.device, fb, nullptr);
+}
+```
+
+`Interpreter::evaluate` change: after the existing topological walk, do a second pass over RENDER-tier nodes in topological order. (Or extend the single walk to handle them last by op-tier comparison.)
+
+**Step 5: Run all tests, verify pass.**
+
+**Step 6: Commit**
+```bash
+git commit -am "feat(joon): geometry pass executor renders scene to color+depth targets"
+```
+
+---
+
+## Phase 6: Wire Compute Graph + GUI
+
+### Task 9: Confirm pass output is consumable as a compute input
+
+The second test in Task 8 already covers this end-to-end. If `levels` reads the geometry-pass output cleanly, no further IR plumbing is needed (since both write into `ResourcePool` keyed by node id). If the test fails because the compute path expects `STORAGE_IMAGE` usage but the render target was allocated with only `COLOR_ATTACHMENT_BIT`, fix `alloc_render_target` to also include `STORAGE_BIT | SAMPLED_BIT`.
+
+**Step 1-3:** Iterate on test until it passes — the failure mode here is informative and shouldn't be guessed at; trust the test output.
+
+**Step 4: Commit any fix as `fix(joon): render targets need STORAGE_BIT for compute reads` (only if needed).**
+
+---
+
+### Task 10: Update gui default DSL to a 3D scene
+
+**Files:**
+- Modify: `projects/joon/gui/app.cpp`
+
+```cpp
+dsl_source = R"(; Joon - 3D scene
+(cube :scale 1.0 :position [0 0 0])
+(camera :fov 60 :position [0 1 4] :target [0 0 0])
+(light :type directional :direction [-0.5 -1 -0.5] :color [1 1 1] :intensity 1.0)
+(def gbuf (pass scene :outputs [albedo depth]))
+(param contrast float 1.0 :min 0.0 :max 3.0)
+(def final (levels gbuf :contrast contrast))
+(output final)
+)";
+```
+
+**Verify manually:** build joon-gui, run it, confirm a shaded cube appears in the viewport. Drag the contrast slider and confirm real-time updates. Check log.txt — no Vulkan validation errors.
+
+**Step: Commit**
+```bash
+git commit -am "feat(joon): default GUI DSL renders a 3D cube via geometry pass"
+```
+
+---
+
+## Phase 7: Final Verification
+
+### Task 11: Run the full test plan, then open PR
+
+- [ ] Clean build: `rm -rf build && /d/prg/premake5.exe vs2022`
+- [ ] Build all 4 projects in Debug
+- [ ] Run `joon-tests` — all tests pass (38 + new tests for scene/render)
+- [ ] Run `joon-gui` — visual confirmation of cube rendering
+- [ ] CI on PR shows all 4 checks green
+
+Push the branch and open a PR titled **"feat(joon): scene graph and hardcoded geometry pass (sub-project 2)"** linking back to this plan and the design spec.
+
+---
+
+## Open Questions (resolve before implementing)
+
+1. **Vec/matrix math.** Does joon already have a vec3/mat4 library? The architecture map didn't surface one explicitly. **Check `include/joon/types.h`** — if it has only the scalar `Type` enum, we need either a tiny inline math header OR adopt one of the deps already pulled in (VMA's internal types are not public). A simple `joon/math.h` with `vec2/vec3/vec4/mat4` plus `look_at`, `perspective`, multiplication is ~200 lines and worth keeping in-tree.
+
+2. **Per-evaluate buffer allocation.** Sub-project 2 creates vertex/index/uniform buffers fresh every `evaluate()` call. This is fine for correctness but means the GUI slider re-uploads geometry on every frame. Is that acceptable for this sub-project? (Yes, per design — pooling is a follow-up if profiling shows it's needed.)
+
+3. **Multiple light support.** The fragment shader hardcodes `lights[0]`. Multiple lights via push-constant array or UBO array can wait for sub-project 3.
+
+Before starting Task 1, surface these to the user if uncertain.

--- a/projects/joon/gui/app.cpp
+++ b/projects/joon/gui/app.cpp
@@ -7,11 +7,14 @@ void App::init() {
     ctx = joon::Context::create();
     ctx->device().log_fn = joon_log::write;
 
-    dsl_source = R"(; Joon - edit this code
-(def base (noise :scale 4.0 :octaves 3))
-(param contrast float 1.2 :min 0.0 :max 3.0)
-(def result (levels base :contrast contrast))
-(output result)
+    dsl_source = R"(; Joon - 3D scene
+(def c (cube :scale 1.0))
+(def cam (camera :fov 60))
+(def l (light :intensity 1.0))
+(def gbuf (pass))
+(param contrast float 1.0 :min 0.0 :max 3.0)
+(def final (levels gbuf :contrast contrast))
+(output final)
 )";
 
     VkSamplerCreateInfo sampler_info{};

--- a/projects/joon/include/joon/evaluator.h
+++ b/projects/joon/include/joon/evaluator.h
@@ -12,6 +12,7 @@ class Graph;
 struct Diagnostic;
 class ResourcePool;
 struct GpuImage;
+struct SceneCollection;
 
 template<typename T>
 class Param {
@@ -55,6 +56,11 @@ public:
     Result node_result(const std::string& name);
 
     const std::vector<Diagnostic>& diagnostics() const;
+
+    // Test-only accessor returning the most recent SceneCollection populated
+    // during evaluate(). Sub-project 2 exposes this so unit tests can verify
+    // scene-tier executors without going through the renderer.
+    const SceneCollection& scene_for_test() const;
 
 private:
     friend class Context;

--- a/projects/joon/include/joon/math.h
+++ b/projects/joon/include/joon/math.h
@@ -1,0 +1,119 @@
+#pragma once
+
+#include <joon/types.h>
+#include <cmath>
+
+namespace joon {
+
+// Column-major mat4 (matches Vulkan/HLSL convention: matrix * column-vector).
+// `m[col*4 + row]` indexing — OR helpers below for readability.
+
+constexpr float PI = 3.14159265358979323846f;
+
+inline float radians(float deg) { return deg * (PI / 180.0f); }
+
+inline mat4 identity_mat4() {
+    mat4 r{};
+    r.m[0] = 1; r.m[5] = 1; r.m[10] = 1; r.m[15] = 1;
+    return r;
+}
+
+inline mat4 mul(const mat4& a, const mat4& b) {
+    mat4 r{};
+    for (int c = 0; c < 4; ++c)
+        for (int row = 0; row < 4; ++row) {
+            float s = 0;
+            for (int k = 0; k < 4; ++k)
+                s += a.m[k * 4 + row] * b.m[c * 4 + k];
+            r.m[c * 4 + row] = s;
+        }
+    return r;
+}
+
+inline vec3 vec3_sub(vec3 a, vec3 b) { return {a.x - b.x, a.y - b.y, a.z - b.z}; }
+inline vec3 vec3_cross(vec3 a, vec3 b) {
+    return {a.y * b.z - a.z * b.y,
+            a.z * b.x - a.x * b.z,
+            a.x * b.y - a.y * b.x};
+}
+inline float vec3_dot(vec3 a, vec3 b) { return a.x * b.x + a.y * b.y + a.z * b.z; }
+inline float vec3_len(vec3 a) { return std::sqrt(vec3_dot(a, a)); }
+inline vec3  vec3_normalize(vec3 a) {
+    float l = vec3_len(a);
+    return l > 0 ? vec3{a.x / l, a.y / l, a.z / l} : vec3{0, 0, 0};
+}
+
+// Translation matrix.
+inline mat4 translate(vec3 t) {
+    mat4 r = identity_mat4();
+    r.m[12] = t.x; r.m[13] = t.y; r.m[14] = t.z;
+    return r;
+}
+
+// Scale matrix.
+inline mat4 scale(vec3 s) {
+    mat4 r{};
+    r.m[0] = s.x; r.m[5] = s.y; r.m[10] = s.z; r.m[15] = 1;
+    return r;
+}
+
+// Rotation matrices (Euler XYZ in radians).
+inline mat4 rotate_x(float r) {
+    mat4 m = identity_mat4();
+    float c = std::cos(r), s = std::sin(r);
+    m.m[5] =  c; m.m[6]  = s;
+    m.m[9] = -s; m.m[10] = c;
+    return m;
+}
+inline mat4 rotate_y(float r) {
+    mat4 m = identity_mat4();
+    float c = std::cos(r), s = std::sin(r);
+    m.m[0]  = c; m.m[2]  = -s;
+    m.m[8]  = s; m.m[10] =  c;
+    return m;
+}
+inline mat4 rotate_z(float r) {
+    mat4 m = identity_mat4();
+    float c = std::cos(r), s = std::sin(r);
+    m.m[0] =  c; m.m[1] = s;
+    m.m[4] = -s; m.m[5] = c;
+    return m;
+}
+
+// Compose TRS — translate * rotateZ * rotateY * rotateX * scale (XYZ Euler).
+inline mat4 compose_trs(vec3 position, vec3 rotation, vec3 sc) {
+    return mul(translate(position),
+               mul(rotate_z(rotation.z),
+                   mul(rotate_y(rotation.y),
+                       mul(rotate_x(rotation.x),
+                           scale(sc)))));
+}
+
+// Right-handed look-at — Vulkan-friendly view matrix.
+inline mat4 look_at(vec3 eye, vec3 target, vec3 up_hint) {
+    vec3 f = vec3_normalize(vec3_sub(target, eye));   // forward
+    vec3 s = vec3_normalize(vec3_cross(f, up_hint));  // right
+    vec3 u = vec3_cross(s, f);                         // true up
+
+    mat4 r{};
+    r.m[0] = s.x;   r.m[4] = s.y;   r.m[8]  = s.z;   r.m[12] = -vec3_dot(s, eye);
+    r.m[1] = u.x;   r.m[5] = u.y;   r.m[9]  = u.z;   r.m[13] = -vec3_dot(u, eye);
+    r.m[2] = -f.x;  r.m[6] = -f.y;  r.m[10] = -f.z;  r.m[14] =  vec3_dot(f, eye);
+    r.m[15] = 1.0f;
+    return r;
+}
+
+// Right-handed perspective with Vulkan clip space (depth in [0, 1], Y-down by
+// flipping m[5] sign). fov_deg is the vertical field of view.
+inline mat4 perspective_vk(float fov_deg, float aspect, float near_z, float far_z) {
+    float f = 1.0f / std::tan(radians(fov_deg) * 0.5f);
+    mat4 r{};
+    r.m[0]  = f / aspect;
+    r.m[5]  = -f;                          // negate to flip Y for Vulkan clip space
+    r.m[10] = far_z / (near_z - far_z);
+    r.m[11] = -1.0f;
+    r.m[14] = (near_z * far_z) / (near_z - far_z);
+    return r;
+}
+
+} // namespace joon

--- a/projects/joon/include/joon/scene.h
+++ b/projects/joon/include/joon/scene.h
@@ -1,0 +1,60 @@
+#pragma once
+#include <joon/types.h>
+#include <vector>
+#include <cstdint>
+
+namespace joon {
+
+struct Vertex {
+    vec3 position;
+    vec3 normal;
+    vec2 uv;
+};
+
+struct Mesh {
+    std::vector<Vertex> vertices;
+    std::vector<uint32_t> indices;
+};
+
+struct SceneObject {
+    Mesh mesh;
+    vec3 position{0, 0, 0};
+    vec3 rotation{0, 0, 0};   // Euler XYZ, radians
+    vec3 scale{1, 1, 1};
+    // Material wired by node id when fragment shading is per-object.
+    // Sub-project 2 uses a single hardcoded fragment, so this is unused for now.
+    uint32_t material_node_id = 0;
+};
+
+enum class LightType { Directional, Point, Spot };
+
+struct Light {
+    LightType type = LightType::Directional;
+    vec3 direction{0, -1, 0};   // directional / spot
+    vec3 position{0, 0, 0};     // point / spot
+    vec3 color{1, 1, 1};
+    float intensity = 1.0f;
+    float spot_angle_deg = 30.0f;
+};
+
+struct Camera {
+    float fov_deg = 60.0f;
+    vec3 position{0, 0, 5};
+    vec3 target{0, 0, 0};
+    vec3 up{0, 1, 0};
+    float near_z = 0.1f;
+    float far_z = 100.0f;
+};
+
+struct SceneCollection {
+    std::vector<SceneObject> objects;
+    std::vector<Light> lights;
+    Camera camera;
+
+    void clear();
+    void add_object(SceneObject obj);
+    void add_light(Light l);
+    void set_camera(Camera c);
+};
+
+} // namespace joon

--- a/projects/joon/include/joon/scene.h
+++ b/projects/joon/include/joon/scene.h
@@ -23,7 +23,8 @@ struct SceneObject {
     vec3 scale{1, 1, 1};
     // Material wired by node id when fragment shading is per-object.
     // Sub-project 2 uses a single hardcoded fragment, so this is unused for now.
-    uint32_t material_node_id = 0;
+    // UINT32_MAX = unset; matches ResolvedKwarg::source_node convention in ir/node.h.
+    uint32_t material_node_id = UINT32_MAX;
 };
 
 enum class LightType { Directional, Point, Spot };

--- a/projects/joon/include/joon/types.h
+++ b/projects/joon/include/joon/types.h
@@ -42,7 +42,11 @@ enum class Type {
     VEC4,
     MAT3,
     MAT4,
-    IMAGE
+    IMAGE,
+    SCENE_OBJECT,
+    LIGHT,
+    CAMERA,
+    RENDER_TARGET
 };
 
 using Value = std::variant<

--- a/projects/joon/shaders/scene_basic.frag.hlsl
+++ b/projects/joon/shaders/scene_basic.frag.hlsl
@@ -1,0 +1,24 @@
+// Hardcoded fragment shader for the sub-project 2 geometry pass.
+// Single directional light via push constants; ambient + lambert.
+
+struct PushLight {
+    float3 light_dir;
+    float pad0;
+    float3 light_color;
+    float pad1;
+};
+
+[[vk::push_constant]] PushLight pc;
+
+struct PSIn {
+    float4 sv     : SV_POSITION;
+    float3 normal : NORMAL;
+    float2 uv     : TEXCOORD0;
+};
+
+float4 main(PSIn i) : SV_TARGET {
+    float3 n = normalize(i.normal);
+    float ndotl = saturate(dot(n, -normalize(pc.light_dir)));
+    float3 col = pc.light_color * (0.1 + 0.9 * ndotl);   // ambient + diffuse
+    return float4(col, 1.0);
+}

--- a/projects/joon/shaders/scene_basic.vert.hlsl
+++ b/projects/joon/shaders/scene_basic.vert.hlsl
@@ -1,0 +1,31 @@
+// Hardcoded vertex shader for the sub-project 2 geometry pass.
+// Reads UBO {mvp, model} from descriptor set 0 binding 0, transforms position
+// and normal into clip / world space, passes UV through.
+
+struct UBO {
+    float4x4 mvp;
+    float4x4 model;
+};
+
+[[vk::binding(0, 0)]] ConstantBuffer<UBO> ubo;
+
+struct VSIn {
+    [[vk::location(0)]] float3 pos    : POSITION;
+    [[vk::location(1)]] float3 normal : NORMAL;
+    [[vk::location(2)]] float2 uv     : TEXCOORD0;
+};
+
+struct VSOut {
+    float4 sv     : SV_POSITION;
+    float3 normal : NORMAL;
+    float2 uv     : TEXCOORD0;
+};
+
+VSOut main(VSIn v) {
+    VSOut o;
+    o.sv = mul(ubo.mvp, float4(v.pos, 1.0));
+    // World-space normal — transpose-of-inverse omitted; for uniform scale this is fine.
+    o.normal = normalize(mul((float3x3)ubo.model, v.normal));
+    o.uv = v.uv;
+    return o;
+}

--- a/projects/joon/src/evaluator.cpp
+++ b/projects/joon/src/evaluator.cpp
@@ -114,15 +114,17 @@ struct Evaluator::Impl {
         graph = ctx.parse_string(""); // placeholder
         graph.ir() = source_graph.ir(); // copy IR
 
-        VkDescriptorPoolSize pool_size{};
-        pool_size.type = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
-        pool_size.descriptorCount = 256;
+        VkDescriptorPoolSize pool_sizes[2]{};
+        pool_sizes[0].type = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
+        pool_sizes[0].descriptorCount = 256;
+        pool_sizes[1].type = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+        pool_sizes[1].descriptorCount = 256;   // for graphics-pipeline UBOs (geometry pass)
 
         VkDescriptorPoolCreateInfo pool_info{};
         pool_info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
-        pool_info.maxSets = 128;
-        pool_info.poolSizeCount = 1;
-        pool_info.pPoolSizes = &pool_size;
+        pool_info.maxSets = 256;
+        pool_info.poolSizeCount = 2;
+        pool_info.pPoolSizes = pool_sizes;
         pool_info.flags = VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT;
         vkCreateDescriptorPool(ctx.device().device, &pool_info, nullptr, &desc_pool);
     }

--- a/projects/joon/src/evaluator.cpp
+++ b/projects/joon/src/evaluator.cpp
@@ -1,6 +1,7 @@
 #include <joon/evaluator.h>
 #include <joon/context.h>
 #include <joon/graph.h>
+#include <joon/scene.h>
 #include "ir/ir_graph.h"
 #include "interpreter/interpreter.h"
 #include "nodes/node_registry.h"
@@ -102,6 +103,7 @@ struct Evaluator::Impl {
     NodeRegistry registry;
     std::unique_ptr<PipelineCache> pipelines;
     VkDescriptorPool desc_pool = VK_NULL_HANDLE;
+    SceneCollection scene;
 
     Impl(Context& ctx, const Graph& source_graph)
         : ctx(ctx),
@@ -140,12 +142,16 @@ Evaluator::~Evaluator() = default;
 void Evaluator::evaluate() {
     vkResetDescriptorPool(m_impl->ctx.device().device, m_impl->desc_pool, 0);
 
+    // Drop any scene state from a previous evaluate so re-runs don't accumulate.
+    m_impl->scene.clear();
+
     EvalContext eval_ctx{
         m_impl->ctx.device(),
         m_impl->ctx.pool(),
         *m_impl->pipelines,
         512, 512,
-        m_impl->desc_pool
+        m_impl->desc_pool,
+        m_impl->scene
     };
 
     Interpreter interp(eval_ctx, m_impl->registry);
@@ -183,6 +189,10 @@ Result Evaluator::node_result(const std::string& name) {
 
 const std::vector<Diagnostic>& Evaluator::diagnostics() const {
     return m_impl->graph.ir().diagnostics;
+}
+
+const SceneCollection& Evaluator::scene_for_test() const {
+    return m_impl->scene;
 }
 
 } // namespace joon

--- a/projects/joon/src/interpreter/interpreter.cpp
+++ b/projects/joon/src/interpreter/interpreter.cpp
@@ -8,6 +8,11 @@ Interpreter::Interpreter(EvalContext& ctx, const NodeRegistry& registry)
 void Interpreter::evaluate(IRGraph& graph) {
     auto order = graph.topological_order();
 
+    // RENDER nodes (e.g. `pass`) must run AFTER all SCENE collection and GPU
+    // compute is done — the geometry pass needs the populated SceneCollection
+    // and any compute-produced textures it samples. Defer them.
+    std::vector<uint32_t> deferred_render;
+
     for (uint32_t id : order) {
         auto& node = graph.nodes[id];
 
@@ -35,10 +40,23 @@ void Interpreter::evaluate(IRGraph& graph) {
                 kw.value = graph.nodes[kw.source_node].constant_value;
         }
 
+        if (node.tier == Tier::RENDER) {
+            deferred_render.push_back(id);
+            continue;
+        }
+
         auto* executor = m_registry.find(node.op);
         if (executor) {
             (*executor)(node, m_ctx);
         }
+    }
+
+    // Deferred RENDER pass — no executors registered for these in sub-project 2's
+    // Task 5; Task 8 wires up `pass`. Nodes without executors are skipped harmlessly.
+    for (uint32_t id : deferred_render) {
+        auto& node = graph.nodes[id];
+        auto* executor = m_registry.find(node.op);
+        if (executor) (*executor)(node, m_ctx);
     }
 }
 

--- a/projects/joon/src/interpreter/interpreter.cpp
+++ b/projects/joon/src/interpreter/interpreter.cpp
@@ -8,19 +8,32 @@ Interpreter::Interpreter(EvalContext& ctx, const NodeRegistry& registry)
 void Interpreter::evaluate(IRGraph& graph) {
     auto order = graph.topological_order();
 
-    // RENDER nodes (e.g. `pass`) must run AFTER all SCENE collection and GPU
-    // compute is done — the geometry pass needs the populated SceneCollection
-    // and any compute-produced textures it samples. Defer them.
-    std::vector<uint32_t> deferred_render;
-
+    // Phase 1: SCENE-tier executors. Scene nodes carry no inter-edges in the
+    // current DSL, so their topo position relative to RENDER/GPU consumers is
+    // arbitrary; doing them as a separate pre-pass guarantees the
+    // SceneCollection is fully populated before any pass executor runs.
     for (uint32_t id : order) {
         auto& node = graph.nodes[id];
+        if (node.tier != Tier::SCENE) continue;
 
-        // Skip nodes that don't produce GPU resources
+        for (auto& kw : node.kwargs) {
+            if (kw.source_node != UINT32_MAX && kw.source_node < graph.nodes.size())
+                kw.value = graph.nodes[kw.source_node].constant_value;
+        }
+
+        auto* executor = m_registry.find(node.op);
+        if (executor) (*executor)(node, m_ctx);
+    }
+
+    // Phase 2: CPU constants + GPU compute + RENDER passes in topological
+    // order so producer-consumer chains (e.g. pass → levels) execute correctly.
+    for (uint32_t id : order) {
+        auto& node = graph.nodes[id];
+        if (node.tier == Tier::SCENE) continue;   // already done
+
+        // Skip nodes that don't produce GPU resources via an executor
         if (node.op == "constant" || node.op == "string_constant" ||
             node.op == "param" || node.op == "error") {
-            // For constant float nodes that feed into GPU ops,
-            // we need to create a constant image so math ops can consume them
             if ((node.op == "constant" || node.op == "param") && node.is_constant) {
                 float val = value_as_float(node.constant_value);
                 auto* img = m_ctx.pool.alloc_image(node.id,
@@ -40,21 +53,6 @@ void Interpreter::evaluate(IRGraph& graph) {
                 kw.value = graph.nodes[kw.source_node].constant_value;
         }
 
-        if (node.tier == Tier::RENDER) {
-            deferred_render.push_back(id);
-            continue;
-        }
-
-        auto* executor = m_registry.find(node.op);
-        if (executor) {
-            (*executor)(node, m_ctx);
-        }
-    }
-
-    // Deferred RENDER pass — no executors registered for these in sub-project 2's
-    // Task 5; Task 8 wires up `pass`. Nodes without executors are skipped harmlessly.
-    for (uint32_t id : deferred_render) {
-        auto& node = graph.nodes[id];
         auto* executor = m_registry.find(node.op);
         if (executor) (*executor)(node, m_ctx);
     }

--- a/projects/joon/src/ir/ir_graph.cpp
+++ b/projects/joon/src/ir/ir_graph.cpp
@@ -1,6 +1,7 @@
 #include "ir/ir_graph.h"
 #include <algorithm>
 #include <queue>
+#include <unordered_set>
 
 namespace joon {
 
@@ -96,12 +97,32 @@ uint32_t IRGraph::resolve_expr(const AstNode& expr) {
     }
 
     if (auto* call = std::get_if<CallNode>(&expr.data)) {
-        Tier tier = Tier::GPU;
-        if (call->op == "image" || call->op == "color" || call->op == "save") {
+        static const std::unordered_set<std::string> SCENE_OPS = {
+            "cube", "sphere", "plane", "cylinder", "mesh", "light", "camera"
+        };
+        static const std::unordered_set<std::string> RENDER_OPS = { "pass" };
+        static const std::unordered_set<std::string> CPU_OPS = {
+            "image", "color", "save"
+        };
+
+        Tier tier;
+        Type output_type = Type::FLOAT;
+        if (SCENE_OPS.count(call->op)) {
+            tier = Tier::SCENE;
+            if (call->op == "light") output_type = Type::LIGHT;
+            else if (call->op == "camera") output_type = Type::CAMERA;
+            else output_type = Type::SCENE_OBJECT;
+        } else if (RENDER_OPS.count(call->op)) {
+            tier = Tier::RENDER;
+            output_type = Type::RENDER_TARGET;
+        } else if (CPU_OPS.count(call->op)) {
             tier = Tier::CPU;
+        } else {
+            tier = Tier::GPU;
         }
 
         uint32_t id = add_node(call->op, tier);
+        nodes[id].output_type = output_type;
 
         for (auto& arg : call->args) {
             uint32_t input_id = resolve_expr(*arg);

--- a/projects/joon/src/ir/node.h
+++ b/projects/joon/src/ir/node.h
@@ -8,6 +8,9 @@
 
 namespace joon {
 
+// Order matches interpreter execution phases: CPU constants resolve first,
+// then GPU compute dispatches, then SCENE collection, then RENDER pass.
+// Don't reorder without auditing the interpreter walk in interpreter.cpp.
 enum class Tier { CPU, GPU, SCENE, RENDER };
 
 struct Edge {

--- a/projects/joon/src/ir/node.h
+++ b/projects/joon/src/ir/node.h
@@ -8,7 +8,7 @@
 
 namespace joon {
 
-enum class Tier { GPU, CPU };
+enum class Tier { CPU, GPU, SCENE, RENDER };
 
 struct Edge {
     uint32_t from_node;

--- a/projects/joon/src/ir/type_checker.cpp
+++ b/projects/joon/src/ir/type_checker.cpp
@@ -30,6 +30,12 @@ void type_check(IRGraph& graph) {
             continue;
         }
 
+        // Scene and render tiers carry their own output types set during
+        // IR lowering; type checking for those is handled by future passes.
+        if (node.tier == Tier::SCENE || node.tier == Tier::RENDER) {
+            continue;
+        }
+
         if (node.op == "image") {
             node.output_type = Type::IMAGE;
             continue;

--- a/projects/joon/src/nodes/node_registry.cpp
+++ b/projects/joon/src/nodes/node_registry.cpp
@@ -21,6 +21,7 @@ NodeRegistry NodeRegistry::create_default() {
     register_image_ops(reg);
     register_save(reg);
     register_scene_nodes(reg);
+    register_geometry_pass(reg);
     return reg;
 }
 

--- a/projects/joon/src/nodes/node_registry.cpp
+++ b/projects/joon/src/nodes/node_registry.cpp
@@ -20,6 +20,7 @@ NodeRegistry NodeRegistry::create_default() {
     register_math_ops(reg);
     register_image_ops(reg);
     register_save(reg);
+    register_scene_nodes(reg);
     return reg;
 }
 

--- a/projects/joon/src/nodes/node_registry.h
+++ b/projects/joon/src/nodes/node_registry.h
@@ -42,5 +42,6 @@ void register_math_ops(NodeRegistry& reg);
 void register_image_ops(NodeRegistry& reg);
 void register_save(NodeRegistry& reg);
 void register_scene_nodes(NodeRegistry& reg);
+void register_geometry_pass(NodeRegistry& reg);
 
 } // namespace joon

--- a/projects/joon/src/nodes/node_registry.h
+++ b/projects/joon/src/nodes/node_registry.h
@@ -10,6 +10,8 @@
 
 namespace joon {
 
+struct SceneCollection;
+
 struct EvalContext {
     Device& device;
     ResourcePool& pool;
@@ -17,6 +19,7 @@ struct EvalContext {
     uint32_t default_width;
     uint32_t default_height;
     VkDescriptorPool desc_pool;
+    SceneCollection& scene;
 };
 
 using NodeExecutor = std::function<void(const Node& node, EvalContext& ctx)>;
@@ -38,5 +41,6 @@ void register_color(NodeRegistry& reg);
 void register_math_ops(NodeRegistry& reg);
 void register_image_ops(NodeRegistry& reg);
 void register_save(NodeRegistry& reg);
+void register_scene_nodes(NodeRegistry& reg);
 
 } // namespace joon

--- a/projects/joon/src/scene/geometry_pass.cpp
+++ b/projects/joon/src/scene/geometry_pass.cpp
@@ -1,0 +1,191 @@
+#include "scene/geometry_pass.h"
+#include "nodes/node_registry.h"
+#include "ir/node.h"
+#include "vulkan/buffer.h"
+#include "vulkan/render_pass.h"
+#include <joon/scene.h>
+#include <joon/math.h>
+#include <vector>
+#include <cstring>
+
+namespace joon {
+
+namespace {
+
+// Vertex shader UBO — must match scene_basic.vert.hlsl layout.
+struct UBO {
+    mat4 mvp;
+    mat4 model;
+};
+
+// Fragment shader push constant — must match scene_basic.frag.hlsl layout.
+struct PushLight {
+    float light_dir[3];
+    float pad0;
+    float light_color[3];
+    float pad1;
+};
+
+void exec_pass(const Node& n, EvalContext& ctx) {
+    // The pass node owns the color render-target slot at its own node id.
+    // The depth slot is keyed at (node_id ^ 0x80000000) — outside the normal
+    // node-id range so it can't collide with another graph node.
+    uint32_t color_id = n.id;
+    uint32_t depth_id = n.id ^ 0x80000000u;
+
+    auto* albedo = ctx.pool.alloc_render_target(color_id, ctx.default_width, ctx.default_height);
+    auto* depth  = ctx.pool.alloc_depth        (depth_id, ctx.default_width, ctx.default_height);
+
+    // Render pass + framebuffer — created per-evaluate (caching is a follow-up).
+    RenderPass rp = create_color_depth_renderpass(ctx.device, { albedo->format });
+    VkFramebuffer fb = create_framebuffer(ctx.device, rp, { albedo->view }, depth->view,
+                                           ctx.default_width, ctx.default_height);
+
+    const auto& gp = ctx.pipelines.get_graphics("scene_basic", rp.pass, sizeof(PushLight));
+
+    // Camera matrices — fall back to defaults if no camera was set.
+    const auto& cam = ctx.scene.camera;
+    mat4 view = look_at(cam.position, cam.target, cam.up);
+    mat4 proj = perspective_vk(cam.fov_deg,
+                                static_cast<float>(ctx.default_width)
+                                    / static_cast<float>(ctx.default_height),
+                                cam.near_z, cam.far_z);
+
+    // Light push constant — first directional light or default.
+    PushLight pc{};
+    if (!ctx.scene.lights.empty()) {
+        const auto& l = ctx.scene.lights[0];
+        pc.light_dir[0]   = l.direction.x;
+        pc.light_dir[1]   = l.direction.y;
+        pc.light_dir[2]   = l.direction.z;
+        pc.light_color[0] = l.color.x * l.intensity;
+        pc.light_color[1] = l.color.y * l.intensity;
+        pc.light_color[2] = l.color.z * l.intensity;
+    } else {
+        pc.light_dir[0] = 0; pc.light_dir[1] = -1; pc.light_dir[2] = 0;
+        pc.light_color[0] = pc.light_color[1] = pc.light_color[2] = 1.0f;
+    }
+
+    VkCommandBuffer cmd = ctx.device.begin_single_command();
+
+    VkClearValue clears[2];
+    clears[0].color = {{ 0.0f, 0.0f, 0.0f, 1.0f }};
+    clears[1].depthStencil = { 1.0f, 0 };
+
+    VkRenderPassBeginInfo rpi{};
+    rpi.sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;
+    rpi.renderPass = rp.pass;
+    rpi.framebuffer = fb;
+    rpi.renderArea.extent = { ctx.default_width, ctx.default_height };
+    rpi.clearValueCount = 2;
+    rpi.pClearValues = clears;
+
+    vkCmdBeginRenderPass(cmd, &rpi, VK_SUBPASS_CONTENTS_INLINE);
+
+    VkViewport vp{};
+    vp.x = 0; vp.y = 0;
+    vp.width  = static_cast<float>(ctx.default_width);
+    vp.height = static_cast<float>(ctx.default_height);
+    vp.minDepth = 0; vp.maxDepth = 1;
+    vkCmdSetViewport(cmd, 0, 1, &vp);
+
+    VkRect2D scissor{};
+    scissor.offset = { 0, 0 };
+    scissor.extent = { ctx.default_width, ctx.default_height };
+    vkCmdSetScissor(cmd, 0, 1, &scissor);
+
+    vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, gp.pipeline);
+    vkCmdPushConstants(cmd, gp.layout, VK_SHADER_STAGE_FRAGMENT_BIT, 0, sizeof(pc), &pc);
+
+    // Per-frame buffers — freed after submit.
+    std::vector<GpuBuffer> per_frame_bufs;
+    per_frame_bufs.reserve(ctx.scene.objects.size() * 3);
+
+    for (const auto& obj : ctx.scene.objects) {
+        if (obj.mesh.vertices.empty() || obj.mesh.indices.empty()) continue;
+
+        auto vb = create_vertex_buffer(ctx.device,
+                                        obj.mesh.vertices.data(),
+                                        obj.mesh.vertices.size() * sizeof(Vertex));
+        auto ib = create_index_buffer(ctx.device,
+                                       obj.mesh.indices.data(),
+                                       obj.mesh.indices.size() * sizeof(uint32_t));
+
+        UBO u;
+        u.model = compose_trs(obj.position, obj.rotation, obj.scale);
+        u.mvp = mul(proj, mul(view, u.model));
+        auto ub = create_uniform_buffer(ctx.device, sizeof(UBO));
+        update_uniform_buffer(ctx.device, ub, &u, sizeof(UBO));
+
+        VkDescriptorSetAllocateInfo dai{};
+        dai.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
+        dai.descriptorPool = ctx.desc_pool;
+        dai.descriptorSetCount = 1;
+        dai.pSetLayouts = &gp.desc_layout;
+        VkDescriptorSet ds = VK_NULL_HANDLE;
+        vkAllocateDescriptorSets(ctx.device.device, &dai, &ds);
+
+        VkDescriptorBufferInfo dbi{};
+        dbi.buffer = ub.buffer;
+        dbi.offset = 0;
+        dbi.range = sizeof(UBO);
+
+        VkWriteDescriptorSet wds{};
+        wds.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+        wds.dstSet = ds;
+        wds.dstBinding = 0;
+        wds.descriptorCount = 1;
+        wds.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+        wds.pBufferInfo = &dbi;
+        vkUpdateDescriptorSets(ctx.device.device, 1, &wds, 0, nullptr);
+
+        vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, gp.layout,
+                                 0, 1, &ds, 0, nullptr);
+
+        VkBuffer vb_handle = vb.buffer;
+        VkDeviceSize offset = 0;
+        vkCmdBindVertexBuffers(cmd, 0, 1, &vb_handle, &offset);
+        vkCmdBindIndexBuffer(cmd, ib.buffer, 0, VK_INDEX_TYPE_UINT32);
+        vkCmdDrawIndexed(cmd, static_cast<uint32_t>(obj.mesh.indices.size()), 1, 0, 0, 0);
+
+        per_frame_bufs.push_back(vb);
+        per_frame_bufs.push_back(ib);
+        per_frame_bufs.push_back(ub);
+    }
+
+    vkCmdEndRenderPass(cmd);
+
+    // Transition color attachment from COLOR_ATTACHMENT_OPTIMAL → GENERAL so
+    // downstream compute and the GUI viewport can read it.
+    VkImageMemoryBarrier barrier{};
+    barrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+    barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    barrier.oldLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+    barrier.newLayout = VK_IMAGE_LAYOUT_GENERAL;
+    barrier.image = albedo->image;
+    barrier.subresourceRange = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1 };
+    barrier.srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+    barrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_SHADER_WRITE_BIT
+                          | VK_ACCESS_TRANSFER_READ_BIT;
+    vkCmdPipelineBarrier(cmd,
+                          VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+                          VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT
+                              | VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT
+                              | VK_PIPELINE_STAGE_TRANSFER_BIT,
+                          0, 0, nullptr, 0, nullptr, 1, &barrier);
+
+    ctx.device.end_single_command(cmd);
+
+    for (auto& b : per_frame_bufs) destroy_buffer(ctx.device, b);
+    vkDestroyFramebuffer(ctx.device.device, fb, nullptr);
+    destroy_renderpass(ctx.device, rp);
+}
+
+} // namespace
+
+void register_geometry_pass(NodeRegistry& reg) {
+    reg.register_node("pass", exec_pass);
+}
+
+} // namespace joon

--- a/projects/joon/src/scene/geometry_pass.h
+++ b/projects/joon/src/scene/geometry_pass.h
@@ -1,0 +1,6 @@
+#pragma once
+
+namespace joon {
+class NodeRegistry;
+void register_geometry_pass(NodeRegistry& reg);
+} // namespace joon

--- a/projects/joon/src/scene/obj_loader.cpp
+++ b/projects/joon/src/scene/obj_loader.cpp
@@ -1,0 +1,71 @@
+#define TINYOBJLOADER_IMPLEMENTATION
+#include "tinyobjloader/tiny_obj_loader.h"
+
+#include "scene/obj_loader.h"
+
+#include <sstream>
+#include <stdexcept>
+
+namespace joon {
+
+static Mesh build_mesh(const tinyobj::attrib_t& attrib,
+                       const std::vector<tinyobj::shape_t>& shapes) {
+    Mesh out;
+    for (const auto& shape : shapes) {
+        for (const auto& idx : shape.mesh.indices) {
+            Vertex v{};
+            v.position = {
+                attrib.vertices[3 * idx.vertex_index + 0],
+                attrib.vertices[3 * idx.vertex_index + 1],
+                attrib.vertices[3 * idx.vertex_index + 2],
+            };
+            if (idx.normal_index >= 0) {
+                v.normal = {
+                    attrib.normals[3 * idx.normal_index + 0],
+                    attrib.normals[3 * idx.normal_index + 1],
+                    attrib.normals[3 * idx.normal_index + 2],
+                };
+            }
+            if (idx.texcoord_index >= 0) {
+                v.uv = {
+                    attrib.texcoords[2 * idx.texcoord_index + 0],
+                    attrib.texcoords[2 * idx.texcoord_index + 1],
+                };
+            }
+            out.vertices.push_back(v);
+            out.indices.push_back(static_cast<uint32_t>(out.indices.size()));
+        }
+    }
+    return out;
+}
+
+Mesh load_obj_string(const std::string& obj_text) {
+    tinyobj::attrib_t attrib;
+    std::vector<tinyobj::shape_t> shapes;
+    std::vector<tinyobj::material_t> materials;
+    std::string warn, err;
+    std::istringstream iss(obj_text);
+    if (!tinyobj::LoadObj(&attrib, &shapes, &materials, &warn, &err, &iss)) {
+        throw std::runtime_error("OBJ parse failed: " + err);
+    }
+    if (shapes.empty()) {
+        throw std::runtime_error("OBJ parse produced no shapes");
+    }
+    return build_mesh(attrib, shapes);
+}
+
+Mesh load_obj_file(const std::string& path) {
+    tinyobj::attrib_t attrib;
+    std::vector<tinyobj::shape_t> shapes;
+    std::vector<tinyobj::material_t> materials;
+    std::string warn, err;
+    if (!tinyobj::LoadObj(&attrib, &shapes, &materials, &warn, &err, path.c_str())) {
+        throw std::runtime_error("OBJ load failed: " + err);
+    }
+    if (shapes.empty()) {
+        throw std::runtime_error("OBJ load produced no shapes from: " + path);
+    }
+    return build_mesh(attrib, shapes);
+}
+
+} // namespace joon

--- a/projects/joon/src/scene/obj_loader.cpp
+++ b/projects/joon/src/scene/obj_loader.cpp
@@ -13,20 +13,28 @@ static Mesh build_mesh(const tinyobj::attrib_t& attrib,
     Mesh out;
     for (const auto& shape : shapes) {
         for (const auto& idx : shape.mesh.indices) {
+            // Bounds-check before indexing — tinyobjloader uses negative indices
+            // as "absent" sentinels and doesn't validate index ranges itself.
+            if (idx.vertex_index < 0 ||
+                static_cast<size_t>(3 * idx.vertex_index + 2) >= attrib.vertices.size()) {
+                throw std::runtime_error("OBJ has invalid vertex index");
+            }
             Vertex v{};
             v.position = {
                 attrib.vertices[3 * idx.vertex_index + 0],
                 attrib.vertices[3 * idx.vertex_index + 1],
                 attrib.vertices[3 * idx.vertex_index + 2],
             };
-            if (idx.normal_index >= 0) {
+            if (idx.normal_index >= 0 &&
+                static_cast<size_t>(3 * idx.normal_index + 2) < attrib.normals.size()) {
                 v.normal = {
                     attrib.normals[3 * idx.normal_index + 0],
                     attrib.normals[3 * idx.normal_index + 1],
                     attrib.normals[3 * idx.normal_index + 2],
                 };
             }
-            if (idx.texcoord_index >= 0) {
+            if (idx.texcoord_index >= 0 &&
+                static_cast<size_t>(2 * idx.texcoord_index + 1) < attrib.texcoords.size()) {
                 v.uv = {
                     attrib.texcoords[2 * idx.texcoord_index + 0],
                     attrib.texcoords[2 * idx.texcoord_index + 1],

--- a/projects/joon/src/scene/obj_loader.h
+++ b/projects/joon/src/scene/obj_loader.h
@@ -1,0 +1,13 @@
+#pragma once
+#include <joon/scene.h>
+#include <string>
+
+namespace joon {
+
+// Parse an OBJ from an in-memory string. Throws std::runtime_error on parse failure.
+Mesh load_obj_string(const std::string& obj_text);
+
+// Parse an OBJ from a file path. Throws std::runtime_error on read or parse failure.
+Mesh load_obj_file(const std::string& path);
+
+} // namespace joon

--- a/projects/joon/src/scene/primitives.cpp
+++ b/projects/joon/src/scene/primitives.cpp
@@ -1,4 +1,5 @@
 #include "scene/primitives.h"
+#include <algorithm>
 #include <cmath>
 
 namespace joon {
@@ -48,6 +49,11 @@ Mesh gen_cube(float size) {
 }
 
 Mesh gen_sphere(float radius, int lat, int lon) {
+    // Clamp segment counts to a sane minimum: <2 latitude rings or <3 longitude
+    // wedges produce a degenerate sphere and divide-by-zero in the parametric loops.
+    lat = std::max(lat, 2);
+    lon = std::max(lon, 3);
+
     Mesh m;
     m.vertices.reserve(static_cast<size_t>(lat + 1) * static_cast<size_t>(lon + 1));
     m.indices.reserve(static_cast<size_t>(lat) * static_cast<size_t>(lon) * 6);
@@ -121,6 +127,9 @@ Mesh gen_plane(float w, float h) {
 }
 
 Mesh gen_cylinder(float radius, float height, int segments) {
+    // Clamp segments to a sane minimum: fewer than 3 produces zero-area caps
+    // and a divide-by-zero in the cap modulo (s+1) % segments.
+    segments = std::max(segments, 3);
     const float hh = height * 0.5f;
 
     Mesh m;

--- a/projects/joon/src/scene/primitives.cpp
+++ b/projects/joon/src/scene/primitives.cpp
@@ -1,0 +1,220 @@
+#include "scene/primitives.h"
+#include <cmath>
+
+namespace joon {
+
+namespace {
+constexpr float PI = 3.14159265358979323846f;
+} // namespace
+
+Mesh gen_cube(float size) {
+    const float h = size * 0.5f;
+    // 6 faces × 4 unique verts each (so normals are flat per-face).
+    const vec3 normals[6] = {
+        { 0, 0, 1}, { 0, 0,-1},   // +Z, -Z
+        { 1, 0, 0}, {-1, 0, 0},   // +X, -X
+        { 0, 1, 0}, { 0,-1, 0},   // +Y, -Y
+    };
+    // Each face's 4 corners in CCW order when viewed from outside.
+    const vec3 corners[6][4] = {
+        {{-h,-h, h},{ h,-h, h},{ h, h, h},{-h, h, h}},  // +Z
+        {{ h,-h,-h},{-h,-h,-h},{-h, h,-h},{ h, h,-h}},  // -Z
+        {{ h,-h, h},{ h,-h,-h},{ h, h,-h},{ h, h, h}},  // +X
+        {{-h,-h,-h},{-h,-h, h},{-h, h, h},{-h, h,-h}},  // -X
+        {{-h, h, h},{ h, h, h},{ h, h,-h},{-h, h,-h}},  // +Y
+        {{-h,-h,-h},{ h,-h,-h},{ h,-h, h},{-h,-h, h}},  // -Y
+    };
+    const vec2 uvs[4] = { {0,0}, {1,0}, {1,1}, {0,1} };
+
+    Mesh m;
+    m.vertices.reserve(24);
+    m.indices.reserve(36);
+
+    for (uint32_t f = 0; f < 6; ++f) {
+        const uint32_t base = f * 4;
+        for (uint32_t i = 0; i < 4; ++i) {
+            m.vertices.push_back({ corners[f][i], normals[f], uvs[i] });
+        }
+        // Two triangles (0,1,2) and (0,2,3) — CCW from outside.
+        m.indices.push_back(base + 0);
+        m.indices.push_back(base + 1);
+        m.indices.push_back(base + 2);
+        m.indices.push_back(base + 0);
+        m.indices.push_back(base + 2);
+        m.indices.push_back(base + 3);
+    }
+
+    return m;
+}
+
+Mesh gen_sphere(float radius, int lat, int lon) {
+    Mesh m;
+    m.vertices.reserve(static_cast<size_t>(lat + 1) * static_cast<size_t>(lon + 1));
+    m.indices.reserve(static_cast<size_t>(lat) * static_cast<size_t>(lon) * 6);
+
+    const float inv_r = (radius != 0.0f) ? (1.0f / radius) : 0.0f;
+
+    for (int i = 0; i <= lat; ++i) {
+        const float v = static_cast<float>(i) / static_cast<float>(lat);   // 0..1, top to bottom
+        const float theta = v * PI;                                        // pole-to-pole
+        const float sin_t = std::sin(theta);
+        const float cos_t = std::cos(theta);
+        for (int j = 0; j <= lon; ++j) {
+            const float u = static_cast<float>(j) / static_cast<float>(lon);   // 0..1, around
+            const float phi = u * 2.0f * PI;
+            const float sin_p = std::sin(phi);
+            const float cos_p = std::cos(phi);
+
+            vec3 pos = { radius * sin_t * cos_p,
+                         radius * cos_t,
+                         radius * sin_t * sin_p };
+            vec3 normal = pos * inv_r;   // outward unit (zero-radius edge case yields {0,0,0})
+            m.vertices.push_back({ pos, normal, { u, v } });
+        }
+    }
+
+    const uint32_t stride = static_cast<uint32_t>(lon + 1);
+    for (int i = 0; i < lat; ++i) {
+        for (int j = 0; j < lon; ++j) {
+            const uint32_t a = static_cast<uint32_t>(i) * stride + static_cast<uint32_t>(j);
+            const uint32_t b = a + 1;
+            const uint32_t c = a + stride;
+            const uint32_t d = c + 1;
+            // Quad (a,b,d,c) → two CCW triangles. Degenerate triangles at the poles
+            // are kept on purpose to match the lat*lon*6 index-count contract.
+            m.indices.push_back(a);
+            m.indices.push_back(c);
+            m.indices.push_back(b);
+
+            m.indices.push_back(b);
+            m.indices.push_back(c);
+            m.indices.push_back(d);
+        }
+    }
+
+    return m;
+}
+
+Mesh gen_plane(float w, float h) {
+    const float hw = w * 0.5f;
+    const float hh = h * 0.5f;
+
+    Mesh m;
+    m.vertices.reserve(4);
+    m.indices.reserve(6);
+
+    const vec3 n = { 0.0f, 1.0f, 0.0f };
+    // 4 corners in CCW order when viewed from +Y (looking down -Y).
+    m.vertices.push_back({ {-hw, 0.0f, -hh}, n, {0.0f, 0.0f} });
+    m.vertices.push_back({ { hw, 0.0f, -hh}, n, {1.0f, 0.0f} });
+    m.vertices.push_back({ { hw, 0.0f,  hh}, n, {1.0f, 1.0f} });
+    m.vertices.push_back({ {-hw, 0.0f,  hh}, n, {0.0f, 1.0f} });
+
+    m.indices.push_back(0);
+    m.indices.push_back(1);
+    m.indices.push_back(2);
+    m.indices.push_back(0);
+    m.indices.push_back(2);
+    m.indices.push_back(3);
+
+    return m;
+}
+
+Mesh gen_cylinder(float radius, float height, int segments) {
+    const float hh = height * 0.5f;
+
+    Mesh m;
+    // Side strip: 2 * (segments + 1)
+    // Top cap: 1 center + segments ring
+    // Bottom cap: 1 center + segments ring
+    m.vertices.reserve(static_cast<size_t>(2 * (segments + 1) + 2 * (segments + 1)));
+    // Indices: 6*segments (side) + 3*segments (top) + 3*segments (bottom) = 12*segments
+    m.indices.reserve(static_cast<size_t>(12 * segments));
+
+    // ------------- Side strip -------------
+    // 2 * (segments + 1) vertices: bottom and top for each ring index 0..segments.
+    // Last ring index duplicates the first position but with UV.x = 1 to allow seam.
+    const uint32_t side_base = 0;
+    for (int s = 0; s <= segments; ++s) {
+        const float u = static_cast<float>(s) / static_cast<float>(segments);
+        const float angle = u * 2.0f * PI;
+        const float cs = std::cos(angle);
+        const float sn = std::sin(angle);
+        const vec3 normal = { cs, 0.0f, sn };
+        const vec3 bottom = { radius * cs, -hh, radius * sn };
+        const vec3 top    = { radius * cs,  hh, radius * sn };
+        m.vertices.push_back({ bottom, normal, { u, 0.0f } });
+        m.vertices.push_back({ top,    normal, { u, 1.0f } });
+    }
+    // Two triangles per segment forming the quad: (b, t, b+1) and (b+1, t, t+1)
+    // where b = 2*s (bottom), t = 2*s+1 (top), b+1 = 2*s+2 next bottom (wraps via duplicated ring).
+    for (int s = 0; s < segments; ++s) {
+        const uint32_t b0 = side_base + static_cast<uint32_t>(s) * 2;
+        const uint32_t t0 = b0 + 1;
+        const uint32_t b1 = b0 + 2;
+        const uint32_t t1 = b0 + 3;
+        // CCW from outside (normal pointing +outward).
+        m.indices.push_back(b0);
+        m.indices.push_back(t0);
+        m.indices.push_back(t1);
+
+        m.indices.push_back(b0);
+        m.indices.push_back(t1);
+        m.indices.push_back(b1);
+    }
+
+    // ------------- Top cap -------------
+    // Center vertex + `segments` ring vertices (no seam needed: triangle fan, last triangle wraps).
+    const uint32_t top_center = static_cast<uint32_t>(m.vertices.size());
+    {
+        const vec3 n_up = { 0.0f, 1.0f, 0.0f };
+        m.vertices.push_back({ { 0.0f, hh, 0.0f }, n_up, { 0.5f, 0.5f } });
+        for (int s = 0; s < segments; ++s) {
+            const float u = static_cast<float>(s) / static_cast<float>(segments);
+            const float angle = u * 2.0f * PI;
+            const float cs = std::cos(angle);
+            const float sn = std::sin(angle);
+            const vec3 pos = { radius * cs, hh, radius * sn };
+            const vec2 uv  = { 0.5f + 0.5f * cs, 0.5f + 0.5f * sn };
+            m.vertices.push_back({ pos, n_up, uv });
+        }
+    }
+    const uint32_t top_ring = top_center + 1;
+    for (int s = 0; s < segments; ++s) {
+        const uint32_t a = top_ring + static_cast<uint32_t>(s);
+        const uint32_t b = top_ring + static_cast<uint32_t>((s + 1) % segments);
+        // CCW when viewed from +Y (above).
+        m.indices.push_back(top_center);
+        m.indices.push_back(a);
+        m.indices.push_back(b);
+    }
+
+    // ------------- Bottom cap -------------
+    const uint32_t bot_center = static_cast<uint32_t>(m.vertices.size());
+    {
+        const vec3 n_dn = { 0.0f, -1.0f, 0.0f };
+        m.vertices.push_back({ { 0.0f, -hh, 0.0f }, n_dn, { 0.5f, 0.5f } });
+        for (int s = 0; s < segments; ++s) {
+            const float u = static_cast<float>(s) / static_cast<float>(segments);
+            const float angle = u * 2.0f * PI;
+            const float cs = std::cos(angle);
+            const float sn = std::sin(angle);
+            const vec3 pos = { radius * cs, -hh, radius * sn };
+            const vec2 uv  = { 0.5f + 0.5f * cs, 0.5f - 0.5f * sn };
+            m.vertices.push_back({ pos, n_dn, uv });
+        }
+    }
+    const uint32_t bot_ring = bot_center + 1;
+    for (int s = 0; s < segments; ++s) {
+        const uint32_t a = bot_ring + static_cast<uint32_t>(s);
+        const uint32_t b = bot_ring + static_cast<uint32_t>((s + 1) % segments);
+        // Reversed winding so it's CCW when viewed from -Y (below).
+        m.indices.push_back(bot_center);
+        m.indices.push_back(b);
+        m.indices.push_back(a);
+    }
+
+    return m;
+}
+
+} // namespace joon

--- a/projects/joon/src/scene/primitives.h
+++ b/projects/joon/src/scene/primitives.h
@@ -1,0 +1,22 @@
+#pragma once
+#include <joon/scene.h>
+
+namespace joon {
+
+// Axis-aligned cube centered at origin, side length = `size`.
+// 24 vertices (4 per face for per-face flat normals), 36 indices.
+Mesh gen_cube(float size = 1.0f);
+
+// UV sphere centered at origin, radius = `radius`.
+// (lat+1) * (lon+1) vertices, lat * lon * 6 indices. Smooth normals.
+Mesh gen_sphere(float radius = 0.5f, int lat = 16, int lon = 32);
+
+// Quad in the XZ plane at y=0, centered, with normal pointing +Y.
+// 4 vertices, 6 indices.
+Mesh gen_plane(float w = 1.0f, float h = 1.0f);
+
+// Cylinder along Y-axis, centered at origin, total height = `height`.
+// Top and bottom caps + side strip. `segments` divides the circle.
+Mesh gen_cylinder(float radius = 0.5f, float height = 1.0f, int segments = 32);
+
+} // namespace joon

--- a/projects/joon/src/scene/scene_collection.cpp
+++ b/projects/joon/src/scene/scene_collection.cpp
@@ -1,0 +1,18 @@
+#include <joon/scene.h>
+
+namespace joon {
+
+void SceneCollection::clear() {
+    objects.clear();
+    lights.clear();
+    // Note: camera is intentionally left at its current value, not reset to default.
+    // Resetting would require the next evaluate() to also re-run the camera node;
+    // since cameras are usually static across re-evaluates, leaving it alone is more efficient.
+    // The clear/add_object test case below explicitly checks this behavior.
+}
+
+void SceneCollection::add_object(SceneObject o) { objects.push_back(std::move(o)); }
+void SceneCollection::add_light(Light l) { lights.push_back(l); }
+void SceneCollection::set_camera(Camera c) { camera = c; }
+
+} // namespace joon

--- a/projects/joon/src/scene/scene_executors.cpp
+++ b/projects/joon/src/scene/scene_executors.cpp
@@ -1,0 +1,110 @@
+#include "scene/scene_executors.h"
+#include "scene/primitives.h"
+#include "scene/obj_loader.h"
+#include "nodes/node_registry.h"
+#include "ir/node.h"
+#include <joon/scene.h>
+
+namespace joon {
+
+namespace {
+
+// Look up a kwarg by name on a Node. Returns the float value or fallback.
+// The DSL parser stores numeric kwargs as `float` in the variant; symbol kwargs
+// that resolve to a constant node have `value` patched by the interpreter to the
+// source's constant_value. value_as_float handles both.
+float kwarg_float(const Node& n, const char* name, float fallback) {
+    for (const auto& k : n.kwargs)
+        if (k.name == name) return value_as_float(k.value, fallback);
+    return fallback;
+}
+
+// vec3 kwargs aren't supported by the parser yet (no [x y z] vector literal
+// tokens). This helper exists so the executor signature is forward-compatible
+// when vector literals are added — for now it always returns the fallback.
+vec3 kwarg_vec3(const Node& /*n*/, const char* /*name*/, vec3 fallback) {
+    return fallback;
+}
+
+void exec_cube(const Node& n, EvalContext& ctx) {
+    SceneObject o;
+    o.mesh = gen_cube(kwarg_float(n, "scale", 1.0f));
+    o.position = kwarg_vec3(n, "position", {0, 0, 0});
+    o.rotation = kwarg_vec3(n, "rotation", {0, 0, 0});
+    ctx.scene.add_object(std::move(o));
+}
+
+void exec_sphere(const Node& n, EvalContext& ctx) {
+    SceneObject o;
+    o.mesh = gen_sphere(kwarg_float(n, "radius", 0.5f));
+    o.position = kwarg_vec3(n, "position", {0, 0, 0});
+    o.rotation = kwarg_vec3(n, "rotation", {0, 0, 0});
+    ctx.scene.add_object(std::move(o));
+}
+
+void exec_plane(const Node& n, EvalContext& ctx) {
+    SceneObject o;
+    o.mesh = gen_plane(kwarg_float(n, "width", 1.0f),
+                       kwarg_float(n, "height", 1.0f));
+    o.position = kwarg_vec3(n, "position", {0, 0, 0});
+    o.rotation = kwarg_vec3(n, "rotation", {0, 0, 0});
+    ctx.scene.add_object(std::move(o));
+}
+
+void exec_cylinder(const Node& n, EvalContext& ctx) {
+    SceneObject o;
+    o.mesh = gen_cylinder(kwarg_float(n, "radius", 0.5f),
+                          kwarg_float(n, "height", 1.0f),
+                          static_cast<int>(kwarg_float(n, "segments", 32.0f)));
+    o.position = kwarg_vec3(n, "position", {0, 0, 0});
+    o.rotation = kwarg_vec3(n, "rotation", {0, 0, 0});
+    ctx.scene.add_object(std::move(o));
+}
+
+void exec_mesh(const Node& n, EvalContext& ctx) {
+    // The OBJ file path comes through as Node::string_arg (parser stores the
+    // first string-typed positional arg there).
+    SceneObject o;
+    if (!n.string_arg.empty()) o.mesh = load_obj_file(n.string_arg);
+    o.position = kwarg_vec3(n, "position", {0, 0, 0});
+    o.rotation = kwarg_vec3(n, "rotation", {0, 0, 0});
+    ctx.scene.add_object(std::move(o));
+}
+
+void exec_light(const Node& n, EvalContext& ctx) {
+    Light l;
+    // type kwarg requires symbol-as-string parsing (not yet wired); default to
+    // Directional for sub-project 2's single-light fragment shader.
+    l.type = LightType::Directional;
+    l.direction = kwarg_vec3(n, "direction", {0, -1, 0});
+    l.position  = kwarg_vec3(n, "position",  {0, 0, 0});
+    l.color     = kwarg_vec3(n, "color",     {1, 1, 1});
+    l.intensity = kwarg_float(n, "intensity", 1.0f);
+    l.spot_angle_deg = kwarg_float(n, "angle", 30.0f);
+    ctx.scene.add_light(l);
+}
+
+void exec_camera(const Node& n, EvalContext& ctx) {
+    Camera c;
+    c.fov_deg  = kwarg_float(n, "fov", 60.0f);
+    c.position = kwarg_vec3(n, "position", {0, 0, 5});
+    c.target   = kwarg_vec3(n, "target",   {0, 0, 0});
+    c.up       = kwarg_vec3(n, "up",       {0, 1, 0});
+    c.near_z   = kwarg_float(n, "near", 0.1f);
+    c.far_z    = kwarg_float(n, "far", 100.0f);
+    ctx.scene.set_camera(c);
+}
+
+} // namespace
+
+void register_scene_nodes(NodeRegistry& reg) {
+    reg.register_node("cube",     exec_cube);
+    reg.register_node("sphere",   exec_sphere);
+    reg.register_node("plane",    exec_plane);
+    reg.register_node("cylinder", exec_cylinder);
+    reg.register_node("mesh",     exec_mesh);
+    reg.register_node("light",    exec_light);
+    reg.register_node("camera",   exec_camera);
+}
+
+} // namespace joon

--- a/projects/joon/src/scene/scene_executors.h
+++ b/projects/joon/src/scene/scene_executors.h
@@ -1,0 +1,6 @@
+#pragma once
+
+namespace joon {
+class NodeRegistry;
+void register_scene_nodes(NodeRegistry& reg);
+} // namespace joon

--- a/projects/joon/src/vulkan/buffer.cpp
+++ b/projects/joon/src/vulkan/buffer.cpp
@@ -1,0 +1,111 @@
+#include "vulkan/buffer.h"
+#include <cstring>
+#include <stdexcept>
+
+namespace joon {
+
+namespace {
+
+GpuBuffer create_device_local_buffer(Device& dev, const void* data, size_t size_bytes,
+                                      VkBufferUsageFlags usage) {
+    if (size_bytes == 0) throw std::runtime_error("create_device_local_buffer: size_bytes == 0");
+
+    // Staging buffer — host-visible, source for the copy.
+    VkBufferCreateInfo staging_info{};
+    staging_info.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
+    staging_info.size = size_bytes;
+    staging_info.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
+    staging_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+
+    VmaAllocationCreateInfo staging_alloc_info{};
+    staging_alloc_info.usage = VMA_MEMORY_USAGE_AUTO;
+    staging_alloc_info.flags = VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT
+                             | VMA_ALLOCATION_CREATE_MAPPED_BIT;
+
+    VkBuffer staging_buf;
+    VmaAllocation staging_alloc;
+    VmaAllocationInfo staging_alloc_meta{};
+    if (vmaCreateBuffer(dev.allocator, &staging_info, &staging_alloc_info,
+                         &staging_buf, &staging_alloc, &staging_alloc_meta) != VK_SUCCESS)
+        throw std::runtime_error("vmaCreateBuffer (staging) failed");
+
+    std::memcpy(staging_alloc_meta.pMappedData, data, size_bytes);
+
+    // Destination buffer — device-local.
+    VkBufferCreateInfo dst_info{};
+    dst_info.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
+    dst_info.size = size_bytes;
+    dst_info.usage = usage | VK_BUFFER_USAGE_TRANSFER_DST_BIT;
+    dst_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+
+    VmaAllocationCreateInfo dst_alloc_info{};
+    dst_alloc_info.usage = VMA_MEMORY_USAGE_AUTO;
+
+    GpuBuffer out;
+    out.size = size_bytes;
+    if (vmaCreateBuffer(dev.allocator, &dst_info, &dst_alloc_info,
+                         &out.buffer, &out.alloc, nullptr) != VK_SUCCESS) {
+        vmaDestroyBuffer(dev.allocator, staging_buf, staging_alloc);
+        throw std::runtime_error("vmaCreateBuffer (device-local) failed");
+    }
+
+    // Copy staging → device-local on the compute queue.
+    VkCommandBuffer cmd = dev.begin_single_command();
+    VkBufferCopy region{};
+    region.size = size_bytes;
+    vkCmdCopyBuffer(cmd, staging_buf, out.buffer, 1, &region);
+    dev.end_single_command(cmd);
+
+    vmaDestroyBuffer(dev.allocator, staging_buf, staging_alloc);
+    return out;
+}
+
+} // namespace
+
+GpuBuffer create_vertex_buffer(Device& dev, const void* data, size_t size_bytes) {
+    return create_device_local_buffer(dev, data, size_bytes, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT);
+}
+
+GpuBuffer create_index_buffer(Device& dev, const void* data, size_t size_bytes) {
+    return create_device_local_buffer(dev, data, size_bytes, VK_BUFFER_USAGE_INDEX_BUFFER_BIT);
+}
+
+GpuBuffer create_uniform_buffer(Device& dev, size_t size_bytes) {
+    if (size_bytes == 0) throw std::runtime_error("create_uniform_buffer: size_bytes == 0");
+
+    VkBufferCreateInfo info{};
+    info.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
+    info.size = size_bytes;
+    info.usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
+    info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+
+    VmaAllocationCreateInfo alloc_info{};
+    alloc_info.usage = VMA_MEMORY_USAGE_AUTO;
+    alloc_info.flags = VMA_ALLOCATION_CREATE_HOST_ACCESS_SEQUENTIAL_WRITE_BIT
+                     | VMA_ALLOCATION_CREATE_MAPPED_BIT;
+
+    GpuBuffer out;
+    out.size = size_bytes;
+    if (vmaCreateBuffer(dev.allocator, &info, &alloc_info,
+                         &out.buffer, &out.alloc, nullptr) != VK_SUCCESS)
+        throw std::runtime_error("vmaCreateBuffer (uniform) failed");
+    return out;
+}
+
+void update_uniform_buffer(Device& dev, GpuBuffer& buf, const void* data, size_t size_bytes) {
+    if (size_bytes > buf.size) throw std::runtime_error("update_uniform_buffer: size > buf.size");
+    void* mapped = nullptr;
+    if (vmaMapMemory(dev.allocator, buf.alloc, &mapped) != VK_SUCCESS)
+        throw std::runtime_error("vmaMapMemory failed");
+    std::memcpy(mapped, data, size_bytes);
+    vmaUnmapMemory(dev.allocator, buf.alloc);
+}
+
+void destroy_buffer(Device& dev, GpuBuffer& buf) {
+    if (buf.buffer) vmaDestroyBuffer(dev.allocator, buf.buffer, buf.alloc);
+    buf.buffer = VK_NULL_HANDLE;
+    buf.alloc = VK_NULL_HANDLE;
+    buf.size = 0;
+}
+
+} // namespace joon

--- a/projects/joon/src/vulkan/buffer.h
+++ b/projects/joon/src/vulkan/buffer.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "vulkan/device.h"
+#include <cstddef>
+
+namespace joon {
+
+// Thin wrappers over VMA-allocated VkBuffer. Sub-project 2 creates fresh
+// vertex/index/uniform buffers each evaluate() and frees them at the end.
+// Pooling can come later if profiling shows it's worth the complexity.
+
+struct GpuBuffer {
+    VkBuffer buffer = VK_NULL_HANDLE;
+    VmaAllocation alloc = VK_NULL_HANDLE;
+    size_t size = 0;
+};
+
+// DEVICE_LOCAL vertex/index buffers — uploaded via a one-shot staging buffer.
+GpuBuffer create_vertex_buffer(Device& dev, const void* data, size_t size_bytes);
+GpuBuffer create_index_buffer (Device& dev, const void* data, size_t size_bytes);
+
+// CPU_TO_GPU mapped uniform buffer — call update_uniform_buffer to refill.
+GpuBuffer create_uniform_buffer(Device& dev, size_t size_bytes);
+void      update_uniform_buffer(Device& dev, GpuBuffer& buf,
+                                 const void* data, size_t size_bytes);
+
+void destroy_buffer(Device& dev, GpuBuffer& buf);
+
+} // namespace joon

--- a/projects/joon/src/vulkan/pipeline_cache.cpp
+++ b/projects/joon/src/vulkan/pipeline_cache.cpp
@@ -1,4 +1,5 @@
 #include "vulkan/pipeline_cache.h"
+#include <joon/scene.h>
 #include <cstdlib>
 #include <filesystem>
 #include <fstream>
@@ -16,6 +17,13 @@ PipelineCache::~PipelineCache() {
         vkDestroyPipelineLayout(m_device.device, p.layout, nullptr);
         vkDestroyDescriptorSetLayout(m_device.device, p.desc_layout, nullptr);
         vkDestroyShaderModule(m_device.device, p.shader_module, nullptr);
+    }
+    for (auto& [name, p] : m_graphics_pipelines) {
+        vkDestroyPipeline(m_device.device, p.pipeline, nullptr);
+        vkDestroyPipelineLayout(m_device.device, p.layout, nullptr);
+        vkDestroyDescriptorSetLayout(m_device.device, p.desc_layout, nullptr);
+        vkDestroyShaderModule(m_device.device, p.vert_module, nullptr);
+        vkDestroyShaderModule(m_device.device, p.frag_module, nullptr);
     }
 }
 
@@ -38,7 +46,8 @@ bool PipelineCache::needs_recompile(const std::string& hlsl_path,
 }
 
 std::vector<uint8_t> PipelineCache::compile_hlsl(const std::string& hlsl_path,
-                                                   const std::string& spv_path) {
+                                                   const std::string& spv_path,
+                                                   const std::string& target_profile) {
     std::string dxc;
     const char* vulkan_sdk = std::getenv("VULKAN_SDK");
     if (vulkan_sdk) {
@@ -50,7 +59,7 @@ std::vector<uint8_t> PipelineCache::compile_hlsl(const std::string& hlsl_path,
         throw std::runtime_error("DXC not found. Set VULKAN_SDK environment variable.");
 
     std::string cmd = "\"" + dxc + "\""
-        + " -T cs_6_0 -E main -spirv -fspv-target-env=vulkan1.1"
+        + " -T " + target_profile + " -E main -spirv -fspv-target-env=vulkan1.1"
         + " \"" + hlsl_path + "\""
         + " -Fo \"" + spv_path + "\""
         + " 2>&1";
@@ -75,7 +84,7 @@ std::vector<uint8_t> PipelineCache::load_or_compile(const std::string& name) {
 
     if (fs::exists(hlsl_path)) {
         if (needs_recompile(hlsl_path, spv_path))
-            return compile_hlsl(hlsl_path, spv_path);
+            return compile_hlsl(hlsl_path, spv_path, "cs_6_0");
         return read_file(spv_path);
     }
 
@@ -83,6 +92,20 @@ std::vector<uint8_t> PipelineCache::load_or_compile(const std::string& name) {
         return read_file(spv_path);
 
     throw std::runtime_error("No shader source found: " + name);
+}
+
+std::vector<uint8_t> PipelineCache::load_or_compile_stage(const std::string& base_name,
+                                                            const std::string& stage,
+                                                            const std::string& target_profile) {
+    // e.g. base_name="scene_basic", stage="vert" → "scene_basic.vert.hlsl" / ".vert.spv"
+    std::string hlsl_path = m_shaderDir + "/" + base_name + "." + stage + ".hlsl";
+    std::string spv_path  = m_shaderDir + "/" + base_name + "." + stage + ".spv";
+
+    if (!fs::exists(hlsl_path))
+        throw std::runtime_error("Graphics shader source missing: " + hlsl_path);
+    if (needs_recompile(hlsl_path, spv_path))
+        return compile_hlsl(hlsl_path, spv_path, target_profile);
+    return read_file(spv_path);
 }
 
 const ComputePipeline& PipelineCache::get(const std::string& name,
@@ -160,6 +183,170 @@ const ComputePipeline& PipelineCache::get(const std::string& name,
 
     m_pipelines[key] = p;
     return m_pipelines[key];
+}
+
+const GraphicsPipeline& PipelineCache::get_graphics(const std::string& name,
+                                                     VkRenderPass render_pass,
+                                                     uint32_t push_constant_size) {
+    std::string key = name + ":" + std::to_string(reinterpret_cast<uintptr_t>(render_pass))
+                    + ":" + std::to_string(push_constant_size);
+    auto it = m_graphics_pipelines.find(key);
+    if (it != m_graphics_pipelines.end()) return it->second;
+
+    GraphicsPipeline p{};
+
+    // Compile both stages.
+    auto vs_spirv = load_or_compile_stage(name, "vert", "vs_6_0");
+    auto fs_spirv = load_or_compile_stage(name, "frag", "ps_6_0");
+
+    auto make_module = [&](const std::vector<uint8_t>& spirv, const char* what) {
+        if (spirv.size() % 4 != 0)
+            throw std::runtime_error(std::string("SPIR-V size not multiple of 4: ") + what);
+        VkShaderModuleCreateInfo info{};
+        info.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
+        info.codeSize = spirv.size();
+        info.pCode = reinterpret_cast<const uint32_t*>(spirv.data());
+        VkShaderModule mod = VK_NULL_HANDLE;
+        if (vkCreateShaderModule(m_device.device, &info, nullptr, &mod) != VK_SUCCESS)
+            throw std::runtime_error(std::string("vkCreateShaderModule failed: ") + what);
+        return mod;
+    };
+    p.vert_module = make_module(vs_spirv, (name + ".vert").c_str());
+    p.frag_module = make_module(fs_spirv, (name + ".frag").c_str());
+
+    // Descriptor set layout — single UBO at binding 0, vertex stage.
+    VkDescriptorSetLayoutBinding ubo_binding{};
+    ubo_binding.binding = 0;
+    ubo_binding.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+    ubo_binding.descriptorCount = 1;
+    ubo_binding.stageFlags = VK_SHADER_STAGE_VERTEX_BIT;
+
+    VkDescriptorSetLayoutCreateInfo desc_info{};
+    desc_info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
+    desc_info.bindingCount = 1;
+    desc_info.pBindings = &ubo_binding;
+    if (vkCreateDescriptorSetLayout(m_device.device, &desc_info, nullptr, &p.desc_layout) != VK_SUCCESS)
+        throw std::runtime_error("graphics: vkCreateDescriptorSetLayout failed");
+
+    // Pipeline layout — descriptor set + optional push constants (fragment stage).
+    VkPipelineLayoutCreateInfo layout_info{};
+    layout_info.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
+    layout_info.setLayoutCount = 1;
+    layout_info.pSetLayouts = &p.desc_layout;
+
+    VkPushConstantRange push_range{};
+    if (push_constant_size > 0) {
+        push_range.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
+        push_range.offset = 0;
+        push_range.size = push_constant_size;
+        layout_info.pushConstantRangeCount = 1;
+        layout_info.pPushConstantRanges = &push_range;
+    }
+    if (vkCreatePipelineLayout(m_device.device, &layout_info, nullptr, &p.layout) != VK_SUCCESS)
+        throw std::runtime_error("graphics: vkCreatePipelineLayout failed");
+
+    // Vertex input — matches joon::Vertex {position, normal, uv}.
+    VkVertexInputBindingDescription vb_desc{};
+    vb_desc.binding = 0;
+    vb_desc.stride = sizeof(Vertex);
+    vb_desc.inputRate = VK_VERTEX_INPUT_RATE_VERTEX;
+
+    VkVertexInputAttributeDescription va_desc[3]{};
+    va_desc[0].binding = 0;
+    va_desc[0].location = 0;
+    va_desc[0].format = VK_FORMAT_R32G32B32_SFLOAT;
+    va_desc[0].offset = offsetof(Vertex, position);
+    va_desc[1].binding = 0;
+    va_desc[1].location = 1;
+    va_desc[1].format = VK_FORMAT_R32G32B32_SFLOAT;
+    va_desc[1].offset = offsetof(Vertex, normal);
+    va_desc[2].binding = 0;
+    va_desc[2].location = 2;
+    va_desc[2].format = VK_FORMAT_R32G32_SFLOAT;
+    va_desc[2].offset = offsetof(Vertex, uv);
+
+    VkPipelineVertexInputStateCreateInfo vi{};
+    vi.sType = VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO;
+    vi.vertexBindingDescriptionCount = 1;
+    vi.pVertexBindingDescriptions = &vb_desc;
+    vi.vertexAttributeDescriptionCount = 3;
+    vi.pVertexAttributeDescriptions = va_desc;
+
+    VkPipelineInputAssemblyStateCreateInfo ia{};
+    ia.sType = VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO;
+    ia.topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
+
+    VkPipelineViewportStateCreateInfo vp{};
+    vp.sType = VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO;
+    vp.viewportCount = 1;
+    vp.scissorCount = 1;
+
+    VkPipelineRasterizationStateCreateInfo rs{};
+    rs.sType = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO;
+    rs.polygonMode = VK_POLYGON_MODE_FILL;
+    rs.cullMode = VK_CULL_MODE_BACK_BIT;
+    rs.frontFace = VK_FRONT_FACE_COUNTER_CLOCKWISE;
+    rs.lineWidth = 1.0f;
+
+    VkPipelineMultisampleStateCreateInfo ms{};
+    ms.sType = VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO;
+    ms.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
+
+    VkPipelineDepthStencilStateCreateInfo ds{};
+    ds.sType = VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO;
+    ds.depthTestEnable = VK_TRUE;
+    ds.depthWriteEnable = VK_TRUE;
+    ds.depthCompareOp = VK_COMPARE_OP_LESS;
+
+    VkPipelineColorBlendAttachmentState cba{};
+    cba.colorWriteMask = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT
+                       | VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT;
+    cba.blendEnable = VK_FALSE;
+
+    VkPipelineColorBlendStateCreateInfo cb{};
+    cb.sType = VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO;
+    cb.attachmentCount = 1;
+    cb.pAttachments = &cba;
+
+    // Dynamic viewport+scissor — set per draw via vkCmdSetViewport/Scissor.
+    VkDynamicState dyn_states[2] = { VK_DYNAMIC_STATE_VIEWPORT, VK_DYNAMIC_STATE_SCISSOR };
+    VkPipelineDynamicStateCreateInfo dyn{};
+    dyn.sType = VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO;
+    dyn.dynamicStateCount = 2;
+    dyn.pDynamicStates = dyn_states;
+
+    VkPipelineShaderStageCreateInfo stages[2]{};
+    stages[0].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+    stages[0].stage = VK_SHADER_STAGE_VERTEX_BIT;
+    stages[0].module = p.vert_module;
+    stages[0].pName = "main";
+    stages[1].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+    stages[1].stage = VK_SHADER_STAGE_FRAGMENT_BIT;
+    stages[1].module = p.frag_module;
+    stages[1].pName = "main";
+
+    VkGraphicsPipelineCreateInfo gp_info{};
+    gp_info.sType = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO;
+    gp_info.stageCount = 2;
+    gp_info.pStages = stages;
+    gp_info.pVertexInputState = &vi;
+    gp_info.pInputAssemblyState = &ia;
+    gp_info.pViewportState = &vp;
+    gp_info.pRasterizationState = &rs;
+    gp_info.pMultisampleState = &ms;
+    gp_info.pDepthStencilState = &ds;
+    gp_info.pColorBlendState = &cb;
+    gp_info.pDynamicState = &dyn;
+    gp_info.layout = p.layout;
+    gp_info.renderPass = render_pass;
+    gp_info.subpass = 0;
+
+    if (vkCreateGraphicsPipelines(m_device.device, VK_NULL_HANDLE, 1, &gp_info, nullptr,
+                                   &p.pipeline) != VK_SUCCESS)
+        throw std::runtime_error("vkCreateGraphicsPipelines failed: " + name);
+
+    m_graphics_pipelines[key] = p;
+    return m_graphics_pipelines[key];
 }
 
 } // namespace joon

--- a/projects/joon/src/vulkan/pipeline_cache.h
+++ b/projects/joon/src/vulkan/pipeline_cache.h
@@ -14,6 +14,14 @@ struct ComputePipeline {
     VkDescriptorSetLayout desc_layout = VK_NULL_HANDLE;
 };
 
+struct GraphicsPipeline {
+    VkShaderModule vert_module = VK_NULL_HANDLE;
+    VkShaderModule frag_module = VK_NULL_HANDLE;
+    VkDescriptorSetLayout desc_layout = VK_NULL_HANDLE;
+    VkPipelineLayout layout = VK_NULL_HANDLE;
+    VkPipeline pipeline = VK_NULL_HANDLE;
+};
+
 class PipelineCache {
 public:
     explicit PipelineCache(Device& device, const std::string& shader_dir);
@@ -23,14 +31,29 @@ public:
                                 uint32_t num_images,
                                 uint32_t push_constant_size = 0);
 
+    // Get-or-create a graphics pipeline keyed by name + render-pass handle.
+    // Compiles `<name>.vert.hlsl` and `<name>.frag.hlsl` via DXC at first use.
+    // Vertex input is hardcoded for joon::Vertex {position, normal, uv}.
+    // Descriptor set 0 binding 0 = UBO (vertex stage).
+    // Push constants in `push_constant_size` bytes go to the FRAGMENT stage.
+    const GraphicsPipeline& get_graphics(const std::string& name,
+                                          VkRenderPass render_pass,
+                                          uint32_t push_constant_size = 0);
+
 private:
     Device& m_device;
     std::string m_shaderDir;
     std::unordered_map<std::string, ComputePipeline> m_pipelines;
+    std::unordered_map<std::string, GraphicsPipeline> m_graphics_pipelines;
 
     std::vector<uint8_t> load_or_compile(const std::string& name);
     bool needs_recompile(const std::string& hlsl_path, const std::string& spv_path);
-    std::vector<uint8_t> compile_hlsl(const std::string& hlsl_path, const std::string& spv_path);
+    std::vector<uint8_t> compile_hlsl(const std::string& hlsl_path,
+                                       const std::string& spv_path,
+                                       const std::string& target_profile = "cs_6_0");
+    std::vector<uint8_t> load_or_compile_stage(const std::string& base_name,
+                                                const std::string& stage,
+                                                const std::string& target_profile);
     std::vector<uint8_t> read_file(const std::string& path);
 };
 

--- a/projects/joon/src/vulkan/render_pass.cpp
+++ b/projects/joon/src/vulkan/render_pass.cpp
@@ -1,0 +1,116 @@
+#include "vulkan/render_pass.h"
+#include <stdexcept>
+
+namespace joon {
+
+RenderPass create_color_depth_renderpass(
+    Device& dev,
+    const std::vector<VkFormat>& color_formats,
+    VkFormat depth_format) {
+
+    if (color_formats.empty())
+        throw std::runtime_error("create_color_depth_renderpass: no color attachments");
+
+    RenderPass out;
+    out.color_formats = color_formats;
+    out.depth_format = depth_format;
+
+    std::vector<VkAttachmentDescription> attachments;
+    attachments.reserve(color_formats.size() + 1);
+    std::vector<VkAttachmentReference> color_refs;
+    color_refs.reserve(color_formats.size());
+
+    for (uint32_t i = 0; i < color_formats.size(); ++i) {
+        VkAttachmentDescription a{};
+        a.format = color_formats[i];
+        a.samples = VK_SAMPLE_COUNT_1_BIT;
+        a.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+        a.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+        a.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+        a.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+        a.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+        a.finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+        attachments.push_back(a);
+
+        VkAttachmentReference ref{};
+        ref.attachment = i;
+        ref.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+        color_refs.push_back(ref);
+    }
+
+    VkAttachmentDescription depth{};
+    depth.format = depth_format;
+    depth.samples = VK_SAMPLE_COUNT_1_BIT;
+    depth.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+    depth.storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+    depth.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+    depth.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+    depth.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    depth.finalLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+    attachments.push_back(depth);
+
+    VkAttachmentReference depth_ref{};
+    depth_ref.attachment = static_cast<uint32_t>(color_formats.size());
+    depth_ref.layout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+
+    VkSubpassDescription subpass{};
+    subpass.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+    subpass.colorAttachmentCount = static_cast<uint32_t>(color_refs.size());
+    subpass.pColorAttachments = color_refs.data();
+    subpass.pDepthStencilAttachment = &depth_ref;
+
+    // External -> subpass dependency on color + depth writes.
+    VkSubpassDependency dep{};
+    dep.srcSubpass = VK_SUBPASS_EXTERNAL;
+    dep.dstSubpass = 0;
+    dep.srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT
+                     | VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT;
+    dep.dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT
+                     | VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT;
+    dep.srcAccessMask = 0;
+    dep.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT
+                      | VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
+
+    VkRenderPassCreateInfo info{};
+    info.sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO;
+    info.attachmentCount = static_cast<uint32_t>(attachments.size());
+    info.pAttachments = attachments.data();
+    info.subpassCount = 1;
+    info.pSubpasses = &subpass;
+    info.dependencyCount = 1;
+    info.pDependencies = &dep;
+
+    if (vkCreateRenderPass(dev.device, &info, nullptr, &out.pass) != VK_SUCCESS)
+        throw std::runtime_error("vkCreateRenderPass failed");
+    return out;
+}
+
+VkFramebuffer create_framebuffer(
+    Device& dev, const RenderPass& rp,
+    const std::vector<VkImageView>& color_views,
+    VkImageView depth_view, uint32_t w, uint32_t h) {
+
+    std::vector<VkImageView> attachments = color_views;
+    attachments.push_back(depth_view);
+
+    VkFramebufferCreateInfo info{};
+    info.sType = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
+    info.renderPass = rp.pass;
+    info.attachmentCount = static_cast<uint32_t>(attachments.size());
+    info.pAttachments = attachments.data();
+    info.width = w;
+    info.height = h;
+    info.layers = 1;
+
+    VkFramebuffer fb = VK_NULL_HANDLE;
+    if (vkCreateFramebuffer(dev.device, &info, nullptr, &fb) != VK_SUCCESS)
+        throw std::runtime_error("vkCreateFramebuffer failed");
+    return fb;
+}
+
+void destroy_renderpass(Device& dev, RenderPass& rp) {
+    if (rp.pass) vkDestroyRenderPass(dev.device, rp.pass, nullptr);
+    rp.pass = VK_NULL_HANDLE;
+}
+
+} // namespace joon

--- a/projects/joon/src/vulkan/render_pass.h
+++ b/projects/joon/src/vulkan/render_pass.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "vulkan/device.h"
+#include <vector>
+
+namespace joon {
+
+struct RenderPass {
+    VkRenderPass pass = VK_NULL_HANDLE;
+    std::vector<VkFormat> color_formats;
+    VkFormat depth_format = VK_FORMAT_D32_SFLOAT;
+};
+
+// Create a render pass with N color attachments + one depth attachment.
+// Color attachments load=CLEAR, store=STORE, finalLayout=COLOR_ATTACHMENT_OPTIMAL
+// (the geometry-pass executor manually transitions them to GENERAL afterwards
+//  so downstream compute / viewport binding can sample).
+// Depth attachment load=CLEAR, store=DONT_CARE, finalLayout=DEPTH_STENCIL_ATTACHMENT_OPTIMAL.
+RenderPass create_color_depth_renderpass(
+    Device& dev,
+    const std::vector<VkFormat>& color_formats,
+    VkFormat depth_format = VK_FORMAT_D32_SFLOAT);
+
+VkFramebuffer create_framebuffer(
+    Device& dev, const RenderPass& rp,
+    const std::vector<VkImageView>& color_views,
+    VkImageView depth_view, uint32_t w, uint32_t h);
+
+void destroy_renderpass(Device& dev, RenderPass& rp);
+
+} // namespace joon

--- a/projects/joon/src/vulkan/resource_pool.cpp
+++ b/projects/joon/src/vulkan/resource_pool.cpp
@@ -62,6 +62,114 @@ GpuImage* ResourcePool::alloc_image(uint32_t node_id, uint32_t width, uint32_t h
     return &m_images[node_id];
 }
 
+GpuImage* ResourcePool::alloc_render_target(uint32_t node_id, uint32_t width, uint32_t height,
+                                              VkFormat format) {
+    auto it = m_images.find(node_id);
+    if (it != m_images.end()) {
+        auto& old = it->second;
+        if (old.width == width && old.height == height && old.format == format) {
+            return &it->second;
+        }
+        vkDestroyImageView(m_device.device, old.view, nullptr);
+        vmaDestroyImage(m_device.allocator, old.image, old.allocation);
+        m_images.erase(it);
+    }
+
+    GpuImage img{};
+    img.width = width;
+    img.height = height;
+    img.format = format;
+
+    VkImageCreateInfo img_info{};
+    img_info.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
+    img_info.imageType = VK_IMAGE_TYPE_2D;
+    img_info.format = format;
+    img_info.extent = { width, height, 1 };
+    img_info.mipLevels = 1;
+    img_info.arrayLayers = 1;
+    img_info.samples = VK_SAMPLE_COUNT_1_BIT;
+    img_info.tiling = VK_IMAGE_TILING_OPTIMAL;
+    img_info.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT
+                   | VK_IMAGE_USAGE_STORAGE_BIT
+                   | VK_IMAGE_USAGE_SAMPLED_BIT
+                   | VK_IMAGE_USAGE_TRANSFER_SRC_BIT
+                   | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
+
+    VmaAllocationCreateInfo alloc_info{};
+    alloc_info.usage = VMA_MEMORY_USAGE_GPU_ONLY;
+
+    if (vmaCreateImage(m_device.allocator, &img_info, &alloc_info,
+                       &img.image, &img.allocation, nullptr) != VK_SUCCESS)
+        throw std::runtime_error("Failed to allocate render target");
+
+    VkImageViewCreateInfo view_info{};
+    view_info.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
+    view_info.image = img.image;
+    view_info.viewType = VK_IMAGE_VIEW_TYPE_2D;
+    view_info.format = format;
+    view_info.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    view_info.subresourceRange.levelCount = 1;
+    view_info.subresourceRange.layerCount = 1;
+
+    if (vkCreateImageView(m_device.device, &view_info, nullptr, &img.view) != VK_SUCCESS)
+        throw std::runtime_error("Failed to create render target view");
+
+    m_images[node_id] = img;
+    return &m_images[node_id];
+}
+
+GpuImage* ResourcePool::alloc_depth(uint32_t node_id, uint32_t width, uint32_t height,
+                                     VkFormat format) {
+    auto it = m_images.find(node_id);
+    if (it != m_images.end()) {
+        auto& old = it->second;
+        if (old.width == width && old.height == height && old.format == format) {
+            return &it->second;
+        }
+        vkDestroyImageView(m_device.device, old.view, nullptr);
+        vmaDestroyImage(m_device.allocator, old.image, old.allocation);
+        m_images.erase(it);
+    }
+
+    GpuImage img{};
+    img.width = width;
+    img.height = height;
+    img.format = format;
+
+    VkImageCreateInfo img_info{};
+    img_info.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
+    img_info.imageType = VK_IMAGE_TYPE_2D;
+    img_info.format = format;
+    img_info.extent = { width, height, 1 };
+    img_info.mipLevels = 1;
+    img_info.arrayLayers = 1;
+    img_info.samples = VK_SAMPLE_COUNT_1_BIT;
+    img_info.tiling = VK_IMAGE_TILING_OPTIMAL;
+    img_info.usage = VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
+
+    VmaAllocationCreateInfo alloc_info{};
+    alloc_info.usage = VMA_MEMORY_USAGE_GPU_ONLY;
+
+    if (vmaCreateImage(m_device.allocator, &img_info, &alloc_info,
+                       &img.image, &img.allocation, nullptr) != VK_SUCCESS)
+        throw std::runtime_error("Failed to allocate depth image");
+
+    VkImageViewCreateInfo view_info{};
+    view_info.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
+    view_info.image = img.image;
+    view_info.viewType = VK_IMAGE_VIEW_TYPE_2D;
+    view_info.format = format;
+    view_info.subresourceRange.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT;
+    view_info.subresourceRange.levelCount = 1;
+    view_info.subresourceRange.layerCount = 1;
+
+    if (vkCreateImageView(m_device.device, &view_info, nullptr, &img.view) != VK_SUCCESS)
+        throw std::runtime_error("Failed to create depth image view");
+
+    m_images[node_id] = img;
+    return &m_images[node_id];
+}
+
 GpuImage* ResourcePool::get_image(uint32_t node_id) {
     auto it = m_images.find(node_id);
     if (it == m_images.end()) return nullptr;

--- a/projects/joon/src/vulkan/resource_pool.h
+++ b/projects/joon/src/vulkan/resource_pool.h
@@ -22,6 +22,16 @@ public:
     GpuImage* alloc_image(uint32_t node_id, uint32_t width, uint32_t height,
                           VkFormat format = VK_FORMAT_R32G32B32A32_SFLOAT);
 
+    // Like alloc_image but adds COLOR_ATTACHMENT_BIT for use as a render target.
+    // Same format default keeps the existing read_pixels() / compute pipeline
+    // contract — render targets are sampleable and compute-writeable.
+    GpuImage* alloc_render_target(uint32_t node_id, uint32_t width, uint32_t height,
+                                   VkFormat format = VK_FORMAT_R32G32B32A32_SFLOAT);
+
+    // Depth attachment with DEPTH_STENCIL_ATTACHMENT_BIT and depth-aspect view.
+    GpuImage* alloc_depth(uint32_t node_id, uint32_t width, uint32_t height,
+                           VkFormat format = VK_FORMAT_D32_SFLOAT);
+
     GpuImage* get_image(uint32_t node_id);
 
     void upload(GpuImage* img, const void* data, size_t size);

--- a/projects/joon/tests/test_geometry_pass.cpp
+++ b/projects/joon/tests/test_geometry_pass.cpp
@@ -1,0 +1,48 @@
+#include "catch_amalgamated.hpp"
+#include <joon/joon.h>
+
+using namespace joon;
+
+TEST_CASE("Geometry pass renders non-clear pixels", "[render][gpu]") {
+    auto ctx = Context::create();
+    auto graph = ctx->parse_string(R"(
+        (def c (cube :scale 1.5))
+        (def cam (camera :fov 60))
+        (def l (light :intensity 1.0))
+        (def gbuf (pass))
+        (output gbuf)
+    )");
+    REQUIRE_FALSE(graph.has_errors());
+
+    auto eval = ctx->create_evaluator(graph);
+    eval->evaluate();
+
+    auto px = eval->result("").read_pixels();
+    REQUIRE(px.size() == 512u * 512u * 4u);
+
+    // Expect at least some lit pixels (not all clear color {0,0,0,1}).
+    int lit = 0;
+    for (size_t i = 0; i < px.size(); i += 4) {
+        if (px[i + 0] > 0.05f || px[i + 1] > 0.05f || px[i + 2] > 0.05f) ++lit;
+    }
+    CHECK(lit > 100);
+}
+
+TEST_CASE("Compute can read geometry-pass output", "[render][gpu]") {
+    auto ctx = Context::create();
+    auto graph = ctx->parse_string(R"(
+        (def c (cube))
+        (def cam (camera))
+        (def l (light))
+        (def gbuf (pass))
+        (def adjusted (levels gbuf :contrast 1.5))
+        (output adjusted)
+    )");
+    REQUIRE_FALSE(graph.has_errors());
+
+    auto eval = ctx->create_evaluator(graph);
+    eval->evaluate();
+
+    auto px = eval->result("").read_pixels();
+    REQUIRE(px.size() == 512u * 512u * 4u);
+}

--- a/projects/joon/tests/test_math.cpp
+++ b/projects/joon/tests/test_math.cpp
@@ -1,0 +1,58 @@
+#include "catch_amalgamated.hpp"
+#include <joon/math.h>
+
+using namespace joon;
+
+TEST_CASE("identity_mat4 is the identity", "[math]") {
+    auto i = identity_mat4();
+    for (int c = 0; c < 4; ++c)
+        for (int r = 0; r < 4; ++r) {
+            float expected = (c == r) ? 1.0f : 0.0f;
+            CHECK(i.m[c * 4 + r] == Catch::Approx(expected));
+        }
+}
+
+TEST_CASE("mul(identity, M) == M and mul(M, identity) == M", "[math]") {
+    mat4 m = translate({1, 2, 3});
+    auto a = mul(identity_mat4(), m);
+    auto b = mul(m, identity_mat4());
+    for (int i = 0; i < 16; ++i) {
+        CHECK(a.m[i] == Catch::Approx(m.m[i]));
+        CHECK(b.m[i] == Catch::Approx(m.m[i]));
+    }
+}
+
+TEST_CASE("translate puts the translation in the last column", "[math]") {
+    auto t = translate({4, 5, 6});
+    CHECK(t.m[12] == Catch::Approx(4.f));
+    CHECK(t.m[13] == Catch::Approx(5.f));
+    CHECK(t.m[14] == Catch::Approx(6.f));
+    CHECK(t.m[15] == Catch::Approx(1.f));
+}
+
+TEST_CASE("vec3_normalize produces unit length", "[math]") {
+    auto u = vec3_normalize({3, 0, 4});   // length 5
+    CHECK(vec3_len(u) == Catch::Approx(1.f));
+    auto z = vec3_normalize({0, 0, 0});
+    CHECK(z.x == Catch::Approx(0.f));
+    CHECK(z.y == Catch::Approx(0.f));
+    CHECK(z.z == Catch::Approx(0.f));
+}
+
+TEST_CASE("look_at from {0,0,5} towards origin produces sane right/up/forward", "[math]") {
+    auto v = look_at({0, 0, 5}, {0, 0, 0}, {0, 1, 0});
+    // forward (-Z in view space) → world -Z → m[2]=-(-1)=+1? Layout per perspective.
+    // Simpler: applying view to the eye position should give origin.
+    // view * vec4(eye, 1) = (0, 0, 0, 1)
+    float vx = v.m[0]*0 + v.m[4]*0 + v.m[8]*5  + v.m[12]*1;
+    float vy = v.m[1]*0 + v.m[5]*0 + v.m[9]*5  + v.m[13]*1;
+    float vz = v.m[2]*0 + v.m[6]*0 + v.m[10]*5 + v.m[14]*1;
+    CHECK(vx == Catch::Approx(0.f).margin(1e-4f));
+    CHECK(vy == Catch::Approx(0.f).margin(1e-4f));
+    CHECK(vz == Catch::Approx(0.f).margin(1e-4f));
+}
+
+TEST_CASE("perspective_vk negates m[5] for Vulkan Y-down clip space", "[math]") {
+    auto p = perspective_vk(60.f, 1.0f, 0.1f, 100.f);
+    CHECK(p.m[5] < 0.f);
+}

--- a/projects/joon/tests/test_obj_loader.cpp
+++ b/projects/joon/tests/test_obj_loader.cpp
@@ -1,0 +1,41 @@
+#include "catch_amalgamated.hpp"
+#include "scene/obj_loader.h"
+#include <cmath>
+
+using namespace joon;
+
+static const char* CUBE_OBJ = R"(
+v -0.5 -0.5 -0.5
+v  0.5 -0.5 -0.5
+v  0.5  0.5 -0.5
+v -0.5  0.5 -0.5
+v -0.5 -0.5  0.5
+v  0.5 -0.5  0.5
+v  0.5  0.5  0.5
+v -0.5  0.5  0.5
+vn 0 0 -1
+vn 0 0  1
+f 1//1 2//1 3//1
+f 1//1 3//1 4//1
+f 5//2 6//2 7//2
+f 5//2 7//2 8//2
+)";
+
+TEST_CASE("OBJ loader parses positions and indices", "[obj]") {
+    auto mesh = load_obj_string(CUBE_OBJ);
+    CHECK(mesh.vertices.size() >= 12);   // 4 verts/face × 2 faces with split normals
+    CHECK(mesh.indices.size() == 12);    // 2 tris × 3 indices × 2 faces
+
+    // Positions are within ±0.5
+    for (auto& v : mesh.vertices) {
+        CHECK(std::abs(v.position.x) <= 0.5f + 1e-5f);
+        CHECK(std::abs(v.position.y) <= 0.5f + 1e-5f);
+        CHECK(std::abs(v.position.z) <= 0.5f + 1e-5f);
+    }
+}
+
+TEST_CASE("OBJ loader handles invalid input gracefully", "[obj]") {
+    // tinyobjloader returns false on garbage and our wrapper throws.
+    // Check the error path exists (don't be too strict about the wording).
+    REQUIRE_THROWS(load_obj_string("not a real obj file\nnonsense\n"));
+}

--- a/projects/joon/tests/test_primitives.cpp
+++ b/projects/joon/tests/test_primitives.cpp
@@ -54,6 +54,33 @@ TEST_CASE("Plane is 4 verts / 6 indices, lies in XZ at y=0, normal +Y", "[primit
     }
 }
 
+TEST_CASE("Generators clamp degenerate segment counts", "[primitives]") {
+    // sphere: lat<2 or lon<3 should be clamped, not divide by zero
+    auto s = gen_sphere(0.5f, 0, 0);
+    CHECK(s.vertices.size() == 3 * 4);   // clamped to lat=2, lon=3 → 3*4 verts
+    CHECK(s.indices.size()  == 2 * 3 * 6);
+    for (auto& v : s.vertices) {
+        // No NaNs from divide-by-zero
+        CHECK(std::isfinite(v.position.x));
+        CHECK(std::isfinite(v.normal.y));
+    }
+
+    // cylinder: segments<3 should be clamped
+    auto c = gen_cylinder(0.5f, 1.0f, 0);
+    CHECK(c.indices.size() == size_t(12 * 3));   // clamped to segments=3
+    for (auto& v : c.vertices) CHECK(std::isfinite(v.position.x));
+}
+
+TEST_CASE("Zero-radius sphere produces origin verts and zero normals (no NaN)", "[primitives]") {
+    auto m = gen_sphere(0.0f, 8, 8);
+    for (auto& v : m.vertices) {
+        CHECK(v.position.x == Catch::Approx(0.f));
+        CHECK(v.position.y == Catch::Approx(0.f));
+        CHECK(v.position.z == Catch::Approx(0.f));
+        CHECK(std::isfinite(v.normal.x));
+    }
+}
+
 TEST_CASE("Cylinder is closed (top + bottom caps + side strip)", "[primitives]") {
     int seg = 32;
     auto m = gen_cylinder(0.5f, 1.0f, seg);

--- a/projects/joon/tests/test_primitives.cpp
+++ b/projects/joon/tests/test_primitives.cpp
@@ -1,0 +1,72 @@
+#include "catch_amalgamated.hpp"
+#include "scene/primitives.h"
+#include <algorithm>
+#include <cmath>
+
+using namespace joon;
+
+TEST_CASE("Cube has 24 vertices / 36 indices, axis-aligned bounds, per-face normals", "[primitives]") {
+    auto m = gen_cube(1.0f);
+    CHECK(m.vertices.size() == 24);   // 4 verts/face × 6 faces
+    CHECK(m.indices.size() == 36);    // 2 tris/face × 3 indices × 6 faces
+
+    float minc = 999.f, maxc = -999.f;
+    for (auto& v : m.vertices) {
+        minc = std::min({minc, v.position.x, v.position.y, v.position.z});
+        maxc = std::max({maxc, v.position.x, v.position.y, v.position.z});
+    }
+    CHECK(minc == Catch::Approx(-0.5f));
+    CHECK(maxc == Catch::Approx( 0.5f));
+
+    // Per-face normals: every group of 4 verts shares one normal.
+    for (size_t f = 0; f < 6; ++f) {
+        auto n = m.vertices[f * 4].normal;
+        for (size_t i = 1; i < 4; ++i) {
+            CHECK(m.vertices[f * 4 + i].normal.x == Catch::Approx(n.x));
+            CHECK(m.vertices[f * 4 + i].normal.y == Catch::Approx(n.y));
+            CHECK(m.vertices[f * 4 + i].normal.z == Catch::Approx(n.z));
+        }
+    }
+}
+
+TEST_CASE("Sphere has consistent vertex/index counts for given segments", "[primitives]") {
+    auto m = gen_sphere(0.5f, /*lat=*/16, /*lon=*/32);
+    // (lat+1) * (lon+1) verts, lat * lon * 6 indices
+    CHECK(m.vertices.size() == 17 * 33);
+    CHECK(m.indices.size()  == 16 * 32 * 6);
+
+    // Every vertex is on the sphere of radius 0.5
+    for (auto& v : m.vertices) {
+        float r = std::sqrt(v.position.x*v.position.x
+                          + v.position.y*v.position.y
+                          + v.position.z*v.position.z);
+        CHECK(r == Catch::Approx(0.5f).margin(1e-4f));
+    }
+}
+
+TEST_CASE("Plane is 4 verts / 6 indices, lies in XZ at y=0, normal +Y", "[primitives]") {
+    auto m = gen_plane(2.0f, 2.0f);
+    CHECK(m.vertices.size() == 4);
+    CHECK(m.indices.size() == 6);
+    for (auto& v : m.vertices) {
+        CHECK(v.position.y == Catch::Approx(0.f));
+        CHECK(v.normal.y == Catch::Approx(1.f));
+    }
+}
+
+TEST_CASE("Cylinder is closed (top + bottom caps + side strip)", "[primitives]") {
+    int seg = 32;
+    auto m = gen_cylinder(0.5f, 1.0f, seg);
+    // Side strip: 2 verts per segment * (seg+1) (or seg*2 verts split per segment).
+    // Caps: seg + 1 vert each (center + ring).
+    // Index count: 6 * seg (side) + 3 * seg (top) + 3 * seg (bottom) = 12 * seg
+    CHECK(m.indices.size() == size_t(12 * seg));
+    // y bounds: [-0.5, 0.5]
+    float ymin = 999.f, ymax = -999.f;
+    for (auto& v : m.vertices) {
+        ymin = std::min(ymin, v.position.y);
+        ymax = std::max(ymax, v.position.y);
+    }
+    CHECK(ymin == Catch::Approx(-0.5f));
+    CHECK(ymax == Catch::Approx( 0.5f));
+}

--- a/projects/joon/tests/test_scene_collection.cpp
+++ b/projects/joon/tests/test_scene_collection.cpp
@@ -7,17 +7,20 @@ TEST_CASE("SceneCollection clear/add roundtrip", "[scene]") {
     SceneCollection s;
     Mesh m;
     m.vertices.push_back({{0,0,0},{0,1,0},{0,0}});
-    s.add_object(SceneObject{m, {1,0,0}, {0,0,0}, {1,1,1}, 0});
+    s.add_object(SceneObject{m, {1,0,0}, {0,0,0}, {1,1,1}, UINT32_MAX});
     s.add_light(Light{LightType::Directional, {0,-1,0}, {0,0,0}, {1,1,1}, 1.0f, 30.0f});
-    s.set_camera(Camera{60.f, {0,0,5}, {0,0,0}, {0,1,0}, 0.1f, 100.f});
+    // Set camera to a NON-default fov so clear-preserves-camera is actually exercised
+    // (vs trivially passing because both "preserve" and "reset to default" land on 60).
+    s.set_camera(Camera{75.f, {1,2,3}, {0,0,0}, {0,1,0}, 0.1f, 100.f});
 
     CHECK(s.objects.size() == 1);
     CHECK(s.lights.size() == 1);
-    CHECK(s.camera.fov_deg == Catch::Approx(60.f));
+    CHECK(s.camera.fov_deg == Catch::Approx(75.f));
     CHECK(s.objects[0].position.x == Catch::Approx(1.f));
 
     s.clear();
     CHECK(s.objects.empty());
     CHECK(s.lights.empty());
-    CHECK(s.camera.fov_deg == Catch::Approx(60.f));   // default-constructed Camera has 60 fov per scene.h
+    CHECK(s.camera.fov_deg == Catch::Approx(75.f));   // clear preserves the camera that was set
+    CHECK(s.camera.position.x == Catch::Approx(1.f));
 }

--- a/projects/joon/tests/test_scene_collection.cpp
+++ b/projects/joon/tests/test_scene_collection.cpp
@@ -1,0 +1,23 @@
+#include "catch_amalgamated.hpp"
+#include <joon/scene.h>
+
+using namespace joon;
+
+TEST_CASE("SceneCollection clear/add roundtrip", "[scene]") {
+    SceneCollection s;
+    Mesh m;
+    m.vertices.push_back({{0,0,0},{0,1,0},{0,0}});
+    s.add_object(SceneObject{m, {1,0,0}, {0,0,0}, {1,1,1}, 0});
+    s.add_light(Light{LightType::Directional, {0,-1,0}, {0,0,0}, {1,1,1}, 1.0f, 30.0f});
+    s.set_camera(Camera{60.f, {0,0,5}, {0,0,0}, {0,1,0}, 0.1f, 100.f});
+
+    CHECK(s.objects.size() == 1);
+    CHECK(s.lights.size() == 1);
+    CHECK(s.camera.fov_deg == Catch::Approx(60.f));
+    CHECK(s.objects[0].position.x == Catch::Approx(1.f));
+
+    s.clear();
+    CHECK(s.objects.empty());
+    CHECK(s.lights.empty());
+    CHECK(s.camera.fov_deg == Catch::Approx(60.f));   // default-constructed Camera has 60 fov per scene.h
+}

--- a/projects/joon/tests/test_scene_executors.cpp
+++ b/projects/joon/tests/test_scene_executors.cpp
@@ -1,0 +1,41 @@
+#include "catch_amalgamated.hpp"
+#include <joon/joon.h>
+#include <joon/scene.h>
+
+using namespace joon;
+
+TEST_CASE("Evaluating a scene populates SceneCollection", "[scene][executors][gpu]") {
+    auto ctx = Context::create();
+    auto graph = ctx->parse_string(R"(
+        (def c (cube :scale 1.0))
+        (def s (sphere :radius 0.5))
+        (def l (light :type directional :intensity 0.8))
+        (def cam (camera :fov 75))
+        (output 0.5)
+    )");
+    REQUIRE_FALSE(graph.has_errors());
+
+    auto eval = ctx->create_evaluator(graph);
+    eval->evaluate();
+
+    auto& scene = eval->scene_for_test();
+    CHECK(scene.objects.size() == 2);
+    CHECK(scene.lights.size() == 1);
+    CHECK(scene.lights[0].intensity == Catch::Approx(0.8f));
+    CHECK(scene.camera.fov_deg == Catch::Approx(75.0f));
+}
+
+TEST_CASE("SceneCollection is cleared between evaluate() calls", "[scene][executors][gpu]") {
+    auto ctx = Context::create();
+    auto graph = ctx->parse_string(R"(
+        (def c (cube))
+        (output 0.5)
+    )");
+    auto eval = ctx->create_evaluator(graph);
+    eval->evaluate();
+    CHECK(eval->scene_for_test().objects.size() == 1);
+
+    // Re-evaluate; objects must not accumulate.
+    eval->evaluate();
+    CHECK(eval->scene_for_test().objects.size() == 1);
+}

--- a/projects/joon/tests/test_scene_ir.cpp
+++ b/projects/joon/tests/test_scene_ir.cpp
@@ -1,0 +1,38 @@
+#include "catch_amalgamated.hpp"
+#include <joon/joon.h>
+#include "ir/ir_graph.h"
+using namespace joon;
+
+TEST_CASE("Scene ops are tagged with SCENE tier", "[scene][ir]") {
+    auto ctx = Context::create();
+    auto graph = ctx->parse_string(R"(
+        (def c (cube :scale 1.0))
+        (def s (sphere :radius 0.5))
+        (def l (light :type directional))
+        (def cam (camera :fov 60))
+    )");
+    REQUIRE_FALSE(graph.has_errors());
+
+    auto& ir = graph.ir();
+    int scene_count = 0;
+    for (auto& n : ir.nodes)
+        if (n.tier == Tier::SCENE) ++scene_count;
+    CHECK(scene_count == 4);
+}
+
+TEST_CASE("pass op is tagged with RENDER tier", "[scene][ir]") {
+    auto ctx = Context::create();
+    auto graph = ctx->parse_string(R"(
+        (def scene (cube))
+        (def cam (camera :fov 60))
+        (def out (pass scene))
+        (output out)
+    )");
+    REQUIRE_FALSE(graph.has_errors());
+
+    auto& ir = graph.ir();
+    bool found_render = false;
+    for (auto& n : ir.nodes)
+        if (n.tier == Tier::RENDER) { found_render = true; break; }
+    CHECK(found_render);
+}

--- a/projects/joon/third_party/tinyobjloader/LICENSE
+++ b/projects/joon/third_party/tinyobjloader/LICENSE
@@ -1,0 +1,42 @@
+The MIT License (MIT)
+
+Copyright (c) 2012-2019 Syoyo Fujita and many contributors.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+----------------------------------
+
+mapbox/earcut.hpp
+
+ISC License
+
+Copyright (c) 2015, Mapbox
+
+Permission to use, copy, modify, and/or distribute this software for any purpose
+with or without fee is hereby granted, provided that the above copyright notice
+and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+THIS SOFTWARE.
+

--- a/projects/joon/third_party/tinyobjloader/tiny_obj_loader.h
+++ b/projects/joon/third_party/tinyobjloader/tiny_obj_loader.h
@@ -1,0 +1,3499 @@
+/*
+The MIT License (MIT)
+
+Copyright (c) 2012-Present, Syoyo Fujita and many contributors.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+//
+// version 2.0.0 : Add new object oriented API. 1.x API is still provided.
+//                 * Add python binding.
+//                 * Support line primitive.
+//                 * Support points primitive.
+//                 * Support multiple search path for .mtl(v1 API).
+//                 * Support vertex skinning weight `vw`(as an tinyobj
+//                 extension). Note that this differs vertex weight([w]
+//                 component in `v` line)
+//                 * Support escaped whitespece in mtllib
+//                 * Add robust triangulation using Mapbox
+//                 earcut(TINYOBJLOADER_USE_MAPBOX_EARCUT).
+// version 1.4.0 : Modifed ParseTextureNameAndOption API
+// version 1.3.1 : Make ParseTextureNameAndOption API public
+// version 1.3.0 : Separate warning and error message(breaking API of LoadObj)
+// version 1.2.3 : Added color space extension('-colorspace') to tex opts.
+// version 1.2.2 : Parse multiple group names.
+// version 1.2.1 : Added initial support for line('l') primitive(PR #178)
+// version 1.2.0 : Hardened implementation(#175)
+// version 1.1.1 : Support smoothing groups(#162)
+// version 1.1.0 : Support parsing vertex color(#144)
+// version 1.0.8 : Fix parsing `g` tag just after `usemtl`(#138)
+// version 1.0.7 : Support multiple tex options(#126)
+// version 1.0.6 : Add TINYOBJLOADER_USE_DOUBLE option(#124)
+// version 1.0.5 : Ignore `Tr` when `d` exists in MTL(#43)
+// version 1.0.4 : Support multiple filenames for 'mtllib'(#112)
+// version 1.0.3 : Support parsing texture options(#85)
+// version 1.0.2 : Improve parsing speed by about a factor of 2 for large
+// files(#105)
+// version 1.0.1 : Fixes a shape is lost if obj ends with a 'usemtl'(#104)
+// version 1.0.0 : Change data structure. Change license from BSD to MIT.
+//
+
+//
+// Use this in *one* .cc
+//   #define TINYOBJLOADER_IMPLEMENTATION
+//   #include "tiny_obj_loader.h"
+//
+
+#ifndef TINY_OBJ_LOADER_H_
+#define TINY_OBJ_LOADER_H_
+
+#include <map>
+#include <string>
+#include <vector>
+
+namespace tinyobj {
+
+// TODO(syoyo): Better C++11 detection for older compiler
+#if __cplusplus > 199711L
+#define TINYOBJ_OVERRIDE override
+#else
+#define TINYOBJ_OVERRIDE
+#endif
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#if __has_warning("-Wzero-as-null-pointer-constant")
+#pragma clang diagnostic ignored "-Wzero-as-null-pointer-constant"
+#endif
+
+#pragma clang diagnostic ignored "-Wpadded"
+
+#endif
+
+// https://en.wikipedia.org/wiki/Wavefront_.obj_file says ...
+//
+//  -blendu on | off                       # set horizontal texture blending
+//  (default on)
+//  -blendv on | off                       # set vertical texture blending
+//  (default on)
+//  -boost real_value                      # boost mip-map sharpness
+//  -mm base_value gain_value              # modify texture map values (default
+//  0 1)
+//                                         #     base_value = brightness,
+//                                         gain_value = contrast
+//  -o u [v [w]]                           # Origin offset             (default
+//  0 0 0)
+//  -s u [v [w]]                           # Scale                     (default
+//  1 1 1)
+//  -t u [v [w]]                           # Turbulence                (default
+//  0 0 0)
+//  -texres resolution                     # texture resolution to create
+//  -clamp on | off                        # only render texels in the clamped
+//  0-1 range (default off)
+//                                         #   When unclamped, textures are
+//                                         repeated across a surface,
+//                                         #   when clamped, only texels which
+//                                         fall within the 0-1
+//                                         #   range are rendered.
+//  -bm mult_value                         # bump multiplier (for bump maps
+//  only)
+//
+//  -imfchan r | g | b | m | l | z         # specifies which channel of the file
+//  is used to
+//                                         # create a scalar or bump texture.
+//                                         r:red, g:green,
+//                                         # b:blue, m:matte, l:luminance,
+//                                         z:z-depth..
+//                                         # (the default for bump is 'l' and
+//                                         for decal is 'm')
+//  bump -imfchan r bumpmap.tga            # says to use the red channel of
+//  bumpmap.tga as the bumpmap
+//
+// For reflection maps...
+//
+//   -type sphere                           # specifies a sphere for a "refl"
+//   reflection map
+//   -type cube_top    | cube_bottom |      # when using a cube map, the texture
+//   file for each
+//         cube_front  | cube_back   |      # side of the cube is specified
+//         separately
+//         cube_left   | cube_right
+//
+// TinyObjLoader extension.
+//
+//   -colorspace SPACE                      # Color space of the texture. e.g.
+//   'sRGB` or 'linear'
+//
+
+#ifdef TINYOBJLOADER_USE_DOUBLE
+//#pragma message "using double"
+typedef double real_t;
+#else
+//#pragma message "using float"
+typedef float real_t;
+#endif
+
+typedef enum {
+  TEXTURE_TYPE_NONE,  // default
+  TEXTURE_TYPE_SPHERE,
+  TEXTURE_TYPE_CUBE_TOP,
+  TEXTURE_TYPE_CUBE_BOTTOM,
+  TEXTURE_TYPE_CUBE_FRONT,
+  TEXTURE_TYPE_CUBE_BACK,
+  TEXTURE_TYPE_CUBE_LEFT,
+  TEXTURE_TYPE_CUBE_RIGHT
+} texture_type_t;
+
+struct texture_option_t {
+  texture_type_t type;      // -type (default TEXTURE_TYPE_NONE)
+  real_t sharpness;         // -boost (default 1.0?)
+  real_t brightness;        // base_value in -mm option (default 0)
+  real_t contrast;          // gain_value in -mm option (default 1)
+  real_t origin_offset[3];  // -o u [v [w]] (default 0 0 0)
+  real_t scale[3];          // -s u [v [w]] (default 1 1 1)
+  real_t turbulence[3];     // -t u [v [w]] (default 0 0 0)
+  int texture_resolution;   // -texres resolution (No default value in the spec.
+                            // We'll use -1)
+  bool clamp;               // -clamp (default false)
+  char imfchan;  // -imfchan (the default for bump is 'l' and for decal is 'm')
+  bool blendu;   // -blendu (default on)
+  bool blendv;   // -blendv (default on)
+  real_t bump_multiplier;  // -bm (for bump maps only, default 1.0)
+
+  // extension
+  std::string colorspace;  // Explicitly specify color space of stored texel
+                           // value. Usually `sRGB` or `linear` (default empty).
+};
+
+struct material_t {
+  std::string name;
+
+  real_t ambient[3];
+  real_t diffuse[3];
+  real_t specular[3];
+  real_t transmittance[3];
+  real_t emission[3];
+  real_t shininess;
+  real_t ior;       // index of refraction
+  real_t dissolve;  // 1 == opaque; 0 == fully transparent
+  // illumination model (see http://www.fileformat.info/format/material/)
+  int illum;
+
+  int dummy;  // Suppress padding warning.
+
+  std::string ambient_texname;   // map_Ka. For ambient or ambient occlusion.
+  std::string diffuse_texname;   // map_Kd
+  std::string specular_texname;  // map_Ks
+  std::string specular_highlight_texname;  // map_Ns
+  std::string bump_texname;                // map_bump, map_Bump, bump
+  std::string displacement_texname;        // disp
+  std::string alpha_texname;               // map_d
+  std::string reflection_texname;          // refl
+
+  texture_option_t ambient_texopt;
+  texture_option_t diffuse_texopt;
+  texture_option_t specular_texopt;
+  texture_option_t specular_highlight_texopt;
+  texture_option_t bump_texopt;
+  texture_option_t displacement_texopt;
+  texture_option_t alpha_texopt;
+  texture_option_t reflection_texopt;
+
+  // PBR extension
+  // http://exocortex.com/blog/extending_wavefront_mtl_to_support_pbr
+  real_t roughness;            // [0, 1] default 0
+  real_t metallic;             // [0, 1] default 0
+  real_t sheen;                // [0, 1] default 0
+  real_t clearcoat_thickness;  // [0, 1] default 0
+  real_t clearcoat_roughness;  // [0, 1] default 0
+  real_t anisotropy;           // aniso. [0, 1] default 0
+  real_t anisotropy_rotation;  // anisor. [0, 1] default 0
+  real_t pad0;
+  std::string roughness_texname;  // map_Pr
+  std::string metallic_texname;   // map_Pm
+  std::string sheen_texname;      // map_Ps
+  std::string emissive_texname;   // map_Ke
+  std::string normal_texname;     // norm. For normal mapping.
+
+  texture_option_t roughness_texopt;
+  texture_option_t metallic_texopt;
+  texture_option_t sheen_texopt;
+  texture_option_t emissive_texopt;
+  texture_option_t normal_texopt;
+
+  int pad2;
+
+  std::map<std::string, std::string> unknown_parameter;
+
+#ifdef TINY_OBJ_LOADER_PYTHON_BINDING
+  // For pybind11
+  std::array<double, 3> GetDiffuse() {
+    std::array<double, 3> values;
+    values[0] = double(diffuse[0]);
+    values[1] = double(diffuse[1]);
+    values[2] = double(diffuse[2]);
+
+    return values;
+  }
+
+  std::array<double, 3> GetSpecular() {
+    std::array<double, 3> values;
+    values[0] = double(specular[0]);
+    values[1] = double(specular[1]);
+    values[2] = double(specular[2]);
+
+    return values;
+  }
+
+  std::array<double, 3> GetTransmittance() {
+    std::array<double, 3> values;
+    values[0] = double(transmittance[0]);
+    values[1] = double(transmittance[1]);
+    values[2] = double(transmittance[2]);
+
+    return values;
+  }
+
+  std::array<double, 3> GetEmission() {
+    std::array<double, 3> values;
+    values[0] = double(emission[0]);
+    values[1] = double(emission[1]);
+    values[2] = double(emission[2]);
+
+    return values;
+  }
+
+  std::array<double, 3> GetAmbient() {
+    std::array<double, 3> values;
+    values[0] = double(ambient[0]);
+    values[1] = double(ambient[1]);
+    values[2] = double(ambient[2]);
+
+    return values;
+  }
+
+  void SetDiffuse(std::array<double, 3> &a) {
+    diffuse[0] = real_t(a[0]);
+    diffuse[1] = real_t(a[1]);
+    diffuse[2] = real_t(a[2]);
+  }
+
+  void SetAmbient(std::array<double, 3> &a) {
+    ambient[0] = real_t(a[0]);
+    ambient[1] = real_t(a[1]);
+    ambient[2] = real_t(a[2]);
+  }
+
+  void SetSpecular(std::array<double, 3> &a) {
+    specular[0] = real_t(a[0]);
+    specular[1] = real_t(a[1]);
+    specular[2] = real_t(a[2]);
+  }
+
+  void SetTransmittance(std::array<double, 3> &a) {
+    transmittance[0] = real_t(a[0]);
+    transmittance[1] = real_t(a[1]);
+    transmittance[2] = real_t(a[2]);
+  }
+
+  std::string GetCustomParameter(const std::string &key) {
+    std::map<std::string, std::string>::const_iterator it =
+        unknown_parameter.find(key);
+
+    if (it != unknown_parameter.end()) {
+      return it->second;
+    }
+    return std::string();
+  }
+
+#endif
+};
+
+struct tag_t {
+  std::string name;
+
+  std::vector<int> intValues;
+  std::vector<real_t> floatValues;
+  std::vector<std::string> stringValues;
+};
+
+struct joint_and_weight_t {
+  int joint_id;
+  real_t weight;
+};
+
+struct skin_weight_t {
+  int vertex_id;  // Corresponding vertex index in `attrib_t::vertices`.
+                  // Compared to `index_t`, this index must be positive and
+                  // start with 0(does not allow relative indexing)
+  std::vector<joint_and_weight_t> weightValues;
+};
+
+// Index struct to support different indices for vtx/normal/texcoord.
+// -1 means not used.
+struct index_t {
+  int vertex_index;
+  int normal_index;
+  int texcoord_index;
+};
+
+struct mesh_t {
+  std::vector<index_t> indices;
+  std::vector<unsigned int>
+      num_face_vertices;          // The number of vertices per
+                                  // face. 3 = triangle, 4 = quad, ...
+  std::vector<int> material_ids;  // per-face material ID
+  std::vector<unsigned int> smoothing_group_ids;  // per-face smoothing group
+                                                  // ID(0 = off. positive value
+                                                  // = group id)
+  std::vector<tag_t> tags;                        // SubD tag
+};
+
+// struct path_t {
+//  std::vector<int> indices;  // pairs of indices for lines
+//};
+
+struct lines_t {
+  // Linear flattened indices.
+  std::vector<index_t> indices;        // indices for vertices(poly lines)
+  std::vector<int> num_line_vertices;  // The number of vertices per line.
+};
+
+struct points_t {
+  std::vector<index_t> indices;  // indices for points
+};
+
+struct shape_t {
+  std::string name;
+  mesh_t mesh;
+  lines_t lines;
+  points_t points;
+};
+
+// Vertex attributes
+struct attrib_t {
+  std::vector<real_t> vertices;  // 'v'(xyz)
+
+  // For backward compatibility, we store vertex weight in separate array.
+  std::vector<real_t> vertex_weights;  // 'v'(w)
+  std::vector<real_t> normals;         // 'vn'
+  std::vector<real_t> texcoords;       // 'vt'(uv)
+
+  // For backward compatibility, we store texture coordinate 'w' in separate
+  // array.
+  std::vector<real_t> texcoord_ws;  // 'vt'(w)
+  std::vector<real_t> colors;       // extension: vertex colors
+
+  //
+  // TinyObj extension.
+  //
+
+  // NOTE(syoyo): array index is based on the appearance order.
+  // To get a corresponding skin weight for a specific vertex id `vid`,
+  // Need to reconstruct a look up table: `skin_weight_t::vertex_id` == `vid`
+  // (e.g. using std::map, std::unordered_map)
+  std::vector<skin_weight_t> skin_weights;
+
+  attrib_t() {}
+
+  //
+  // For pybind11
+  //
+  const std::vector<real_t> &GetVertices() const { return vertices; }
+
+  const std::vector<real_t> &GetVertexWeights() const { return vertex_weights; }
+};
+
+struct callback_t {
+  // W is optional and set to 1 if there is no `w` item in `v` line
+  void (*vertex_cb)(void *user_data, real_t x, real_t y, real_t z, real_t w);
+  void (*vertex_color_cb)(void *user_data, real_t x, real_t y, real_t z,
+                          real_t r, real_t g, real_t b, bool has_color);
+  void (*normal_cb)(void *user_data, real_t x, real_t y, real_t z);
+
+  // y and z are optional and set to 0 if there is no `y` and/or `z` item(s) in
+  // `vt` line.
+  void (*texcoord_cb)(void *user_data, real_t x, real_t y, real_t z);
+
+  // called per 'f' line. num_indices is the number of face indices(e.g. 3 for
+  // triangle, 4 for quad)
+  // 0 will be passed for undefined index in index_t members.
+  void (*index_cb)(void *user_data, index_t *indices, int num_indices);
+  // `name` material name, `material_id` = the array index of material_t[]. -1
+  // if
+  // a material not found in .mtl
+  void (*usemtl_cb)(void *user_data, const char *name, int material_id);
+  // `materials` = parsed material data.
+  void (*mtllib_cb)(void *user_data, const material_t *materials,
+                    int num_materials);
+  // There may be multiple group names
+  void (*group_cb)(void *user_data, const char **names, int num_names);
+  void (*object_cb)(void *user_data, const char *name);
+
+  callback_t()
+      : vertex_cb(NULL),
+        vertex_color_cb(NULL),
+        normal_cb(NULL),
+        texcoord_cb(NULL),
+        index_cb(NULL),
+        usemtl_cb(NULL),
+        mtllib_cb(NULL),
+        group_cb(NULL),
+        object_cb(NULL) {}
+};
+
+class MaterialReader {
+ public:
+  MaterialReader() {}
+  virtual ~MaterialReader();
+
+  virtual bool operator()(const std::string &matId,
+                          std::vector<material_t> *materials,
+                          std::map<std::string, int> *matMap, std::string *warn,
+                          std::string *err) = 0;
+};
+
+///
+/// Read .mtl from a file.
+///
+class MaterialFileReader : public MaterialReader {
+ public:
+  // Path could contain separator(';' in Windows, ':' in Posix)
+  explicit MaterialFileReader(const std::string &mtl_basedir)
+      : m_mtlBaseDir(mtl_basedir) {}
+  virtual ~MaterialFileReader() TINYOBJ_OVERRIDE {}
+  virtual bool operator()(const std::string &matId,
+                          std::vector<material_t> *materials,
+                          std::map<std::string, int> *matMap, std::string *warn,
+                          std::string *err) TINYOBJ_OVERRIDE;
+
+ private:
+  std::string m_mtlBaseDir;
+};
+
+///
+/// Read .mtl from a stream.
+///
+class MaterialStreamReader : public MaterialReader {
+ public:
+  explicit MaterialStreamReader(std::istream &inStream)
+      : m_inStream(inStream) {}
+  virtual ~MaterialStreamReader() TINYOBJ_OVERRIDE {}
+  virtual bool operator()(const std::string &matId,
+                          std::vector<material_t> *materials,
+                          std::map<std::string, int> *matMap, std::string *warn,
+                          std::string *err) TINYOBJ_OVERRIDE;
+
+ private:
+  std::istream &m_inStream;
+};
+
+// v2 API
+struct ObjReaderConfig {
+  bool triangulate;  // triangulate polygon?
+
+  // Currently not used.
+  // "simple" or empty: Create triangle fan
+  // "earcut": Use the algorithm based on Ear clipping
+  std::string triangulation_method;
+
+  /// Parse vertex color.
+  /// If vertex color is not present, its filled with default value.
+  /// false = no vertex color
+  /// This will increase memory of parsed .obj
+  bool vertex_color;
+
+  ///
+  /// Search path to .mtl file.
+  /// Default = "" = search from the same directory of .obj file.
+  /// Valid only when loading .obj from a file.
+  ///
+  std::string mtl_search_path;
+
+  ObjReaderConfig()
+      : triangulate(true), triangulation_method("simple"), vertex_color(true) {}
+};
+
+///
+/// Wavefront .obj reader class(v2 API)
+///
+class ObjReader {
+ public:
+  ObjReader() : valid_(false) {}
+
+  ///
+  /// Load .obj and .mtl from a file.
+  ///
+  /// @param[in] filename wavefront .obj filename
+  /// @param[in] config Reader configuration
+  ///
+  bool ParseFromFile(const std::string &filename,
+                     const ObjReaderConfig &config = ObjReaderConfig());
+
+  ///
+  /// Parse .obj from a text string.
+  /// Need to supply .mtl text string by `mtl_text`.
+  /// This function ignores `mtllib` line in .obj text.
+  ///
+  /// @param[in] obj_text wavefront .obj filename
+  /// @param[in] mtl_text wavefront .mtl filename
+  /// @param[in] config Reader configuration
+  ///
+  bool ParseFromString(const std::string &obj_text, const std::string &mtl_text,
+                       const ObjReaderConfig &config = ObjReaderConfig());
+
+  ///
+  /// .obj was loaded or parsed correctly.
+  ///
+  bool Valid() const { return valid_; }
+
+  const attrib_t &GetAttrib() const { return attrib_; }
+
+  const std::vector<shape_t> &GetShapes() const { return shapes_; }
+
+  const std::vector<material_t> &GetMaterials() const { return materials_; }
+
+  ///
+  /// Warning message(may be filled after `Load` or `Parse`)
+  ///
+  const std::string &Warning() const { return warning_; }
+
+  ///
+  /// Error message(filled when `Load` or `Parse` failed)
+  ///
+  const std::string &Error() const { return error_; }
+
+ private:
+  bool valid_;
+
+  attrib_t attrib_;
+  std::vector<shape_t> shapes_;
+  std::vector<material_t> materials_;
+
+  std::string warning_;
+  std::string error_;
+};
+
+/// ==>>========= Legacy v1 API =============================================
+
+/// Loads .obj from a file.
+/// 'attrib', 'shapes' and 'materials' will be filled with parsed shape data
+/// 'shapes' will be filled with parsed shape data
+/// Returns true when loading .obj become success.
+/// Returns warning message into `warn`, and error message into `err`
+/// 'mtl_basedir' is optional, and used for base directory for .mtl file.
+/// In default(`NULL'), .mtl file is searched from an application's working
+/// directory.
+/// 'triangulate' is optional, and used whether triangulate polygon face in .obj
+/// or not.
+/// Option 'default_vcols_fallback' specifies whether vertex colors should
+/// always be defined, even if no colors are given (fallback to white).
+bool LoadObj(attrib_t *attrib, std::vector<shape_t> *shapes,
+             std::vector<material_t> *materials, std::string *warn,
+             std::string *err, const char *filename,
+             const char *mtl_basedir = NULL, bool triangulate = true,
+             bool default_vcols_fallback = true);
+
+/// Loads .obj from a file with custom user callback.
+/// .mtl is loaded as usual and parsed material_t data will be passed to
+/// `callback.mtllib_cb`.
+/// Returns true when loading .obj/.mtl become success.
+/// Returns warning message into `warn`, and error message into `err`
+/// See `examples/callback_api/` for how to use this function.
+bool LoadObjWithCallback(std::istream &inStream, const callback_t &callback,
+                         void *user_data = NULL,
+                         MaterialReader *readMatFn = NULL,
+                         std::string *warn = NULL, std::string *err = NULL);
+
+/// Loads object from a std::istream, uses `readMatFn` to retrieve
+/// std::istream for materials.
+/// Returns true when loading .obj become success.
+/// Returns warning and error message into `err`
+bool LoadObj(attrib_t *attrib, std::vector<shape_t> *shapes,
+             std::vector<material_t> *materials, std::string *warn,
+             std::string *err, std::istream *inStream,
+             MaterialReader *readMatFn = NULL, bool triangulate = true,
+             bool default_vcols_fallback = true);
+
+/// Loads materials into std::map
+void LoadMtl(std::map<std::string, int> *material_map,
+             std::vector<material_t> *materials, std::istream *inStream,
+             std::string *warning, std::string *err);
+
+///
+/// Parse texture name and texture option for custom texture parameter through
+/// material::unknown_parameter
+///
+/// @param[out] texname Parsed texture name
+/// @param[out] texopt Parsed texopt
+/// @param[in] linebuf Input string
+///
+bool ParseTextureNameAndOption(std::string *texname, texture_option_t *texopt,
+                               const char *linebuf);
+
+/// =<<========== Legacy v1 API =============================================
+
+}  // namespace tinyobj
+
+#endif  // TINY_OBJ_LOADER_H_
+
+#ifdef TINYOBJLOADER_IMPLEMENTATION
+#include <cassert>
+#include <cctype>
+#include <cmath>
+#include <cstddef>
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
+#include <limits>
+#include <set>
+#include <sstream>
+#include <utility>
+
+#ifdef TINYOBJLOADER_USE_MAPBOX_EARCUT
+
+#ifdef TINYOBJLOADER_DONOT_INCLUDE_MAPBOX_EARCUT
+// Assume earcut.hpp is included outside of tiny_obj_loader.h
+#else
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Weverything"
+#endif
+
+#include <array>
+
+#include "mapbox/earcut.hpp"
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
+
+#endif
+
+#endif  // TINYOBJLOADER_USE_MAPBOX_EARCUT
+
+namespace tinyobj {
+
+MaterialReader::~MaterialReader() {}
+
+struct vertex_index_t {
+  int v_idx, vt_idx, vn_idx;
+  vertex_index_t() : v_idx(-1), vt_idx(-1), vn_idx(-1) {}
+  explicit vertex_index_t(int idx) : v_idx(idx), vt_idx(idx), vn_idx(idx) {}
+  vertex_index_t(int vidx, int vtidx, int vnidx)
+      : v_idx(vidx), vt_idx(vtidx), vn_idx(vnidx) {}
+};
+
+// Internal data structure for face representation
+// index + smoothing group.
+struct face_t {
+  unsigned int
+      smoothing_group_id;  // smoothing group id. 0 = smoothing groupd is off.
+  int pad_;
+  std::vector<vertex_index_t> vertex_indices;  // face vertex indices.
+
+  face_t() : smoothing_group_id(0), pad_(0) {}
+};
+
+// Internal data structure for line representation
+struct __line_t {
+  // l v1/vt1 v2/vt2 ...
+  // In the specification, line primitrive does not have normal index, but
+  // TinyObjLoader allow it
+  std::vector<vertex_index_t> vertex_indices;
+};
+
+// Internal data structure for points representation
+struct __points_t {
+  // p v1 v2 ...
+  // In the specification, point primitrive does not have normal index and
+  // texture coord index, but TinyObjLoader allow it.
+  std::vector<vertex_index_t> vertex_indices;
+};
+
+struct tag_sizes {
+  tag_sizes() : num_ints(0), num_reals(0), num_strings(0) {}
+  int num_ints;
+  int num_reals;
+  int num_strings;
+};
+
+struct obj_shape {
+  std::vector<real_t> v;
+  std::vector<real_t> vn;
+  std::vector<real_t> vt;
+};
+
+//
+// Manages group of primitives(face, line, points, ...)
+struct PrimGroup {
+  std::vector<face_t> faceGroup;
+  std::vector<__line_t> lineGroup;
+  std::vector<__points_t> pointsGroup;
+
+  void clear() {
+    faceGroup.clear();
+    lineGroup.clear();
+    pointsGroup.clear();
+  }
+
+  bool IsEmpty() const {
+    return faceGroup.empty() && lineGroup.empty() && pointsGroup.empty();
+  }
+
+  // TODO(syoyo): bspline, surface, ...
+};
+
+// See
+// http://stackoverflow.com/questions/6089231/getting-std-ifstream-to-handle-lf-cr-and-crlf
+static std::istream &safeGetline(std::istream &is, std::string &t) {
+  t.clear();
+
+  // The characters in the stream are read one-by-one using a std::streambuf.
+  // That is faster than reading them one-by-one using the std::istream.
+  // Code that uses streambuf this way must be guarded by a sentry object.
+  // The sentry object performs various tasks,
+  // such as thread synchronization and updating the stream state.
+
+  std::istream::sentry se(is, true);
+  std::streambuf *sb = is.rdbuf();
+
+  if (se) {
+    for (;;) {
+      int c = sb->sbumpc();
+      switch (c) {
+        case '\n':
+          return is;
+        case '\r':
+          if (sb->sgetc() == '\n') sb->sbumpc();
+          return is;
+        case EOF:
+          // Also handle the case when the last line has no line ending
+          if (t.empty()) is.setstate(std::ios::eofbit);
+          return is;
+        default:
+          t += static_cast<char>(c);
+      }
+    }
+  }
+
+  return is;
+}
+
+#define IS_SPACE(x) (((x) == ' ') || ((x) == '\t'))
+#define IS_DIGIT(x) \
+  (static_cast<unsigned int>((x) - '0') < static_cast<unsigned int>(10))
+#define IS_NEW_LINE(x) (((x) == '\r') || ((x) == '\n') || ((x) == '\0'))
+
+template <typename T>
+static inline std::string toString(const T &t) {
+  std::stringstream ss;
+  ss << t;
+  return ss.str();
+}
+
+struct warning_context {
+  std::string *warn;
+  size_t line_number;
+};
+
+// Make index zero-base, and also support relative index.
+static inline bool fixIndex(int idx, int n, int *ret, bool allow_zero,
+                            const warning_context &context) {
+  if (!ret) {
+    return false;
+  }
+
+  if (idx > 0) {
+    (*ret) = idx - 1;
+    return true;
+  }
+
+  if (idx == 0) {
+    // zero is not allowed according to the spec.
+    if (context.warn) {
+      (*context.warn) +=
+          "A zero value index found (will have a value of -1 for normal and "
+          "tex indices. Line " +
+          toString(context.line_number) + ").\n";
+    }
+
+    (*ret) = idx - 1;
+    return allow_zero;
+  }
+
+  if (idx < 0) {
+    (*ret) = n + idx;  // negative value = relative
+    if ((*ret) < 0) {
+      return false;  // invalid relative index
+    }
+    return true;
+  }
+
+  return false;  // never reach here.
+}
+
+static inline std::string parseString(const char **token) {
+  std::string s;
+  (*token) += strspn((*token), " \t");
+  size_t e = strcspn((*token), " \t\r");
+  s = std::string((*token), &(*token)[e]);
+  (*token) += e;
+  return s;
+}
+
+static inline int parseInt(const char **token) {
+  (*token) += strspn((*token), " \t");
+  int i = atoi((*token));
+  (*token) += strcspn((*token), " \t\r");
+  return i;
+}
+
+// Tries to parse a floating point number located at s.
+//
+// s_end should be a location in the string where reading should absolutely
+// stop. For example at the end of the string, to prevent buffer overflows.
+//
+// Parses the following EBNF grammar:
+//   sign    = "+" | "-" ;
+//   END     = ? anything not in digit ?
+//   digit   = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" ;
+//   integer = [sign] , digit , {digit} ;
+//   decimal = integer , ["." , integer] ;
+//   float   = ( decimal , END ) | ( decimal , ("E" | "e") , integer , END ) ;
+//
+//  Valid strings are for example:
+//   -0  +3.1417e+2  -0.0E-3  1.0324  -1.41   11e2
+//
+// If the parsing is a success, result is set to the parsed value and true
+// is returned.
+//
+// The function is greedy and will parse until any of the following happens:
+//  - a non-conforming character is encountered.
+//  - s_end is reached.
+//
+// The following situations triggers a failure:
+//  - s >= s_end.
+//  - parse failure.
+//
+static bool tryParseDouble(const char *s, const char *s_end, double *result) {
+  if (s >= s_end) {
+    return false;
+  }
+
+  double mantissa = 0.0;
+  // This exponent is base 2 rather than 10.
+  // However the exponent we parse is supposed to be one of ten,
+  // thus we must take care to convert the exponent/and or the
+  // mantissa to a * 2^E, where a is the mantissa and E is the
+  // exponent.
+  // To get the final double we will use ldexp, it requires the
+  // exponent to be in base 2.
+  int exponent = 0;
+
+  // NOTE: THESE MUST BE DECLARED HERE SINCE WE ARE NOT ALLOWED
+  // TO JUMP OVER DEFINITIONS.
+  char sign = '+';
+  char exp_sign = '+';
+  char const *curr = s;
+
+  // How many characters were read in a loop.
+  int read = 0;
+  // Tells whether a loop terminated due to reaching s_end.
+  bool end_not_reached = false;
+  bool leading_decimal_dots = false;
+
+  /*
+          BEGIN PARSING.
+  */
+
+  // Find out what sign we've got.
+  if (*curr == '+' || *curr == '-') {
+    sign = *curr;
+    curr++;
+    if ((curr != s_end) && (*curr == '.')) {
+      // accept. Somethig like `.7e+2`, `-.5234`
+      leading_decimal_dots = true;
+    }
+  } else if (IS_DIGIT(*curr)) { /* Pass through. */
+  } else if (*curr == '.') {
+    // accept. Somethig like `.7e+2`, `-.5234`
+    leading_decimal_dots = true;
+  } else {
+    goto fail;
+  }
+
+  // Read the integer part.
+  end_not_reached = (curr != s_end);
+  if (!leading_decimal_dots) {
+    while (end_not_reached && IS_DIGIT(*curr)) {
+      mantissa *= 10;
+      mantissa += static_cast<int>(*curr - 0x30);
+      curr++;
+      read++;
+      end_not_reached = (curr != s_end);
+    }
+
+    // We must make sure we actually got something.
+    if (read == 0) goto fail;
+  }
+
+  // We allow numbers of form "#", "###" etc.
+  if (!end_not_reached) goto assemble;
+
+  // Read the decimal part.
+  if (*curr == '.') {
+    curr++;
+    read = 1;
+    end_not_reached = (curr != s_end);
+    while (end_not_reached && IS_DIGIT(*curr)) {
+      static const double pow_lut[] = {
+          1.0, 0.1, 0.01, 0.001, 0.0001, 0.00001, 0.000001, 0.0000001,
+      };
+      const int lut_entries = sizeof pow_lut / sizeof pow_lut[0];
+
+      // NOTE: Don't use powf here, it will absolutely murder precision.
+      mantissa += static_cast<int>(*curr - 0x30) *
+                  (read < lut_entries ? pow_lut[read] : std::pow(10.0, -read));
+      read++;
+      curr++;
+      end_not_reached = (curr != s_end);
+    }
+  } else if (*curr == 'e' || *curr == 'E') {
+  } else {
+    goto assemble;
+  }
+
+  if (!end_not_reached) goto assemble;
+
+  // Read the exponent part.
+  if (*curr == 'e' || *curr == 'E') {
+    curr++;
+    // Figure out if a sign is present and if it is.
+    end_not_reached = (curr != s_end);
+    if (end_not_reached && (*curr == '+' || *curr == '-')) {
+      exp_sign = *curr;
+      curr++;
+    } else if (IS_DIGIT(*curr)) { /* Pass through. */
+    } else {
+      // Empty E is not allowed.
+      goto fail;
+    }
+
+    read = 0;
+    end_not_reached = (curr != s_end);
+    while (end_not_reached && IS_DIGIT(*curr)) {
+      // To avoid annoying MSVC's min/max macro definiton,
+      // Use hardcoded int max value
+      if (exponent >
+          (2147483647 / 10)) {  // 2147483647 = std::numeric_limits<int>::max()
+        // Integer overflow
+        goto fail;
+      }
+      exponent *= 10;
+      exponent += static_cast<int>(*curr - 0x30);
+      curr++;
+      read++;
+      end_not_reached = (curr != s_end);
+    }
+    exponent *= (exp_sign == '+' ? 1 : -1);
+    if (read == 0) goto fail;
+  }
+
+assemble:
+  *result = (sign == '+' ? 1 : -1) *
+            (exponent ? std::ldexp(mantissa * std::pow(5.0, exponent), exponent)
+                      : mantissa);
+  return true;
+fail:
+  return false;
+}
+
+static inline real_t parseReal(const char **token, double default_value = 0.0) {
+  (*token) += strspn((*token), " \t");
+  const char *end = (*token) + strcspn((*token), " \t\r");
+  double val = default_value;
+  tryParseDouble((*token), end, &val);
+  real_t f = static_cast<real_t>(val);
+  (*token) = end;
+  return f;
+}
+
+static inline bool parseReal(const char **token, real_t *out) {
+  (*token) += strspn((*token), " \t");
+  const char *end = (*token) + strcspn((*token), " \t\r");
+  double val;
+  bool ret = tryParseDouble((*token), end, &val);
+  if (ret) {
+    real_t f = static_cast<real_t>(val);
+    (*out) = f;
+  }
+  (*token) = end;
+  return ret;
+}
+
+static inline void parseReal2(real_t *x, real_t *y, const char **token,
+                              const double default_x = 0.0,
+                              const double default_y = 0.0) {
+  (*x) = parseReal(token, default_x);
+  (*y) = parseReal(token, default_y);
+}
+
+static inline void parseReal3(real_t *x, real_t *y, real_t *z,
+                              const char **token, const double default_x = 0.0,
+                              const double default_y = 0.0,
+                              const double default_z = 0.0) {
+  (*x) = parseReal(token, default_x);
+  (*y) = parseReal(token, default_y);
+  (*z) = parseReal(token, default_z);
+}
+
+#if 0  // not used
+static inline void parseV(real_t *x, real_t *y, real_t *z, real_t *w,
+                          const char **token, const double default_x = 0.0,
+                          const double default_y = 0.0,
+                          const double default_z = 0.0,
+                          const double default_w = 1.0) {
+  (*x) = parseReal(token, default_x);
+  (*y) = parseReal(token, default_y);
+  (*z) = parseReal(token, default_z);
+  (*w) = parseReal(token, default_w);
+}
+#endif
+
+// Extension: parse vertex with colors(6 items)
+// Return 3: xyz, 4: xyzw, 6: xyzrgb
+// `r`: red(case 6) or [w](case 4)
+static inline int parseVertexWithColor(real_t *x, real_t *y, real_t *z,
+                                       real_t *r, real_t *g, real_t *b,
+                                       const char **token,
+                                       const double default_x = 0.0,
+                                       const double default_y = 0.0,
+                                       const double default_z = 0.0) {
+  // TODO: Check error
+  (*x) = parseReal(token, default_x);
+  (*y) = parseReal(token, default_y);
+  (*z) = parseReal(token, default_z);
+
+  // - 4 components(x, y, z, w) ot 6 components
+  bool has_r = parseReal(token, r);
+
+  if (!has_r) {
+    (*r) = (*g) = (*b) = 1.0;
+    return 3;
+  }
+
+  bool has_g = parseReal(token, g);
+
+  if (!has_g) {
+    (*g) = (*b) = 1.0;
+    return 4;
+  }
+
+  bool has_b = parseReal(token, b);
+
+  if (!has_b) {
+    (*r) = (*g) = (*b) = 1.0;
+    return 3;  // treated as xyz
+  }
+
+  return 6;
+}
+
+static inline bool parseOnOff(const char **token, bool default_value = true) {
+  (*token) += strspn((*token), " \t");
+  const char *end = (*token) + strcspn((*token), " \t\r");
+
+  bool ret = default_value;
+  if ((0 == strncmp((*token), "on", 2))) {
+    ret = true;
+  } else if ((0 == strncmp((*token), "off", 3))) {
+    ret = false;
+  }
+
+  (*token) = end;
+  return ret;
+}
+
+static inline texture_type_t parseTextureType(
+    const char **token, texture_type_t default_value = TEXTURE_TYPE_NONE) {
+  (*token) += strspn((*token), " \t");
+  const char *end = (*token) + strcspn((*token), " \t\r");
+  texture_type_t ty = default_value;
+
+  if ((0 == strncmp((*token), "cube_top", strlen("cube_top")))) {
+    ty = TEXTURE_TYPE_CUBE_TOP;
+  } else if ((0 == strncmp((*token), "cube_bottom", strlen("cube_bottom")))) {
+    ty = TEXTURE_TYPE_CUBE_BOTTOM;
+  } else if ((0 == strncmp((*token), "cube_left", strlen("cube_left")))) {
+    ty = TEXTURE_TYPE_CUBE_LEFT;
+  } else if ((0 == strncmp((*token), "cube_right", strlen("cube_right")))) {
+    ty = TEXTURE_TYPE_CUBE_RIGHT;
+  } else if ((0 == strncmp((*token), "cube_front", strlen("cube_front")))) {
+    ty = TEXTURE_TYPE_CUBE_FRONT;
+  } else if ((0 == strncmp((*token), "cube_back", strlen("cube_back")))) {
+    ty = TEXTURE_TYPE_CUBE_BACK;
+  } else if ((0 == strncmp((*token), "sphere", strlen("sphere")))) {
+    ty = TEXTURE_TYPE_SPHERE;
+  }
+
+  (*token) = end;
+  return ty;
+}
+
+static tag_sizes parseTagTriple(const char **token) {
+  tag_sizes ts;
+
+  (*token) += strspn((*token), " \t");
+  ts.num_ints = atoi((*token));
+  (*token) += strcspn((*token), "/ \t\r");
+  if ((*token)[0] != '/') {
+    return ts;
+  }
+
+  (*token)++;  // Skip '/'
+
+  (*token) += strspn((*token), " \t");
+  ts.num_reals = atoi((*token));
+  (*token) += strcspn((*token), "/ \t\r");
+  if ((*token)[0] != '/') {
+    return ts;
+  }
+  (*token)++;  // Skip '/'
+
+  ts.num_strings = parseInt(token);
+
+  return ts;
+}
+
+// Parse triples with index offsets: i, i/j/k, i//k, i/j
+static bool parseTriple(const char **token, int vsize, int vnsize, int vtsize,
+                        vertex_index_t *ret, const warning_context &context) {
+  if (!ret) {
+    return false;
+  }
+
+  vertex_index_t vi(-1);
+
+  if (!fixIndex(atoi((*token)), vsize, &vi.v_idx, false, context)) {
+    return false;
+  }
+
+  (*token) += strcspn((*token), "/ \t\r");
+  if ((*token)[0] != '/') {
+    (*ret) = vi;
+    return true;
+  }
+  (*token)++;
+
+  // i//k
+  if ((*token)[0] == '/') {
+    (*token)++;
+    if (!fixIndex(atoi((*token)), vnsize, &vi.vn_idx, true, context)) {
+      return false;
+    }
+    (*token) += strcspn((*token), "/ \t\r");
+    (*ret) = vi;
+    return true;
+  }
+
+  // i/j/k or i/j
+  if (!fixIndex(atoi((*token)), vtsize, &vi.vt_idx, true, context)) {
+    return false;
+  }
+
+  (*token) += strcspn((*token), "/ \t\r");
+  if ((*token)[0] != '/') {
+    (*ret) = vi;
+    return true;
+  }
+
+  // i/j/k
+  (*token)++;  // skip '/'
+  if (!fixIndex(atoi((*token)), vnsize, &vi.vn_idx, true, context)) {
+    return false;
+  }
+  (*token) += strcspn((*token), "/ \t\r");
+
+  (*ret) = vi;
+
+  return true;
+}
+
+// Parse raw triples: i, i/j/k, i//k, i/j
+static vertex_index_t parseRawTriple(const char **token) {
+  vertex_index_t vi(static_cast<int>(0));  // 0 is an invalid index in OBJ
+
+  vi.v_idx = atoi((*token));
+  (*token) += strcspn((*token), "/ \t\r");
+  if ((*token)[0] != '/') {
+    return vi;
+  }
+  (*token)++;
+
+  // i//k
+  if ((*token)[0] == '/') {
+    (*token)++;
+    vi.vn_idx = atoi((*token));
+    (*token) += strcspn((*token), "/ \t\r");
+    return vi;
+  }
+
+  // i/j/k or i/j
+  vi.vt_idx = atoi((*token));
+  (*token) += strcspn((*token), "/ \t\r");
+  if ((*token)[0] != '/') {
+    return vi;
+  }
+
+  // i/j/k
+  (*token)++;  // skip '/'
+  vi.vn_idx = atoi((*token));
+  (*token) += strcspn((*token), "/ \t\r");
+  return vi;
+}
+
+bool ParseTextureNameAndOption(std::string *texname, texture_option_t *texopt,
+                               const char *linebuf) {
+  // @todo { write more robust lexer and parser. }
+  bool found_texname = false;
+  std::string texture_name;
+
+  const char *token = linebuf;  // Assume line ends with NULL
+
+  while (!IS_NEW_LINE((*token))) {
+    token += strspn(token, " \t");  // skip space
+    if ((0 == strncmp(token, "-blendu", 7)) && IS_SPACE((token[7]))) {
+      token += 8;
+      texopt->blendu = parseOnOff(&token, /* default */ true);
+    } else if ((0 == strncmp(token, "-blendv", 7)) && IS_SPACE((token[7]))) {
+      token += 8;
+      texopt->blendv = parseOnOff(&token, /* default */ true);
+    } else if ((0 == strncmp(token, "-clamp", 6)) && IS_SPACE((token[6]))) {
+      token += 7;
+      texopt->clamp = parseOnOff(&token, /* default */ true);
+    } else if ((0 == strncmp(token, "-boost", 6)) && IS_SPACE((token[6]))) {
+      token += 7;
+      texopt->sharpness = parseReal(&token, 1.0);
+    } else if ((0 == strncmp(token, "-bm", 3)) && IS_SPACE((token[3]))) {
+      token += 4;
+      texopt->bump_multiplier = parseReal(&token, 1.0);
+    } else if ((0 == strncmp(token, "-o", 2)) && IS_SPACE((token[2]))) {
+      token += 3;
+      parseReal3(&(texopt->origin_offset[0]), &(texopt->origin_offset[1]),
+                 &(texopt->origin_offset[2]), &token);
+    } else if ((0 == strncmp(token, "-s", 2)) && IS_SPACE((token[2]))) {
+      token += 3;
+      parseReal3(&(texopt->scale[0]), &(texopt->scale[1]), &(texopt->scale[2]),
+                 &token, 1.0, 1.0, 1.0);
+    } else if ((0 == strncmp(token, "-t", 2)) && IS_SPACE((token[2]))) {
+      token += 3;
+      parseReal3(&(texopt->turbulence[0]), &(texopt->turbulence[1]),
+                 &(texopt->turbulence[2]), &token);
+    } else if ((0 == strncmp(token, "-type", 5)) && IS_SPACE((token[5]))) {
+      token += 5;
+      texopt->type = parseTextureType((&token), TEXTURE_TYPE_NONE);
+    } else if ((0 == strncmp(token, "-texres", 7)) && IS_SPACE((token[7]))) {
+      token += 7;
+      // TODO(syoyo): Check if arg is int type.
+      texopt->texture_resolution = parseInt(&token);
+    } else if ((0 == strncmp(token, "-imfchan", 8)) && IS_SPACE((token[8]))) {
+      token += 9;
+      token += strspn(token, " \t");
+      const char *end = token + strcspn(token, " \t\r");
+      if ((end - token) == 1) {  // Assume one char for -imfchan
+        texopt->imfchan = (*token);
+      }
+      token = end;
+    } else if ((0 == strncmp(token, "-mm", 3)) && IS_SPACE((token[3]))) {
+      token += 4;
+      parseReal2(&(texopt->brightness), &(texopt->contrast), &token, 0.0, 1.0);
+    } else if ((0 == strncmp(token, "-colorspace", 11)) &&
+               IS_SPACE((token[11]))) {
+      token += 12;
+      texopt->colorspace = parseString(&token);
+    } else {
+// Assume texture filename
+#if 0
+      size_t len = strcspn(token, " \t\r");  // untile next space
+      texture_name = std::string(token, token + len);
+      token += len;
+
+      token += strspn(token, " \t");  // skip space
+#else
+      // Read filename until line end to parse filename containing whitespace
+      // TODO(syoyo): Support parsing texture option flag after the filename.
+      texture_name = std::string(token);
+      token += texture_name.length();
+#endif
+
+      found_texname = true;
+    }
+  }
+
+  if (found_texname) {
+    (*texname) = texture_name;
+    return true;
+  } else {
+    return false;
+  }
+}
+
+static void InitTexOpt(texture_option_t *texopt, const bool is_bump) {
+  if (is_bump) {
+    texopt->imfchan = 'l';
+  } else {
+    texopt->imfchan = 'm';
+  }
+  texopt->bump_multiplier = static_cast<real_t>(1.0);
+  texopt->clamp = false;
+  texopt->blendu = true;
+  texopt->blendv = true;
+  texopt->sharpness = static_cast<real_t>(1.0);
+  texopt->brightness = static_cast<real_t>(0.0);
+  texopt->contrast = static_cast<real_t>(1.0);
+  texopt->origin_offset[0] = static_cast<real_t>(0.0);
+  texopt->origin_offset[1] = static_cast<real_t>(0.0);
+  texopt->origin_offset[2] = static_cast<real_t>(0.0);
+  texopt->scale[0] = static_cast<real_t>(1.0);
+  texopt->scale[1] = static_cast<real_t>(1.0);
+  texopt->scale[2] = static_cast<real_t>(1.0);
+  texopt->turbulence[0] = static_cast<real_t>(0.0);
+  texopt->turbulence[1] = static_cast<real_t>(0.0);
+  texopt->turbulence[2] = static_cast<real_t>(0.0);
+  texopt->texture_resolution = -1;
+  texopt->type = TEXTURE_TYPE_NONE;
+}
+
+static void InitMaterial(material_t *material) {
+  InitTexOpt(&material->ambient_texopt, /* is_bump */ false);
+  InitTexOpt(&material->diffuse_texopt, /* is_bump */ false);
+  InitTexOpt(&material->specular_texopt, /* is_bump */ false);
+  InitTexOpt(&material->specular_highlight_texopt, /* is_bump */ false);
+  InitTexOpt(&material->bump_texopt, /* is_bump */ true);
+  InitTexOpt(&material->displacement_texopt, /* is_bump */ false);
+  InitTexOpt(&material->alpha_texopt, /* is_bump */ false);
+  InitTexOpt(&material->reflection_texopt, /* is_bump */ false);
+  InitTexOpt(&material->roughness_texopt, /* is_bump */ false);
+  InitTexOpt(&material->metallic_texopt, /* is_bump */ false);
+  InitTexOpt(&material->sheen_texopt, /* is_bump */ false);
+  InitTexOpt(&material->emissive_texopt, /* is_bump */ false);
+  InitTexOpt(&material->normal_texopt,
+             /* is_bump */ false);  // @fixme { is_bump will be true? }
+  material->name = "";
+  material->ambient_texname = "";
+  material->diffuse_texname = "";
+  material->specular_texname = "";
+  material->specular_highlight_texname = "";
+  material->bump_texname = "";
+  material->displacement_texname = "";
+  material->reflection_texname = "";
+  material->alpha_texname = "";
+  for (int i = 0; i < 3; i++) {
+    material->ambient[i] = static_cast<real_t>(0.0);
+    material->diffuse[i] = static_cast<real_t>(0.0);
+    material->specular[i] = static_cast<real_t>(0.0);
+    material->transmittance[i] = static_cast<real_t>(0.0);
+    material->emission[i] = static_cast<real_t>(0.0);
+  }
+  material->illum = 0;
+  material->dissolve = static_cast<real_t>(1.0);
+  material->shininess = static_cast<real_t>(1.0);
+  material->ior = static_cast<real_t>(1.0);
+
+  material->roughness = static_cast<real_t>(0.0);
+  material->metallic = static_cast<real_t>(0.0);
+  material->sheen = static_cast<real_t>(0.0);
+  material->clearcoat_thickness = static_cast<real_t>(0.0);
+  material->clearcoat_roughness = static_cast<real_t>(0.0);
+  material->anisotropy_rotation = static_cast<real_t>(0.0);
+  material->anisotropy = static_cast<real_t>(0.0);
+  material->roughness_texname = "";
+  material->metallic_texname = "";
+  material->sheen_texname = "";
+  material->emissive_texname = "";
+  material->normal_texname = "";
+
+  material->unknown_parameter.clear();
+}
+
+// code from https://wrf.ecse.rpi.edu//Research/Short_Notes/pnpoly.html
+template <typename T>
+static int pnpoly(int nvert, T *vertx, T *verty, T testx, T testy) {
+  int i, j, c = 0;
+  for (i = 0, j = nvert - 1; i < nvert; j = i++) {
+    if (((verty[i] > testy) != (verty[j] > testy)) &&
+        (testx <
+         (vertx[j] - vertx[i]) * (testy - verty[i]) / (verty[j] - verty[i]) +
+             vertx[i]))
+      c = !c;
+  }
+  return c;
+}
+
+struct TinyObjPoint {
+  real_t x, y, z;
+  TinyObjPoint() : x(0), y(0), z(0) {}
+  TinyObjPoint(real_t x_, real_t y_, real_t z_) : x(x_), y(y_), z(z_) {}
+};
+
+inline TinyObjPoint cross(const TinyObjPoint &v1, const TinyObjPoint &v2) {
+  return TinyObjPoint(v1.y * v2.z - v1.z * v2.y, v1.z * v2.x - v1.x * v2.z,
+                      v1.x * v2.y - v1.y * v2.x);
+}
+
+inline real_t dot(const TinyObjPoint &v1, const TinyObjPoint &v2) {
+  return (v1.x * v2.x + v1.y * v2.y + v1.z * v2.z);
+}
+
+inline real_t GetLength(TinyObjPoint &e) {
+  return std::sqrt(e.x * e.x + e.y * e.y + e.z * e.z);
+}
+
+inline TinyObjPoint Normalize(TinyObjPoint e) {
+  real_t inv_length = real_t(1) / GetLength(e);
+  return TinyObjPoint(e.x * inv_length, e.y * inv_length, e.z * inv_length);
+}
+
+inline TinyObjPoint WorldToLocal(const TinyObjPoint &a, const TinyObjPoint &u,
+                                 const TinyObjPoint &v, const TinyObjPoint &w) {
+  return TinyObjPoint(dot(a, u), dot(a, v), dot(a, w));
+}
+
+// TODO(syoyo): refactor function.
+static bool exportGroupsToShape(shape_t *shape, const PrimGroup &prim_group,
+                                const std::vector<tag_t> &tags,
+                                const int material_id, const std::string &name,
+                                bool triangulate, const std::vector<real_t> &v,
+                                std::string *warn) {
+  if (prim_group.IsEmpty()) {
+    return false;
+  }
+
+  shape->name = name;
+
+  // polygon
+  if (!prim_group.faceGroup.empty()) {
+    // Flatten vertices and indices
+    for (size_t i = 0; i < prim_group.faceGroup.size(); i++) {
+      const face_t &face = prim_group.faceGroup[i];
+
+      size_t npolys = face.vertex_indices.size();
+
+      if (npolys < 3) {
+        // Face must have 3+ vertices.
+        if (warn) {
+          (*warn) += "Degenerated face found\n.";
+        }
+        continue;
+      }
+
+      if (triangulate && npolys != 3) {
+        if (npolys == 4) {
+          vertex_index_t i0 = face.vertex_indices[0];
+          vertex_index_t i1 = face.vertex_indices[1];
+          vertex_index_t i2 = face.vertex_indices[2];
+          vertex_index_t i3 = face.vertex_indices[3];
+
+          size_t vi0 = size_t(i0.v_idx);
+          size_t vi1 = size_t(i1.v_idx);
+          size_t vi2 = size_t(i2.v_idx);
+          size_t vi3 = size_t(i3.v_idx);
+
+          if (((3 * vi0 + 2) >= v.size()) || ((3 * vi1 + 2) >= v.size()) ||
+              ((3 * vi2 + 2) >= v.size()) || ((3 * vi3 + 2) >= v.size())) {
+            // Invalid triangle.
+            // FIXME(syoyo): Is it ok to simply skip this invalid triangle?
+            if (warn) {
+              (*warn) += "Face with invalid vertex index found.\n";
+            }
+            continue;
+          }
+
+          real_t v0x = v[vi0 * 3 + 0];
+          real_t v0y = v[vi0 * 3 + 1];
+          real_t v0z = v[vi0 * 3 + 2];
+          real_t v1x = v[vi1 * 3 + 0];
+          real_t v1y = v[vi1 * 3 + 1];
+          real_t v1z = v[vi1 * 3 + 2];
+          real_t v2x = v[vi2 * 3 + 0];
+          real_t v2y = v[vi2 * 3 + 1];
+          real_t v2z = v[vi2 * 3 + 2];
+          real_t v3x = v[vi3 * 3 + 0];
+          real_t v3y = v[vi3 * 3 + 1];
+          real_t v3z = v[vi3 * 3 + 2];
+
+          // There are two candidates to split the quad into two triangles.
+          //
+          // Choose the shortest edge.
+          // TODO: Is it better to determine the edge to split by calculating
+          // the area of each triangle?
+          //
+          // +---+
+          // |\  |
+          // | \ |
+          // |  \|
+          // +---+
+          //
+          // +---+
+          // |  /|
+          // | / |
+          // |/  |
+          // +---+
+
+          real_t e02x = v2x - v0x;
+          real_t e02y = v2y - v0y;
+          real_t e02z = v2z - v0z;
+          real_t e13x = v3x - v1x;
+          real_t e13y = v3y - v1y;
+          real_t e13z = v3z - v1z;
+
+          real_t sqr02 = e02x * e02x + e02y * e02y + e02z * e02z;
+          real_t sqr13 = e13x * e13x + e13y * e13y + e13z * e13z;
+
+          index_t idx0, idx1, idx2, idx3;
+
+          idx0.vertex_index = i0.v_idx;
+          idx0.normal_index = i0.vn_idx;
+          idx0.texcoord_index = i0.vt_idx;
+          idx1.vertex_index = i1.v_idx;
+          idx1.normal_index = i1.vn_idx;
+          idx1.texcoord_index = i1.vt_idx;
+          idx2.vertex_index = i2.v_idx;
+          idx2.normal_index = i2.vn_idx;
+          idx2.texcoord_index = i2.vt_idx;
+          idx3.vertex_index = i3.v_idx;
+          idx3.normal_index = i3.vn_idx;
+          idx3.texcoord_index = i3.vt_idx;
+
+          if (sqr02 < sqr13) {
+            // [0, 1, 2], [0, 2, 3]
+            shape->mesh.indices.push_back(idx0);
+            shape->mesh.indices.push_back(idx1);
+            shape->mesh.indices.push_back(idx2);
+
+            shape->mesh.indices.push_back(idx0);
+            shape->mesh.indices.push_back(idx2);
+            shape->mesh.indices.push_back(idx3);
+          } else {
+            // [0, 1, 3], [1, 2, 3]
+            shape->mesh.indices.push_back(idx0);
+            shape->mesh.indices.push_back(idx1);
+            shape->mesh.indices.push_back(idx3);
+
+            shape->mesh.indices.push_back(idx1);
+            shape->mesh.indices.push_back(idx2);
+            shape->mesh.indices.push_back(idx3);
+          }
+
+          // Two triangle faces
+          shape->mesh.num_face_vertices.push_back(3);
+          shape->mesh.num_face_vertices.push_back(3);
+
+          shape->mesh.material_ids.push_back(material_id);
+          shape->mesh.material_ids.push_back(material_id);
+
+          shape->mesh.smoothing_group_ids.push_back(face.smoothing_group_id);
+          shape->mesh.smoothing_group_ids.push_back(face.smoothing_group_id);
+
+        } else {
+#ifdef TINYOBJLOADER_USE_MAPBOX_EARCUT
+          vertex_index_t i0 = face.vertex_indices[0];
+          vertex_index_t i0_2 = i0;
+
+          // TMW change: Find the normal axis of the polygon using Newell's
+          // method
+          TinyObjPoint n;
+          for (size_t k = 0; k < npolys; ++k) {
+            i0 = face.vertex_indices[k % npolys];
+            size_t vi0 = size_t(i0.v_idx);
+
+            size_t j = (k + 1) % npolys;
+            i0_2 = face.vertex_indices[j];
+            size_t vi0_2 = size_t(i0_2.v_idx);
+
+            real_t v0x = v[vi0 * 3 + 0];
+            real_t v0y = v[vi0 * 3 + 1];
+            real_t v0z = v[vi0 * 3 + 2];
+
+            real_t v0x_2 = v[vi0_2 * 3 + 0];
+            real_t v0y_2 = v[vi0_2 * 3 + 1];
+            real_t v0z_2 = v[vi0_2 * 3 + 2];
+
+            const TinyObjPoint point1(v0x, v0y, v0z);
+            const TinyObjPoint point2(v0x_2, v0y_2, v0z_2);
+
+            TinyObjPoint a(point1.x - point2.x, point1.y - point2.y,
+                           point1.z - point2.z);
+            TinyObjPoint b(point1.x + point2.x, point1.y + point2.y,
+                           point1.z + point2.z);
+
+            n.x += (a.y * b.z);
+            n.y += (a.z * b.x);
+            n.z += (a.x * b.y);
+          }
+          real_t length_n = GetLength(n);
+          // Check if zero length normal
+          if (length_n <= 0) {
+            continue;
+          }
+          // Negative is to flip the normal to the correct direction
+          real_t inv_length = -real_t(1.0) / length_n;
+          n.x *= inv_length;
+          n.y *= inv_length;
+          n.z *= inv_length;
+
+          TinyObjPoint axis_w, axis_v, axis_u;
+          axis_w = n;
+          TinyObjPoint a;
+          if (std::fabs(axis_w.x) > real_t(0.9999999)) {
+            a = TinyObjPoint(0, 1, 0);
+          } else {
+            a = TinyObjPoint(1, 0, 0);
+          }
+          axis_v = Normalize(cross(axis_w, a));
+          axis_u = cross(axis_w, axis_v);
+          using Point = std::array<real_t, 2>;
+
+          // first polyline define the main polygon.
+          // following polylines define holes(not used in tinyobj).
+          std::vector<std::vector<Point> > polygon;
+
+          std::vector<Point> polyline;
+
+          // TMW change: Find best normal and project v0x and v0y to those
+          // coordinates, instead of picking a plane aligned with an axis (which
+          // can flip polygons).
+
+          // Fill polygon data(facevarying vertices).
+          for (size_t k = 0; k < npolys; k++) {
+            i0 = face.vertex_indices[k];
+            size_t vi0 = size_t(i0.v_idx);
+
+            assert(((3 * vi0 + 2) < v.size()));
+
+            real_t v0x = v[vi0 * 3 + 0];
+            real_t v0y = v[vi0 * 3 + 1];
+            real_t v0z = v[vi0 * 3 + 2];
+
+            TinyObjPoint polypoint(v0x, v0y, v0z);
+            TinyObjPoint loc = WorldToLocal(polypoint, axis_u, axis_v, axis_w);
+
+            polyline.push_back({loc.x, loc.y});
+          }
+
+          polygon.push_back(polyline);
+          std::vector<uint32_t> indices = mapbox::earcut<uint32_t>(polygon);
+          // => result = 3 * faces, clockwise
+
+          assert(indices.size() % 3 == 0);
+
+          // Reconstruct vertex_index_t
+          for (size_t k = 0; k < indices.size() / 3; k++) {
+            {
+              index_t idx0, idx1, idx2;
+              idx0.vertex_index = face.vertex_indices[indices[3 * k + 0]].v_idx;
+              idx0.normal_index =
+                  face.vertex_indices[indices[3 * k + 0]].vn_idx;
+              idx0.texcoord_index =
+                  face.vertex_indices[indices[3 * k + 0]].vt_idx;
+              idx1.vertex_index = face.vertex_indices[indices[3 * k + 1]].v_idx;
+              idx1.normal_index =
+                  face.vertex_indices[indices[3 * k + 1]].vn_idx;
+              idx1.texcoord_index =
+                  face.vertex_indices[indices[3 * k + 1]].vt_idx;
+              idx2.vertex_index = face.vertex_indices[indices[3 * k + 2]].v_idx;
+              idx2.normal_index =
+                  face.vertex_indices[indices[3 * k + 2]].vn_idx;
+              idx2.texcoord_index =
+                  face.vertex_indices[indices[3 * k + 2]].vt_idx;
+
+              shape->mesh.indices.push_back(idx0);
+              shape->mesh.indices.push_back(idx1);
+              shape->mesh.indices.push_back(idx2);
+
+              shape->mesh.num_face_vertices.push_back(3);
+              shape->mesh.material_ids.push_back(material_id);
+              shape->mesh.smoothing_group_ids.push_back(
+                  face.smoothing_group_id);
+            }
+          }
+
+#else  // Built-in ear clipping triangulation
+          vertex_index_t i0 = face.vertex_indices[0];
+          vertex_index_t i1(-1);
+          vertex_index_t i2 = face.vertex_indices[1];
+
+          // find the two axes to work in
+          size_t axes[2] = {1, 2};
+          for (size_t k = 0; k < npolys; ++k) {
+            i0 = face.vertex_indices[(k + 0) % npolys];
+            i1 = face.vertex_indices[(k + 1) % npolys];
+            i2 = face.vertex_indices[(k + 2) % npolys];
+            size_t vi0 = size_t(i0.v_idx);
+            size_t vi1 = size_t(i1.v_idx);
+            size_t vi2 = size_t(i2.v_idx);
+
+            if (((3 * vi0 + 2) >= v.size()) || ((3 * vi1 + 2) >= v.size()) ||
+                ((3 * vi2 + 2) >= v.size())) {
+              // Invalid triangle.
+              // FIXME(syoyo): Is it ok to simply skip this invalid triangle?
+              continue;
+            }
+            real_t v0x = v[vi0 * 3 + 0];
+            real_t v0y = v[vi0 * 3 + 1];
+            real_t v0z = v[vi0 * 3 + 2];
+            real_t v1x = v[vi1 * 3 + 0];
+            real_t v1y = v[vi1 * 3 + 1];
+            real_t v1z = v[vi1 * 3 + 2];
+            real_t v2x = v[vi2 * 3 + 0];
+            real_t v2y = v[vi2 * 3 + 1];
+            real_t v2z = v[vi2 * 3 + 2];
+            real_t e0x = v1x - v0x;
+            real_t e0y = v1y - v0y;
+            real_t e0z = v1z - v0z;
+            real_t e1x = v2x - v1x;
+            real_t e1y = v2y - v1y;
+            real_t e1z = v2z - v1z;
+            real_t cx = std::fabs(e0y * e1z - e0z * e1y);
+            real_t cy = std::fabs(e0z * e1x - e0x * e1z);
+            real_t cz = std::fabs(e0x * e1y - e0y * e1x);
+            const real_t epsilon = std::numeric_limits<real_t>::epsilon();
+            // std::cout << "cx " << cx << ", cy " << cy << ", cz " << cz <<
+            // "\n";
+            if (cx > epsilon || cy > epsilon || cz > epsilon) {
+              // std::cout << "corner\n";
+              // found a corner
+              if (cx > cy && cx > cz) {
+                // std::cout << "pattern0\n";
+              } else {
+                // std::cout << "axes[0] = 0\n";
+                axes[0] = 0;
+                if (cz > cx && cz > cy) {
+                  // std::cout << "axes[1] = 1\n";
+                  axes[1] = 1;
+                }
+              }
+              break;
+            }
+          }
+
+          face_t remainingFace = face;  // copy
+          size_t guess_vert = 0;
+          vertex_index_t ind[3];
+          real_t vx[3];
+          real_t vy[3];
+
+          // How many iterations can we do without decreasing the remaining
+          // vertices.
+          size_t remainingIterations = face.vertex_indices.size();
+          size_t previousRemainingVertices =
+              remainingFace.vertex_indices.size();
+
+          while (remainingFace.vertex_indices.size() > 3 &&
+                 remainingIterations > 0) {
+            // std::cout << "remainingIterations " << remainingIterations <<
+            // "\n";
+
+            npolys = remainingFace.vertex_indices.size();
+            if (guess_vert >= npolys) {
+              guess_vert -= npolys;
+            }
+
+            if (previousRemainingVertices != npolys) {
+              // The number of remaining vertices decreased. Reset counters.
+              previousRemainingVertices = npolys;
+              remainingIterations = npolys;
+            } else {
+              // We didn't consume a vertex on previous iteration, reduce the
+              // available iterations.
+              remainingIterations--;
+            }
+
+            for (size_t k = 0; k < 3; k++) {
+              ind[k] = remainingFace.vertex_indices[(guess_vert + k) % npolys];
+              size_t vi = size_t(ind[k].v_idx);
+              if (((vi * 3 + axes[0]) >= v.size()) ||
+                  ((vi * 3 + axes[1]) >= v.size())) {
+                // ???
+                vx[k] = static_cast<real_t>(0.0);
+                vy[k] = static_cast<real_t>(0.0);
+              } else {
+                vx[k] = v[vi * 3 + axes[0]];
+                vy[k] = v[vi * 3 + axes[1]];
+              }
+            }
+
+            //
+            // area is calculated per face
+            //
+            real_t e0x = vx[1] - vx[0];
+            real_t e0y = vy[1] - vy[0];
+            real_t e1x = vx[2] - vx[1];
+            real_t e1y = vy[2] - vy[1];
+            real_t cross = e0x * e1y - e0y * e1x;
+            // std::cout << "axes = " << axes[0] << ", " << axes[1] << "\n";
+            // std::cout << "e0x, e0y, e1x, e1y " << e0x << ", " << e0y << ", "
+            // << e1x << ", " << e1y << "\n";
+
+            real_t area =
+                (vx[0] * vy[1] - vy[0] * vx[1]) * static_cast<real_t>(0.5);
+            // std::cout << "cross " << cross << ", area " << area << "\n";
+            // if an internal angle
+            if (cross * area < static_cast<real_t>(0.0)) {
+              // std::cout << "internal \n";
+              guess_vert += 1;
+              // std::cout << "guess vert : " << guess_vert << "\n";
+              continue;
+            }
+
+            // check all other verts in case they are inside this triangle
+            bool overlap = false;
+            for (size_t otherVert = 3; otherVert < npolys; ++otherVert) {
+              size_t idx = (guess_vert + otherVert) % npolys;
+
+              if (idx >= remainingFace.vertex_indices.size()) {
+                // std::cout << "???0\n";
+                // ???
+                continue;
+              }
+
+              size_t ovi = size_t(remainingFace.vertex_indices[idx].v_idx);
+
+              if (((ovi * 3 + axes[0]) >= v.size()) ||
+                  ((ovi * 3 + axes[1]) >= v.size())) {
+                // std::cout << "???1\n";
+                // ???
+                continue;
+              }
+              real_t tx = v[ovi * 3 + axes[0]];
+              real_t ty = v[ovi * 3 + axes[1]];
+              if (pnpoly(3, vx, vy, tx, ty)) {
+                // std::cout << "overlap\n";
+                overlap = true;
+                break;
+              }
+            }
+
+            if (overlap) {
+              // std::cout << "overlap2\n";
+              guess_vert += 1;
+              continue;
+            }
+
+            // this triangle is an ear
+            {
+              index_t idx0, idx1, idx2;
+              idx0.vertex_index = ind[0].v_idx;
+              idx0.normal_index = ind[0].vn_idx;
+              idx0.texcoord_index = ind[0].vt_idx;
+              idx1.vertex_index = ind[1].v_idx;
+              idx1.normal_index = ind[1].vn_idx;
+              idx1.texcoord_index = ind[1].vt_idx;
+              idx2.vertex_index = ind[2].v_idx;
+              idx2.normal_index = ind[2].vn_idx;
+              idx2.texcoord_index = ind[2].vt_idx;
+
+              shape->mesh.indices.push_back(idx0);
+              shape->mesh.indices.push_back(idx1);
+              shape->mesh.indices.push_back(idx2);
+
+              shape->mesh.num_face_vertices.push_back(3);
+              shape->mesh.material_ids.push_back(material_id);
+              shape->mesh.smoothing_group_ids.push_back(
+                  face.smoothing_group_id);
+            }
+
+            // remove v1 from the list
+            size_t removed_vert_index = (guess_vert + 1) % npolys;
+            while (removed_vert_index + 1 < npolys) {
+              remainingFace.vertex_indices[removed_vert_index] =
+                  remainingFace.vertex_indices[removed_vert_index + 1];
+              removed_vert_index += 1;
+            }
+            remainingFace.vertex_indices.pop_back();
+          }
+
+          // std::cout << "remainingFace.vi.size = " <<
+          // remainingFace.vertex_indices.size() << "\n";
+          if (remainingFace.vertex_indices.size() == 3) {
+            i0 = remainingFace.vertex_indices[0];
+            i1 = remainingFace.vertex_indices[1];
+            i2 = remainingFace.vertex_indices[2];
+            {
+              index_t idx0, idx1, idx2;
+              idx0.vertex_index = i0.v_idx;
+              idx0.normal_index = i0.vn_idx;
+              idx0.texcoord_index = i0.vt_idx;
+              idx1.vertex_index = i1.v_idx;
+              idx1.normal_index = i1.vn_idx;
+              idx1.texcoord_index = i1.vt_idx;
+              idx2.vertex_index = i2.v_idx;
+              idx2.normal_index = i2.vn_idx;
+              idx2.texcoord_index = i2.vt_idx;
+
+              shape->mesh.indices.push_back(idx0);
+              shape->mesh.indices.push_back(idx1);
+              shape->mesh.indices.push_back(idx2);
+
+              shape->mesh.num_face_vertices.push_back(3);
+              shape->mesh.material_ids.push_back(material_id);
+              shape->mesh.smoothing_group_ids.push_back(
+                  face.smoothing_group_id);
+            }
+          }
+#endif
+        }  // npolys
+      } else {
+        for (size_t k = 0; k < npolys; k++) {
+          index_t idx;
+          idx.vertex_index = face.vertex_indices[k].v_idx;
+          idx.normal_index = face.vertex_indices[k].vn_idx;
+          idx.texcoord_index = face.vertex_indices[k].vt_idx;
+          shape->mesh.indices.push_back(idx);
+        }
+
+        shape->mesh.num_face_vertices.push_back(
+            static_cast<unsigned int>(npolys));
+        shape->mesh.material_ids.push_back(material_id);  // per face
+        shape->mesh.smoothing_group_ids.push_back(
+            face.smoothing_group_id);  // per face
+      }
+    }
+
+    shape->mesh.tags = tags;
+  }
+
+  // line
+  if (!prim_group.lineGroup.empty()) {
+    // Flatten indices
+    for (size_t i = 0; i < prim_group.lineGroup.size(); i++) {
+      for (size_t j = 0; j < prim_group.lineGroup[i].vertex_indices.size();
+           j++) {
+        const vertex_index_t &vi = prim_group.lineGroup[i].vertex_indices[j];
+
+        index_t idx;
+        idx.vertex_index = vi.v_idx;
+        idx.normal_index = vi.vn_idx;
+        idx.texcoord_index = vi.vt_idx;
+
+        shape->lines.indices.push_back(idx);
+      }
+
+      shape->lines.num_line_vertices.push_back(
+          int(prim_group.lineGroup[i].vertex_indices.size()));
+    }
+  }
+
+  // points
+  if (!prim_group.pointsGroup.empty()) {
+    // Flatten & convert indices
+    for (size_t i = 0; i < prim_group.pointsGroup.size(); i++) {
+      for (size_t j = 0; j < prim_group.pointsGroup[i].vertex_indices.size();
+           j++) {
+        const vertex_index_t &vi = prim_group.pointsGroup[i].vertex_indices[j];
+
+        index_t idx;
+        idx.vertex_index = vi.v_idx;
+        idx.normal_index = vi.vn_idx;
+        idx.texcoord_index = vi.vt_idx;
+
+        shape->points.indices.push_back(idx);
+      }
+    }
+  }
+
+  return true;
+}
+
+// Split a string with specified delimiter character and escape character.
+// https://rosettacode.org/wiki/Tokenize_a_string_with_escaping#C.2B.2B
+static void SplitString(const std::string &s, char delim, char escape,
+                        std::vector<std::string> &elems) {
+  std::string token;
+
+  bool escaping = false;
+  for (size_t i = 0; i < s.size(); ++i) {
+    char ch = s[i];
+    if (escaping) {
+      escaping = false;
+    } else if (ch == escape) {
+      escaping = true;
+      continue;
+    } else if (ch == delim) {
+      if (!token.empty()) {
+        elems.push_back(token);
+      }
+      token.clear();
+      continue;
+    }
+    token += ch;
+  }
+
+  elems.push_back(token);
+}
+
+static std::string JoinPath(const std::string &dir,
+                            const std::string &filename) {
+  if (dir.empty()) {
+    return filename;
+  } else {
+    // check '/'
+    char lastChar = *dir.rbegin();
+    if (lastChar != '/') {
+      return dir + std::string("/") + filename;
+    } else {
+      return dir + filename;
+    }
+  }
+}
+
+void LoadMtl(std::map<std::string, int> *material_map,
+             std::vector<material_t> *materials, std::istream *inStream,
+             std::string *warning, std::string *err) {
+  (void)err;
+
+  // Create a default material anyway.
+  material_t material;
+  InitMaterial(&material);
+
+  // Issue 43. `d` wins against `Tr` since `Tr` is not in the MTL specification.
+  bool has_d = false;
+  bool has_tr = false;
+
+  // has_kd is used to set a default diffuse value when map_Kd is present
+  // and Kd is not.
+  bool has_kd = false;
+
+  std::stringstream warn_ss;
+
+  size_t line_no = 0;
+  std::string linebuf;
+  while (inStream->peek() != -1) {
+    safeGetline(*inStream, linebuf);
+    line_no++;
+
+    // Trim trailing whitespace.
+    if (linebuf.size() > 0) {
+      linebuf = linebuf.substr(0, linebuf.find_last_not_of(" \t") + 1);
+    }
+
+    // Trim newline '\r\n' or '\n'
+    if (linebuf.size() > 0) {
+      if (linebuf[linebuf.size() - 1] == '\n')
+        linebuf.erase(linebuf.size() - 1);
+    }
+    if (linebuf.size() > 0) {
+      if (linebuf[linebuf.size() - 1] == '\r')
+        linebuf.erase(linebuf.size() - 1);
+    }
+
+    // Skip if empty line.
+    if (linebuf.empty()) {
+      continue;
+    }
+
+    // Skip leading space.
+    const char *token = linebuf.c_str();
+    token += strspn(token, " \t");
+
+    assert(token);
+    if (token[0] == '\0') continue;  // empty line
+
+    if (token[0] == '#') continue;  // comment line
+
+    // new mtl
+    if ((0 == strncmp(token, "newmtl", 6)) && IS_SPACE((token[6]))) {
+      // flush previous material.
+      if (!material.name.empty()) {
+        material_map->insert(std::pair<std::string, int>(
+            material.name, static_cast<int>(materials->size())));
+        materials->push_back(material);
+      }
+
+      // initial temporary material
+      InitMaterial(&material);
+
+      has_d = false;
+      has_tr = false;
+
+      // set new mtl name
+      token += 7;
+      {
+        std::string namebuf = parseString(&token);
+        // TODO: empty name check?
+        if (namebuf.empty()) {
+          if (warning) {
+            (*warning) += "empty material name in `newmtl`\n";
+          }
+        }
+        material.name = namebuf;
+      }
+      continue;
+    }
+
+    // ambient
+    if (token[0] == 'K' && token[1] == 'a' && IS_SPACE((token[2]))) {
+      token += 2;
+      real_t r, g, b;
+      parseReal3(&r, &g, &b, &token);
+      material.ambient[0] = r;
+      material.ambient[1] = g;
+      material.ambient[2] = b;
+      continue;
+    }
+
+    // diffuse
+    if (token[0] == 'K' && token[1] == 'd' && IS_SPACE((token[2]))) {
+      token += 2;
+      real_t r, g, b;
+      parseReal3(&r, &g, &b, &token);
+      material.diffuse[0] = r;
+      material.diffuse[1] = g;
+      material.diffuse[2] = b;
+      has_kd = true;
+      continue;
+    }
+
+    // specular
+    if (token[0] == 'K' && token[1] == 's' && IS_SPACE((token[2]))) {
+      token += 2;
+      real_t r, g, b;
+      parseReal3(&r, &g, &b, &token);
+      material.specular[0] = r;
+      material.specular[1] = g;
+      material.specular[2] = b;
+      continue;
+    }
+
+    // transmittance
+    if ((token[0] == 'K' && token[1] == 't' && IS_SPACE((token[2]))) ||
+        (token[0] == 'T' && token[1] == 'f' && IS_SPACE((token[2])))) {
+      token += 2;
+      real_t r, g, b;
+      parseReal3(&r, &g, &b, &token);
+      material.transmittance[0] = r;
+      material.transmittance[1] = g;
+      material.transmittance[2] = b;
+      continue;
+    }
+
+    // ior(index of refraction)
+    if (token[0] == 'N' && token[1] == 'i' && IS_SPACE((token[2]))) {
+      token += 2;
+      material.ior = parseReal(&token);
+      continue;
+    }
+
+    // emission
+    if (token[0] == 'K' && token[1] == 'e' && IS_SPACE(token[2])) {
+      token += 2;
+      real_t r, g, b;
+      parseReal3(&r, &g, &b, &token);
+      material.emission[0] = r;
+      material.emission[1] = g;
+      material.emission[2] = b;
+      continue;
+    }
+
+    // shininess
+    if (token[0] == 'N' && token[1] == 's' && IS_SPACE(token[2])) {
+      token += 2;
+      material.shininess = parseReal(&token);
+      continue;
+    }
+
+    // illum model
+    if (0 == strncmp(token, "illum", 5) && IS_SPACE(token[5])) {
+      token += 6;
+      material.illum = parseInt(&token);
+      continue;
+    }
+
+    // dissolve
+    if ((token[0] == 'd' && IS_SPACE(token[1]))) {
+      token += 1;
+      material.dissolve = parseReal(&token);
+
+      if (has_tr) {
+        warn_ss << "Both `d` and `Tr` parameters defined for \""
+                << material.name
+                << "\". Use the value of `d` for dissolve (line " << line_no
+                << " in .mtl.)\n";
+      }
+      has_d = true;
+      continue;
+    }
+    if (token[0] == 'T' && token[1] == 'r' && IS_SPACE(token[2])) {
+      token += 2;
+      if (has_d) {
+        // `d` wins. Ignore `Tr` value.
+        warn_ss << "Both `d` and `Tr` parameters defined for \""
+                << material.name
+                << "\". Use the value of `d` for dissolve (line " << line_no
+                << " in .mtl.)\n";
+      } else {
+        // We invert value of Tr(assume Tr is in range [0, 1])
+        // NOTE: Interpretation of Tr is application(exporter) dependent. For
+        // some application(e.g. 3ds max obj exporter), Tr = d(Issue 43)
+        material.dissolve = static_cast<real_t>(1.0) - parseReal(&token);
+      }
+      has_tr = true;
+      continue;
+    }
+
+    // PBR: roughness
+    if (token[0] == 'P' && token[1] == 'r' && IS_SPACE(token[2])) {
+      token += 2;
+      material.roughness = parseReal(&token);
+      continue;
+    }
+
+    // PBR: metallic
+    if (token[0] == 'P' && token[1] == 'm' && IS_SPACE(token[2])) {
+      token += 2;
+      material.metallic = parseReal(&token);
+      continue;
+    }
+
+    // PBR: sheen
+    if (token[0] == 'P' && token[1] == 's' && IS_SPACE(token[2])) {
+      token += 2;
+      material.sheen = parseReal(&token);
+      continue;
+    }
+
+    // PBR: clearcoat thickness
+    if (token[0] == 'P' && token[1] == 'c' && IS_SPACE(token[2])) {
+      token += 2;
+      material.clearcoat_thickness = parseReal(&token);
+      continue;
+    }
+
+    // PBR: clearcoat roughness
+    if ((0 == strncmp(token, "Pcr", 3)) && IS_SPACE(token[3])) {
+      token += 4;
+      material.clearcoat_roughness = parseReal(&token);
+      continue;
+    }
+
+    // PBR: anisotropy
+    if ((0 == strncmp(token, "aniso", 5)) && IS_SPACE(token[5])) {
+      token += 6;
+      material.anisotropy = parseReal(&token);
+      continue;
+    }
+
+    // PBR: anisotropy rotation
+    if ((0 == strncmp(token, "anisor", 6)) && IS_SPACE(token[6])) {
+      token += 7;
+      material.anisotropy_rotation = parseReal(&token);
+      continue;
+    }
+
+    // ambient or ambient occlusion texture
+    if ((0 == strncmp(token, "map_Ka", 6)) && IS_SPACE(token[6])) {
+      token += 7;
+      ParseTextureNameAndOption(&(material.ambient_texname),
+                                &(material.ambient_texopt), token);
+      continue;
+    }
+
+    // diffuse texture
+    if ((0 == strncmp(token, "map_Kd", 6)) && IS_SPACE(token[6])) {
+      token += 7;
+      ParseTextureNameAndOption(&(material.diffuse_texname),
+                                &(material.diffuse_texopt), token);
+
+      // Set a decent diffuse default value if a diffuse texture is specified
+      // without a matching Kd value.
+      if (!has_kd) {
+        material.diffuse[0] = static_cast<real_t>(0.6);
+        material.diffuse[1] = static_cast<real_t>(0.6);
+        material.diffuse[2] = static_cast<real_t>(0.6);
+      }
+
+      continue;
+    }
+
+    // specular texture
+    if ((0 == strncmp(token, "map_Ks", 6)) && IS_SPACE(token[6])) {
+      token += 7;
+      ParseTextureNameAndOption(&(material.specular_texname),
+                                &(material.specular_texopt), token);
+      continue;
+    }
+
+    // specular highlight texture
+    if ((0 == strncmp(token, "map_Ns", 6)) && IS_SPACE(token[6])) {
+      token += 7;
+      ParseTextureNameAndOption(&(material.specular_highlight_texname),
+                                &(material.specular_highlight_texopt), token);
+      continue;
+    }
+
+    // bump texture
+    if (((0 == strncmp(token, "map_bump", 8)) ||
+         (0 == strncmp(token, "map_Bump", 8))) &&
+        IS_SPACE(token[8])) {
+      token += 9;
+      ParseTextureNameAndOption(&(material.bump_texname),
+                                &(material.bump_texopt), token);
+      continue;
+    }
+
+    // bump texture
+    if ((0 == strncmp(token, "bump", 4)) && IS_SPACE(token[4])) {
+      token += 5;
+      ParseTextureNameAndOption(&(material.bump_texname),
+                                &(material.bump_texopt), token);
+      continue;
+    }
+
+    // alpha texture
+    if ((0 == strncmp(token, "map_d", 5)) && IS_SPACE(token[5])) {
+      token += 6;
+      material.alpha_texname = token;
+      ParseTextureNameAndOption(&(material.alpha_texname),
+                                &(material.alpha_texopt), token);
+      continue;
+    }
+
+    // displacement texture
+    if (((0 == strncmp(token, "map_disp", 8)) ||
+         (0 == strncmp(token, "map_Disp", 8))) &&
+        IS_SPACE(token[8])) {
+      token += 9;
+      ParseTextureNameAndOption(&(material.displacement_texname),
+                                &(material.displacement_texopt), token);
+      continue;
+    }
+
+    // displacement texture
+    if ((0 == strncmp(token, "disp", 4)) && IS_SPACE(token[4])) {
+      token += 5;
+      ParseTextureNameAndOption(&(material.displacement_texname),
+                                &(material.displacement_texopt), token);
+      continue;
+    }
+
+    // reflection map
+    if ((0 == strncmp(token, "refl", 4)) && IS_SPACE(token[4])) {
+      token += 5;
+      ParseTextureNameAndOption(&(material.reflection_texname),
+                                &(material.reflection_texopt), token);
+      continue;
+    }
+
+    // PBR: roughness texture
+    if ((0 == strncmp(token, "map_Pr", 6)) && IS_SPACE(token[6])) {
+      token += 7;
+      ParseTextureNameAndOption(&(material.roughness_texname),
+                                &(material.roughness_texopt), token);
+      continue;
+    }
+
+    // PBR: metallic texture
+    if ((0 == strncmp(token, "map_Pm", 6)) && IS_SPACE(token[6])) {
+      token += 7;
+      ParseTextureNameAndOption(&(material.metallic_texname),
+                                &(material.metallic_texopt), token);
+      continue;
+    }
+
+    // PBR: sheen texture
+    if ((0 == strncmp(token, "map_Ps", 6)) && IS_SPACE(token[6])) {
+      token += 7;
+      ParseTextureNameAndOption(&(material.sheen_texname),
+                                &(material.sheen_texopt), token);
+      continue;
+    }
+
+    // PBR: emissive texture
+    if ((0 == strncmp(token, "map_Ke", 6)) && IS_SPACE(token[6])) {
+      token += 7;
+      ParseTextureNameAndOption(&(material.emissive_texname),
+                                &(material.emissive_texopt), token);
+      continue;
+    }
+
+    // PBR: normal map texture
+    if ((0 == strncmp(token, "norm", 4)) && IS_SPACE(token[4])) {
+      token += 5;
+      ParseTextureNameAndOption(&(material.normal_texname),
+                                &(material.normal_texopt), token);
+      continue;
+    }
+
+    // unknown parameter
+    const char *_space = strchr(token, ' ');
+    if (!_space) {
+      _space = strchr(token, '\t');
+    }
+    if (_space) {
+      std::ptrdiff_t len = _space - token;
+      std::string key(token, static_cast<size_t>(len));
+      std::string value = _space + 1;
+      material.unknown_parameter.insert(
+          std::pair<std::string, std::string>(key, value));
+    }
+  }
+  // flush last material.
+  material_map->insert(std::pair<std::string, int>(
+      material.name, static_cast<int>(materials->size())));
+  materials->push_back(material);
+
+  if (warning) {
+    (*warning) = warn_ss.str();
+  }
+}
+
+bool MaterialFileReader::operator()(const std::string &matId,
+                                    std::vector<material_t> *materials,
+                                    std::map<std::string, int> *matMap,
+                                    std::string *warn, std::string *err) {
+  if (!m_mtlBaseDir.empty()) {
+#ifdef _WIN32
+    char sep = ';';
+#else
+    char sep = ':';
+#endif
+
+    // https://stackoverflow.com/questions/5167625/splitting-a-c-stdstring-using-tokens-e-g
+    std::vector<std::string> paths;
+    std::istringstream f(m_mtlBaseDir);
+
+    std::string s;
+    while (getline(f, s, sep)) {
+      paths.push_back(s);
+    }
+
+    for (size_t i = 0; i < paths.size(); i++) {
+      std::string filepath = JoinPath(paths[i], matId);
+
+      std::ifstream matIStream(filepath.c_str());
+      if (matIStream) {
+        LoadMtl(matMap, materials, &matIStream, warn, err);
+
+        return true;
+      }
+    }
+
+    std::stringstream ss;
+    ss << "Material file [ " << matId
+       << " ] not found in a path : " << m_mtlBaseDir << "\n";
+    if (warn) {
+      (*warn) += ss.str();
+    }
+    return false;
+
+  } else {
+    std::string filepath = matId;
+    std::ifstream matIStream(filepath.c_str());
+    if (matIStream) {
+      LoadMtl(matMap, materials, &matIStream, warn, err);
+
+      return true;
+    }
+
+    std::stringstream ss;
+    ss << "Material file [ " << filepath
+       << " ] not found in a path : " << m_mtlBaseDir << "\n";
+    if (warn) {
+      (*warn) += ss.str();
+    }
+
+    return false;
+  }
+}
+
+bool MaterialStreamReader::operator()(const std::string &matId,
+                                      std::vector<material_t> *materials,
+                                      std::map<std::string, int> *matMap,
+                                      std::string *warn, std::string *err) {
+  (void)err;
+  (void)matId;
+  if (!m_inStream) {
+    std::stringstream ss;
+    ss << "Material stream in error state. \n";
+    if (warn) {
+      (*warn) += ss.str();
+    }
+    return false;
+  }
+
+  LoadMtl(matMap, materials, &m_inStream, warn, err);
+
+  return true;
+}
+
+bool LoadObj(attrib_t *attrib, std::vector<shape_t> *shapes,
+             std::vector<material_t> *materials, std::string *warn,
+             std::string *err, const char *filename, const char *mtl_basedir,
+             bool triangulate, bool default_vcols_fallback) {
+  attrib->vertices.clear();
+  attrib->normals.clear();
+  attrib->texcoords.clear();
+  attrib->colors.clear();
+  shapes->clear();
+
+  std::stringstream errss;
+
+  std::ifstream ifs(filename);
+  if (!ifs) {
+    errss << "Cannot open file [" << filename << "]\n";
+    if (err) {
+      (*err) = errss.str();
+    }
+    return false;
+  }
+
+  std::string baseDir = mtl_basedir ? mtl_basedir : "";
+  if (!baseDir.empty()) {
+#ifndef _WIN32
+    const char dirsep = '/';
+#else
+    const char dirsep = '\\';
+#endif
+    if (baseDir[baseDir.length() - 1] != dirsep) baseDir += dirsep;
+  }
+  MaterialFileReader matFileReader(baseDir);
+
+  return LoadObj(attrib, shapes, materials, warn, err, &ifs, &matFileReader,
+                 triangulate, default_vcols_fallback);
+}
+
+bool LoadObj(attrib_t *attrib, std::vector<shape_t> *shapes,
+             std::vector<material_t> *materials, std::string *warn,
+             std::string *err, std::istream *inStream,
+             MaterialReader *readMatFn /*= NULL*/, bool triangulate,
+             bool default_vcols_fallback) {
+  std::stringstream errss;
+
+  std::vector<real_t> v;
+  std::vector<real_t> vertex_weights;  // optional [w] component in `v`
+  std::vector<real_t> vn;
+  std::vector<real_t> vt;
+  std::vector<real_t> vc;
+  std::vector<skin_weight_t> vw;  // tinyobj extension: vertex skin weights
+  std::vector<tag_t> tags;
+  PrimGroup prim_group;
+  std::string name;
+
+  // material
+  std::set<std::string> material_filenames;
+  std::map<std::string, int> material_map;
+  int material = -1;
+
+  // smoothing group id
+  unsigned int current_smoothing_id =
+      0;  // Initial value. 0 means no smoothing.
+
+  int greatest_v_idx = -1;
+  int greatest_vn_idx = -1;
+  int greatest_vt_idx = -1;
+
+  shape_t shape;
+
+  bool found_all_colors = true;  // check if all 'v' line has color info
+
+  size_t line_num = 0;
+  std::string linebuf;
+  while (inStream->peek() != -1) {
+    safeGetline(*inStream, linebuf);
+
+    line_num++;
+
+    // Trim newline '\r\n' or '\n'
+    if (linebuf.size() > 0) {
+      if (linebuf[linebuf.size() - 1] == '\n')
+        linebuf.erase(linebuf.size() - 1);
+    }
+    if (linebuf.size() > 0) {
+      if (linebuf[linebuf.size() - 1] == '\r')
+        linebuf.erase(linebuf.size() - 1);
+    }
+
+    // Skip if empty line.
+    if (linebuf.empty()) {
+      continue;
+    }
+
+    // Skip leading space.
+    const char *token = linebuf.c_str();
+    token += strspn(token, " \t");
+
+    assert(token);
+    if (token[0] == '\0') continue;  // empty line
+
+    if (token[0] == '#') continue;  // comment line
+
+    // vertex
+    if (token[0] == 'v' && IS_SPACE((token[1]))) {
+      token += 2;
+      real_t x, y, z;
+      real_t r, g, b;
+
+      int num_components = parseVertexWithColor(&x, &y, &z, &r, &g, &b, &token);
+      found_all_colors &= (num_components == 6);
+
+      v.push_back(x);
+      v.push_back(y);
+      v.push_back(z);
+
+      vertex_weights.push_back(
+          r);  // r = w, and initialized to 1.0 when `w` component is not found.
+
+      if ((num_components == 6) || default_vcols_fallback) {
+        vc.push_back(r);
+        vc.push_back(g);
+        vc.push_back(b);
+      }
+
+      continue;
+    }
+
+    // normal
+    if (token[0] == 'v' && token[1] == 'n' && IS_SPACE((token[2]))) {
+      token += 3;
+      real_t x, y, z;
+      parseReal3(&x, &y, &z, &token);
+      vn.push_back(x);
+      vn.push_back(y);
+      vn.push_back(z);
+      continue;
+    }
+
+    // texcoord
+    if (token[0] == 'v' && token[1] == 't' && IS_SPACE((token[2]))) {
+      token += 3;
+      real_t x, y;
+      parseReal2(&x, &y, &token);
+      vt.push_back(x);
+      vt.push_back(y);
+      continue;
+    }
+
+    // skin weight. tinyobj extension
+    if (token[0] == 'v' && token[1] == 'w' && IS_SPACE((token[2]))) {
+      token += 3;
+
+      // vw <vid> <joint_0> <weight_0> <joint_1> <weight_1> ...
+      // example:
+      // vw 0 0 0.25 1 0.25 2 0.5
+
+      // TODO(syoyo): Add syntax check
+      int vid = 0;
+      vid = parseInt(&token);
+
+      skin_weight_t sw;
+
+      sw.vertex_id = vid;
+
+      while (!IS_NEW_LINE(token[0])) {
+        real_t j, w;
+        // joint_id should not be negative, weight may be negative
+        // TODO(syoyo): # of elements check
+        parseReal2(&j, &w, &token, -1.0);
+
+        if (j < static_cast<real_t>(0)) {
+          if (err) {
+            std::stringstream ss;
+            ss << "Failed parse `vw' line. joint_id is negative. "
+                  "line "
+               << line_num << ".)\n";
+            (*err) += ss.str();
+          }
+          return false;
+        }
+
+        joint_and_weight_t jw;
+
+        jw.joint_id = int(j);
+        jw.weight = w;
+
+        sw.weightValues.push_back(jw);
+
+        size_t n = strspn(token, " \t\r");
+        token += n;
+      }
+
+      vw.push_back(sw);
+    }
+
+    warning_context context;
+    context.warn = warn;
+    context.line_number = line_num;
+
+    // line
+    if (token[0] == 'l' && IS_SPACE((token[1]))) {
+      token += 2;
+
+      __line_t line;
+
+      while (!IS_NEW_LINE(token[0])) {
+        vertex_index_t vi;
+        if (!parseTriple(&token, static_cast<int>(v.size() / 3),
+                         static_cast<int>(vn.size() / 3),
+                         static_cast<int>(vt.size() / 2), &vi, context)) {
+          if (err) {
+            (*err) +=
+                "Failed to parse `l' line (e.g. a zero value for vertex index. "
+                "Line " +
+                toString(line_num) + ").\n";
+          }
+          return false;
+        }
+
+        line.vertex_indices.push_back(vi);
+
+        size_t n = strspn(token, " \t\r");
+        token += n;
+      }
+
+      prim_group.lineGroup.push_back(line);
+
+      continue;
+    }
+
+    // points
+    if (token[0] == 'p' && IS_SPACE((token[1]))) {
+      token += 2;
+
+      __points_t pts;
+
+      while (!IS_NEW_LINE(token[0])) {
+        vertex_index_t vi;
+        if (!parseTriple(&token, static_cast<int>(v.size() / 3),
+                         static_cast<int>(vn.size() / 3),
+                         static_cast<int>(vt.size() / 2), &vi, context)) {
+          if (err) {
+            (*err) +=
+                "Failed to parse `p' line (e.g. a zero value for vertex index. "
+                "Line " +
+                toString(line_num) + ").\n";
+          }
+          return false;
+        }
+
+        pts.vertex_indices.push_back(vi);
+
+        size_t n = strspn(token, " \t\r");
+        token += n;
+      }
+
+      prim_group.pointsGroup.push_back(pts);
+
+      continue;
+    }
+
+    // face
+    if (token[0] == 'f' && IS_SPACE((token[1]))) {
+      token += 2;
+      token += strspn(token, " \t");
+
+      face_t face;
+
+      face.smoothing_group_id = current_smoothing_id;
+      face.vertex_indices.reserve(3);
+
+      while (!IS_NEW_LINE(token[0])) {
+        vertex_index_t vi;
+        if (!parseTriple(&token, static_cast<int>(v.size() / 3),
+                         static_cast<int>(vn.size() / 3),
+                         static_cast<int>(vt.size() / 2), &vi, context)) {
+          if (err) {
+            (*err) +=
+                "Failed to parse `f' line (e.g. a zero value for vertex index "
+                "or invalid relative vertex index). Line " +
+                toString(line_num) + ").\n";
+          }
+          return false;
+        }
+
+        greatest_v_idx = greatest_v_idx > vi.v_idx ? greatest_v_idx : vi.v_idx;
+        greatest_vn_idx =
+            greatest_vn_idx > vi.vn_idx ? greatest_vn_idx : vi.vn_idx;
+        greatest_vt_idx =
+            greatest_vt_idx > vi.vt_idx ? greatest_vt_idx : vi.vt_idx;
+
+        face.vertex_indices.push_back(vi);
+        size_t n = strspn(token, " \t\r");
+        token += n;
+      }
+
+      // replace with emplace_back + std::move on C++11
+      prim_group.faceGroup.push_back(face);
+
+      continue;
+    }
+
+    // use mtl
+    if ((0 == strncmp(token, "usemtl", 6))) {
+      token += 6;
+      std::string namebuf = parseString(&token);
+
+      int newMaterialId = -1;
+      std::map<std::string, int>::const_iterator it =
+          material_map.find(namebuf);
+      if (it != material_map.end()) {
+        newMaterialId = it->second;
+      } else {
+        // { error!! material not found }
+        if (warn) {
+          (*warn) += "material [ '" + namebuf + "' ] not found in .mtl\n";
+        }
+      }
+
+      if (newMaterialId != material) {
+        // Create per-face material. Thus we don't add `shape` to `shapes` at
+        // this time.
+        // just clear `faceGroup` after `exportGroupsToShape()` call.
+        exportGroupsToShape(&shape, prim_group, tags, material, name,
+                            triangulate, v, warn);
+        prim_group.faceGroup.clear();
+        material = newMaterialId;
+      }
+
+      continue;
+    }
+
+    // load mtl
+    if ((0 == strncmp(token, "mtllib", 6)) && IS_SPACE((token[6]))) {
+      if (readMatFn) {
+        token += 7;
+
+        std::vector<std::string> filenames;
+        SplitString(std::string(token), ' ', '\\', filenames);
+
+        if (filenames.empty()) {
+          if (warn) {
+            std::stringstream ss;
+            ss << "Looks like empty filename for mtllib. Use default "
+                  "material (line "
+               << line_num << ".)\n";
+
+            (*warn) += ss.str();
+          }
+        } else {
+          bool found = false;
+          for (size_t s = 0; s < filenames.size(); s++) {
+            if (material_filenames.count(filenames[s]) > 0) {
+              found = true;
+              continue;
+            }
+
+            std::string warn_mtl;
+            std::string err_mtl;
+            bool ok = (*readMatFn)(filenames[s].c_str(), materials,
+                                   &material_map, &warn_mtl, &err_mtl);
+            if (warn && (!warn_mtl.empty())) {
+              (*warn) += warn_mtl;
+            }
+
+            if (err && (!err_mtl.empty())) {
+              (*err) += err_mtl;
+            }
+
+            if (ok) {
+              found = true;
+              material_filenames.insert(filenames[s]);
+              break;
+            }
+          }
+
+          if (!found) {
+            if (warn) {
+              (*warn) +=
+                  "Failed to load material file(s). Use default "
+                  "material.\n";
+            }
+          }
+        }
+      }
+
+      continue;
+    }
+
+    // group name
+    if (token[0] == 'g' && IS_SPACE((token[1]))) {
+      // flush previous face group.
+      bool ret = exportGroupsToShape(&shape, prim_group, tags, material, name,
+                                     triangulate, v, warn);
+      (void)ret;  // return value not used.
+
+      if (shape.mesh.indices.size() > 0) {
+        shapes->push_back(shape);
+      }
+
+      shape = shape_t();
+
+      // material = -1;
+      prim_group.clear();
+
+      std::vector<std::string> names;
+
+      while (!IS_NEW_LINE(token[0])) {
+        std::string str = parseString(&token);
+        names.push_back(str);
+        token += strspn(token, " \t\r");  // skip tag
+      }
+
+      // names[0] must be 'g'
+
+      if (names.size() < 2) {
+        // 'g' with empty names
+        if (warn) {
+          std::stringstream ss;
+          ss << "Empty group name. line: " << line_num << "\n";
+          (*warn) += ss.str();
+          name = "";
+        }
+      } else {
+        std::stringstream ss;
+        ss << names[1];
+
+        // tinyobjloader does not support multiple groups for a primitive.
+        // Currently we concatinate multiple group names with a space to get
+        // single group name.
+
+        for (size_t i = 2; i < names.size(); i++) {
+          ss << " " << names[i];
+        }
+
+        name = ss.str();
+      }
+
+      continue;
+    }
+
+    // object name
+    if (token[0] == 'o' && IS_SPACE((token[1]))) {
+      // flush previous face group.
+      bool ret = exportGroupsToShape(&shape, prim_group, tags, material, name,
+                                     triangulate, v, warn);
+      (void)ret;  // return value not used.
+
+      if (shape.mesh.indices.size() > 0 || shape.lines.indices.size() > 0 ||
+          shape.points.indices.size() > 0) {
+        shapes->push_back(shape);
+      }
+
+      // material = -1;
+      prim_group.clear();
+      shape = shape_t();
+
+      // @todo { multiple object name? }
+      token += 2;
+      std::stringstream ss;
+      ss << token;
+      name = ss.str();
+
+      continue;
+    }
+
+    if (token[0] == 't' && IS_SPACE(token[1])) {
+      const int max_tag_nums = 8192;  // FIXME(syoyo): Parameterize.
+      tag_t tag;
+
+      token += 2;
+
+      tag.name = parseString(&token);
+
+      tag_sizes ts = parseTagTriple(&token);
+
+      if (ts.num_ints < 0) {
+        ts.num_ints = 0;
+      }
+      if (ts.num_ints > max_tag_nums) {
+        ts.num_ints = max_tag_nums;
+      }
+
+      if (ts.num_reals < 0) {
+        ts.num_reals = 0;
+      }
+      if (ts.num_reals > max_tag_nums) {
+        ts.num_reals = max_tag_nums;
+      }
+
+      if (ts.num_strings < 0) {
+        ts.num_strings = 0;
+      }
+      if (ts.num_strings > max_tag_nums) {
+        ts.num_strings = max_tag_nums;
+      }
+
+      tag.intValues.resize(static_cast<size_t>(ts.num_ints));
+
+      for (size_t i = 0; i < static_cast<size_t>(ts.num_ints); ++i) {
+        tag.intValues[i] = parseInt(&token);
+      }
+
+      tag.floatValues.resize(static_cast<size_t>(ts.num_reals));
+      for (size_t i = 0; i < static_cast<size_t>(ts.num_reals); ++i) {
+        tag.floatValues[i] = parseReal(&token);
+      }
+
+      tag.stringValues.resize(static_cast<size_t>(ts.num_strings));
+      for (size_t i = 0; i < static_cast<size_t>(ts.num_strings); ++i) {
+        tag.stringValues[i] = parseString(&token);
+      }
+
+      tags.push_back(tag);
+
+      continue;
+    }
+
+    if (token[0] == 's' && IS_SPACE(token[1])) {
+      // smoothing group id
+      token += 2;
+
+      // skip space.
+      token += strspn(token, " \t");  // skip space
+
+      if (token[0] == '\0') {
+        continue;
+      }
+
+      if (token[0] == '\r' || token[1] == '\n') {
+        continue;
+      }
+
+      if (strlen(token) >= 3 && token[0] == 'o' && token[1] == 'f' &&
+          token[2] == 'f') {
+        current_smoothing_id = 0;
+      } else {
+        // assume number
+        int smGroupId = parseInt(&token);
+        if (smGroupId < 0) {
+          // parse error. force set to 0.
+          // FIXME(syoyo): Report warning.
+          current_smoothing_id = 0;
+        } else {
+          current_smoothing_id = static_cast<unsigned int>(smGroupId);
+        }
+      }
+
+      continue;
+    }  // smoothing group id
+
+    // Ignore unknown command.
+  }
+
+  // not all vertices have colors, no default colors desired? -> clear colors
+  if (!found_all_colors && !default_vcols_fallback) {
+    vc.clear();
+  }
+
+  if (greatest_v_idx >= static_cast<int>(v.size() / 3)) {
+    if (warn) {
+      std::stringstream ss;
+      ss << "Vertex indices out of bounds (line " << line_num << ".)\n\n";
+      (*warn) += ss.str();
+    }
+  }
+  if (greatest_vn_idx >= static_cast<int>(vn.size() / 3)) {
+    if (warn) {
+      std::stringstream ss;
+      ss << "Vertex normal indices out of bounds (line " << line_num
+         << ".)\n\n";
+      (*warn) += ss.str();
+    }
+  }
+  if (greatest_vt_idx >= static_cast<int>(vt.size() / 2)) {
+    if (warn) {
+      std::stringstream ss;
+      ss << "Vertex texcoord indices out of bounds (line " << line_num
+         << ".)\n\n";
+      (*warn) += ss.str();
+    }
+  }
+
+  bool ret = exportGroupsToShape(&shape, prim_group, tags, material, name,
+                                 triangulate, v, warn);
+  // exportGroupsToShape return false when `usemtl` is called in the last
+  // line.
+  // we also add `shape` to `shapes` when `shape.mesh` has already some
+  // faces(indices)
+  if (ret || shape.mesh.indices
+                 .size()) {  // FIXME(syoyo): Support other prims(e.g. lines)
+    shapes->push_back(shape);
+  }
+  prim_group.clear();  // for safety
+
+  if (err) {
+    (*err) += errss.str();
+  }
+
+  attrib->vertices.swap(v);
+  attrib->vertex_weights.swap(vertex_weights);
+  attrib->normals.swap(vn);
+  attrib->texcoords.swap(vt);
+  attrib->texcoord_ws.swap(vt);
+  attrib->colors.swap(vc);
+  attrib->skin_weights.swap(vw);
+
+  return true;
+}
+
+bool LoadObjWithCallback(std::istream &inStream, const callback_t &callback,
+                         void *user_data /*= NULL*/,
+                         MaterialReader *readMatFn /*= NULL*/,
+                         std::string *warn, /* = NULL*/
+                         std::string *err /*= NULL*/) {
+  std::stringstream errss;
+
+  // material
+  std::set<std::string> material_filenames;
+  std::map<std::string, int> material_map;
+  int material_id = -1;  // -1 = invalid
+
+  std::vector<index_t> indices;
+  std::vector<material_t> materials;
+  std::vector<std::string> names;
+  names.reserve(2);
+  std::vector<const char *> names_out;
+
+  std::string linebuf;
+  while (inStream.peek() != -1) {
+    safeGetline(inStream, linebuf);
+
+    // Trim newline '\r\n' or '\n'
+    if (linebuf.size() > 0) {
+      if (linebuf[linebuf.size() - 1] == '\n')
+        linebuf.erase(linebuf.size() - 1);
+    }
+    if (linebuf.size() > 0) {
+      if (linebuf[linebuf.size() - 1] == '\r')
+        linebuf.erase(linebuf.size() - 1);
+    }
+
+    // Skip if empty line.
+    if (linebuf.empty()) {
+      continue;
+    }
+
+    // Skip leading space.
+    const char *token = linebuf.c_str();
+    token += strspn(token, " \t");
+
+    assert(token);
+    if (token[0] == '\0') continue;  // empty line
+
+    if (token[0] == '#') continue;  // comment line
+
+    // vertex
+    if (token[0] == 'v' && IS_SPACE((token[1]))) {
+      token += 2;
+      real_t x, y, z;
+      real_t r, g, b;
+
+      int num_components = parseVertexWithColor(&x, &y, &z, &r, &g, &b, &token);
+      if (callback.vertex_cb) {
+        callback.vertex_cb(user_data, x, y, z, r);  // r=w is optional
+      }
+      if (callback.vertex_color_cb) {
+        bool found_color = (num_components == 6);
+        callback.vertex_color_cb(user_data, x, y, z, r, g, b, found_color);
+      }
+      continue;
+    }
+
+    // normal
+    if (token[0] == 'v' && token[1] == 'n' && IS_SPACE((token[2]))) {
+      token += 3;
+      real_t x, y, z;
+      parseReal3(&x, &y, &z, &token);
+      if (callback.normal_cb) {
+        callback.normal_cb(user_data, x, y, z);
+      }
+      continue;
+    }
+
+    // texcoord
+    if (token[0] == 'v' && token[1] == 't' && IS_SPACE((token[2]))) {
+      token += 3;
+      real_t x, y, z;  // y and z are optional. default = 0.0
+      parseReal3(&x, &y, &z, &token);
+      if (callback.texcoord_cb) {
+        callback.texcoord_cb(user_data, x, y, z);
+      }
+      continue;
+    }
+
+    // face
+    if (token[0] == 'f' && IS_SPACE((token[1]))) {
+      token += 2;
+      token += strspn(token, " \t");
+
+      indices.clear();
+      while (!IS_NEW_LINE(token[0])) {
+        vertex_index_t vi = parseRawTriple(&token);
+
+        index_t idx;
+        idx.vertex_index = vi.v_idx;
+        idx.normal_index = vi.vn_idx;
+        idx.texcoord_index = vi.vt_idx;
+
+        indices.push_back(idx);
+        size_t n = strspn(token, " \t\r");
+        token += n;
+      }
+
+      if (callback.index_cb && indices.size() > 0) {
+        callback.index_cb(user_data, &indices.at(0),
+                          static_cast<int>(indices.size()));
+      }
+
+      continue;
+    }
+
+    // use mtl
+    if ((0 == strncmp(token, "usemtl", 6)) && IS_SPACE((token[6]))) {
+      token += 7;
+      std::stringstream ss;
+      ss << token;
+      std::string namebuf = ss.str();
+
+      int newMaterialId = -1;
+      std::map<std::string, int>::const_iterator it =
+          material_map.find(namebuf);
+      if (it != material_map.end()) {
+        newMaterialId = it->second;
+      } else {
+        // { warn!! material not found }
+        if (warn && (!callback.usemtl_cb)) {
+          (*warn) += "material [ " + namebuf + " ] not found in .mtl\n";
+        }
+      }
+
+      if (newMaterialId != material_id) {
+        material_id = newMaterialId;
+      }
+
+      if (callback.usemtl_cb) {
+        callback.usemtl_cb(user_data, namebuf.c_str(), material_id);
+      }
+
+      continue;
+    }
+
+    // load mtl
+    if ((0 == strncmp(token, "mtllib", 6)) && IS_SPACE((token[6]))) {
+      if (readMatFn) {
+        token += 7;
+
+        std::vector<std::string> filenames;
+        SplitString(std::string(token), ' ', '\\', filenames);
+
+        if (filenames.empty()) {
+          if (warn) {
+            (*warn) +=
+                "Looks like empty filename for mtllib. Use default "
+                "material. \n";
+          }
+        } else {
+          bool found = false;
+          for (size_t s = 0; s < filenames.size(); s++) {
+            if (material_filenames.count(filenames[s]) > 0) {
+              found = true;
+              continue;
+            }
+
+            std::string warn_mtl;
+            std::string err_mtl;
+            bool ok = (*readMatFn)(filenames[s].c_str(), &materials,
+                                   &material_map, &warn_mtl, &err_mtl);
+
+            if (warn && (!warn_mtl.empty())) {
+              (*warn) += warn_mtl;  // This should be warn message.
+            }
+
+            if (err && (!err_mtl.empty())) {
+              (*err) += err_mtl;
+            }
+
+            if (ok) {
+              found = true;
+              material_filenames.insert(filenames[s]);
+              break;
+            }
+          }
+
+          if (!found) {
+            if (warn) {
+              (*warn) +=
+                  "Failed to load material file(s). Use default "
+                  "material.\n";
+            }
+          } else {
+            if (callback.mtllib_cb) {
+              callback.mtllib_cb(user_data, &materials.at(0),
+                                 static_cast<int>(materials.size()));
+            }
+          }
+        }
+      }
+
+      continue;
+    }
+
+    // group name
+    if (token[0] == 'g' && IS_SPACE((token[1]))) {
+      names.clear();
+
+      while (!IS_NEW_LINE(token[0])) {
+        std::string str = parseString(&token);
+        names.push_back(str);
+        token += strspn(token, " \t\r");  // skip tag
+      }
+
+      assert(names.size() > 0);
+
+      if (callback.group_cb) {
+        if (names.size() > 1) {
+          // create const char* array.
+          names_out.resize(names.size() - 1);
+          for (size_t j = 0; j < names_out.size(); j++) {
+            names_out[j] = names[j + 1].c_str();
+          }
+          callback.group_cb(user_data, &names_out.at(0),
+                            static_cast<int>(names_out.size()));
+
+        } else {
+          callback.group_cb(user_data, NULL, 0);
+        }
+      }
+
+      continue;
+    }
+
+    // object name
+    if (token[0] == 'o' && IS_SPACE((token[1]))) {
+      // @todo { multiple object name? }
+      token += 2;
+
+      std::stringstream ss;
+      ss << token;
+      std::string object_name = ss.str();
+
+      if (callback.object_cb) {
+        callback.object_cb(user_data, object_name.c_str());
+      }
+
+      continue;
+    }
+
+#if 0  // @todo
+    if (token[0] == 't' && IS_SPACE(token[1])) {
+      tag_t tag;
+
+      token += 2;
+      std::stringstream ss;
+      ss << token;
+      tag.name = ss.str();
+
+      token += tag.name.size() + 1;
+
+      tag_sizes ts = parseTagTriple(&token);
+
+      tag.intValues.resize(static_cast<size_t>(ts.num_ints));
+
+      for (size_t i = 0; i < static_cast<size_t>(ts.num_ints); ++i) {
+        tag.intValues[i] = atoi(token);
+        token += strcspn(token, "/ \t\r") + 1;
+      }
+
+      tag.floatValues.resize(static_cast<size_t>(ts.num_reals));
+      for (size_t i = 0; i < static_cast<size_t>(ts.num_reals); ++i) {
+        tag.floatValues[i] = parseReal(&token);
+        token += strcspn(token, "/ \t\r") + 1;
+      }
+
+      tag.stringValues.resize(static_cast<size_t>(ts.num_strings));
+      for (size_t i = 0; i < static_cast<size_t>(ts.num_strings); ++i) {
+        std::stringstream ss;
+        ss << token;
+        tag.stringValues[i] = ss.str();
+        token += tag.stringValues[i].size() + 1;
+      }
+
+      tags.push_back(tag);
+    }
+#endif
+
+    // Ignore unknown command.
+  }
+
+  if (err) {
+    (*err) += errss.str();
+  }
+
+  return true;
+}
+
+bool ObjReader::ParseFromFile(const std::string &filename,
+                              const ObjReaderConfig &config) {
+  std::string mtl_search_path;
+
+  if (config.mtl_search_path.empty()) {
+    //
+    // split at last '/'(for unixish system) or '\\'(for windows) to get
+    // the base directory of .obj file
+    //
+    size_t pos = filename.find_last_of("/\\");
+    if (pos != std::string::npos) {
+      mtl_search_path = filename.substr(0, pos);
+    }
+  } else {
+    mtl_search_path = config.mtl_search_path;
+  }
+
+  valid_ = LoadObj(&attrib_, &shapes_, &materials_, &warning_, &error_,
+                   filename.c_str(), mtl_search_path.c_str(),
+                   config.triangulate, config.vertex_color);
+
+  return valid_;
+}
+
+bool ObjReader::ParseFromString(const std::string &obj_text,
+                                const std::string &mtl_text,
+                                const ObjReaderConfig &config) {
+  std::stringbuf obj_buf(obj_text);
+  std::stringbuf mtl_buf(mtl_text);
+
+  std::istream obj_ifs(&obj_buf);
+  std::istream mtl_ifs(&mtl_buf);
+
+  MaterialStreamReader mtl_ss(mtl_ifs);
+
+  valid_ = LoadObj(&attrib_, &shapes_, &materials_, &warning_, &error_,
+                   &obj_ifs, &mtl_ss, config.triangulate, config.vertex_color);
+
+  return valid_;
+}
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
+}  // namespace tinyobj
+
+#endif


### PR DESCRIPTION
## Summary

- Adds a 3D scene graph to joon with two new IR tiers: `SCENE` (meshes, lights, cameras) and `RENDER` (the `pass` node that rasterizes)
- Scene-tier executors populate a `SceneCollection` during evaluation; the `pass` executor builds a Vulkan graphics pipeline with hardcoded HLSL vertex/fragment shaders and renders all collected geometry to a color+depth render target
- Render target feeds back into the compute graph as a `GpuImage`, so downstream compute nodes (e.g. `levels`) can process it
- Includes procedural primitives (cube, sphere, plane, cylinder), OBJ loading via vendored tinyobjloader, vertex/index/uniform buffer wrappers, `VkRenderPass` + `VkGraphicsPipeline` caching, and a `math.h` with vec/mat types + `look_at`/`perspective`

## What changed

| Phase | Files | Description |
|-------|-------|-------------|
| IR tiers | `node.h`, `types.h`, `ir_graph.cpp` | `Tier::SCENE`, `Tier::RENDER`, new output types |
| Value types | `scene.h`, `scene_collection.cpp` | `Mesh`, `SceneObject`, `Light`, `Camera`, `SceneCollection` |
| Primitives | `primitives.h/cpp` | `gen_cube`, `gen_sphere`, `gen_plane`, `gen_cylinder` |
| OBJ loader | `obj_loader.h/cpp`, `tinyobjloader/` | Vendored single-header OBJ parser |
| Evaluator | `node_registry.h`, `evaluator.cpp`, `interpreter.cpp` | Scene collection in `EvalContext`, multi-tier evaluation order |
| Scene executors | `scene_executors.h/cpp` | 7 executors: cube/sphere/plane/cylinder/mesh/light/camera |
| Vulkan infra | `buffer.h/cpp`, `render_pass.h/cpp`, `pipeline_cache.h/cpp`, `resource_pool.h/cpp` | GPU buffers, render pass, graphics pipeline caching, render targets |
| Geometry pass | `geometry_pass.h/cpp` | Records draw commands, MVP uniforms, N·L lighting via push constants |
| Shaders | `scene_basic.vert.hlsl`, `scene_basic.frag.hlsl` | Hardcoded vertex (MVP transform) + fragment (lambert diffuse) |
| Math | `math.h` | `vec2/3/4`, `mat4`, `look_at`, `perspective`, operators |
| GUI | `app.cpp` | Default DSL is now a 3D cube scene with contrast slider |

## Test plan

```bash
# Switch to worktree
cd /mnt/d/prg/plum-joon-scene-graph

# Build
cd projects/joon/build
"/c/Program Files/Microsoft Visual Studio/2022/Community/MSBuild/Current/Bin/MSBuild.exe" \
  Joon.sln -p:Configuration=Debug -p:Platform=x64 -m -v:minimal

# Run all tests (59 cases, 1262 assertions)
./bin/Debug/joon-tests.exe

# Run just the scene/render tests
./bin/Debug/joon-tests.exe "[scene]"
./bin/Debug/joon-tests.exe "[render][gpu]"

# Visual: launch GUI, confirm shaded cube in viewport, drag contrast slider
./bin/Debug/joon-gui.exe
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)