### PR TITLE
fix(rp): five bugs found during project audit

### DIFF
--- a/projects/aiserver/ollama.py
+++ b/projects/aiserver/ollama.py
@@ -27,11 +27,11 @@ class OllamaClient:
           {"token": "...", "thinking": bool, "done": False}
           {"token": "", "done": True, "total_tokens": N, "tokens_per_second": F}
         """
-        think = False
+        think = None
         ollama_options = {}
         if options:
             options = dict(options)
-            think = options.pop("think", False)
+            think = options.pop("think", None)
             ollama_options = {k: v for k, v in options.items() if v is not None}
 
         body: dict = {
@@ -43,8 +43,8 @@ class OllamaClient:
             body["system"] = system
         if ollama_options:
             body["options"] = ollama_options
-        if think:
-            body["think"] = True
+        if think is not None:
+            body["think"] = think
 
         total_tokens = 0
         try:
@@ -99,11 +99,11 @@ class OllamaClient:
           {"token": "...", "thinking": bool, "done": False}
           {"token": "", "done": True, "total_tokens": N, "tokens_per_second": F}
         """
-        think = False
+        think = None
         ollama_options = {}
         if options:
             options = dict(options)
-            think = options.pop("think", False)
+            think = options.pop("think", None)
             ollama_options = {k: v for k, v in options.items() if v is not None}
 
         body: dict = {
@@ -113,8 +113,8 @@ class OllamaClient:
         }
         if ollama_options:
             body["options"] = ollama_options
-        if think:
-            body["think"] = True
+        if think is not None:
+            body["think"] = think
         if stop:
             body["stop"] = stop
 
@@ -210,7 +210,7 @@ class OllamaClient:
         model: str,
         messages: list[dict],
         tools: list[dict] | None = None,
-        think: bool = False,
+        think: bool | None = None,
     ) -> dict:
         """Non-streaming chat call. Returns the full Ollama response dict.
 
@@ -223,8 +223,8 @@ class OllamaClient:
         }
         if tools:
             body["tools"] = tools
-        if think:
-            body["think"] = True
+        if think is not None:
+            body["think"] = think
         try:
             async with httpx.AsyncClient(timeout=120.0) as client:
                 resp = await client.post(f"{self.base_url}/api/chat", json=body)

--- a/projects/rp/generate_examples.py
+++ b/projects/rp/generate_examples.py
@@ -376,7 +376,7 @@ async def main() -> None:
             return
 
         pairs = await get_conversation_pairs(
-            pool, args.card_id, limit=0
+            pool, args.card_id, limit=args.limit
         )
         total_mined = len(pairs)
 

--- a/projects/rp/lora_export.py
+++ b/projects/rp/lora_export.py
@@ -53,7 +53,7 @@ def _build_system_prompt(ai_card: dict, user_card: dict, scenario: dict) -> str:
         "char_pronouns": ai_data.get("pronouns", ""),
     }
 
-    system_part, post_part = _split_template(DEFAULT_PROMPT_TEMPLATE)
+    system_part, post_part, _, _ = _split_template(DEFAULT_PROMPT_TEMPLATE)
     system_prompt = render_template(system_part, values)
 
     # Apply variable substitution

--- a/projects/rp/lora_generate.py
+++ b/projects/rp/lora_generate.py
@@ -328,7 +328,7 @@ def build_system_prompt(ai_card: dict, user_card: dict, scenario_text: str) -> s
         "char_pronouns": ai_data.get("pronouns", ""),
     }
 
-    system_part, post_part = _split_template(DEFAULT_PROMPT_TEMPLATE)
+    system_part, post_part, _, _ = _split_template(DEFAULT_PROMPT_TEMPLATE)
     system_prompt = render_template(system_part, values)
 
     char_name = ai_data.get("name", "Character")

--- a/projects/rp/models.py
+++ b/projects/rp/models.py
@@ -73,6 +73,11 @@ class SendMessageRequest(BaseModel):
     content: str
 
 
+class SavePartialRequest(BaseModel):
+    content: str
+    role: str = "assistant"
+
+
 class EditMessageRequest(BaseModel):
     content: str
 

--- a/projects/rp/routes.py
+++ b/projects/rp/routes.py
@@ -11,7 +11,8 @@ from .cards import parse_card_png, export_card_png, extract_name
 from .models import (
     CardCreate, CardResponse, ScenarioCreate, ScenarioResponse,
     ConversationCreate, ConversationResponse, ConversationDetailResponse,
-    MessageResponse, SendMessageRequest, EditMessageRequest, SceneStateRequest,
+    MessageResponse, SendMessageRequest, SavePartialRequest, EditMessageRequest,
+    SceneStateRequest,
 )
 from .pipeline import create_default_pipeline
 from .budget import BudgetError, allocate_injections
@@ -31,7 +32,7 @@ from . import conv_log
 _PRI_INTERACTIVE = 0   # UI chat: /message, /continue, /regenerate, /auto-reply
 _PRI_BACKGROUND = 5    # card generation, scene state, summaries
 
-_log = logging.getLogger(__name__)
+_log = logging.getLogger("rp.routes")
 
 _ollama = None
 _pipeline = None
@@ -579,8 +580,6 @@ def setup(app: FastAPI, ollama, resolve_model=None):
             clean = clean[len(char_name) + 1:].strip()
         return clean
 
-    _log = logging.getLogger("rp.routes")
-
     _scene_state_model = "q36"
 
     def _build_scene_state_prompt(messages: list[dict], previous_state: str = "",
@@ -831,7 +830,7 @@ def setup(app: FastAPI, ollama, resolve_model=None):
         return StreamingResponse(stream(), media_type="application/x-ndjson")
 
     @app.post("/rp/conversations/{conv_id}/save-partial")
-    async def save_partial(conv_id: int, req: SendMessageRequest):
+    async def save_partial(conv_id: int, req: SavePartialRequest):
         """Save a partial response when the user hits Stop mid-stream."""
         conv = await db.get_conversation(conv_id)
         if not conv:
@@ -839,7 +838,8 @@ def setup(app: FastAPI, ollama, resolve_model=None):
         content = req.content.strip()
         if not content:
             return {"ok": False}
-        await db.add_message(conv_id, "assistant", content)
+        role = req.role if req.role in ("assistant", "user") else "assistant"
+        await db.add_message(conv_id, role, content)
         return {"ok": True}
 
     @app.put("/rp/messages/{msg_id}", response_model=MessageResponse)

--- a/projects/rp/routes.py
+++ b/projects/rp/routes.py
@@ -567,7 +567,7 @@ def setup(app: FastAPI, ollama, resolve_model=None):
             _ollama.generate(
                 model=model, prompt=full_prompt,
                 system=f"You are writing the opening narration for {char_name}. Stay in character.",
-                options={"temperature": 1.05, "num_predict": 768, "min_p": 0.1, "repeat_penalty": 1.08},
+                options={"temperature": 1.05, "num_predict": 768, "min_p": 0.1, "repeat_penalty": 1.08, "think": False},
             ),
             timeout=300,
         )
@@ -641,7 +641,7 @@ def setup(app: FastAPI, ollama, resolve_model=None):
         result = await _ollama.generate(
             model=summary_model, prompt=prompt,
             system="Output only the scene state summary. No thinking, no preamble.",
-            options={"temperature": 0.2, "num_predict": 800},
+            options={"temperature": 0.2, "num_predict": 800, "think": False},
         )
         clean = clean_scene_state_response(result)
         return validate_scene_state(clean, previous_state, messages)

--- a/projects/rp/static/app.js
+++ b/projects/rp/static/app.js
@@ -372,7 +372,7 @@
     }
 
     // Load latest summary for the Summary tab
-    api("GET", "/rp/conversations/" + id + "/summaries").then(function (summaries) {
+    api("GET", "/rp/conversations/" + conversation.id + "/summaries").then(function (summaries) {
       if (summaries && summaries.length > 0) {
         var latest = summaries[summaries.length - 1];
         $("underHoodSummaryContent").textContent =

--- a/projects/rp/summarize.py
+++ b/projects/rp/summarize.py
@@ -11,7 +11,7 @@ from .tokenizer import count_tokens
 
 _log = logging.getLogger("rp.summarize")
 
-SUMMARY_MODEL = "q25"
+SUMMARY_MODEL = "q8"
 SUMMARY_THRESHOLD = 10  # unsummarized messages before triggering
 
 

--- a/projects/rp/tests/test_summarize.py
+++ b/projects/rp/tests/test_summarize.py
@@ -2,6 +2,7 @@ import asyncio
 from unittest.mock import AsyncMock, patch
 
 from projects.rp.summarize import (
+    SUMMARY_MODEL,
     build_summary_prompt,
     clean_summary_response,
     maybe_generate_summary,
@@ -254,7 +255,7 @@ class TestMaybeGenerateSummary:
                 )
 
                 call_args = ollama.generate.call_args
-                assert call_args[1]["model"] == "resolved-q25"
+                assert call_args[1]["model"] == f"resolved-{SUMMARY_MODEL}"
         asyncio.run(run())
 
     def test_falls_back_to_conv_model_without_resolve(self):


### PR DESCRIPTION
## Summary

- **`_split_template` crash**: `lora_generate.py:331` and `lora_export.py:56` unpacked as 2-tuple but function returns 4-tuple after style/scene-style sections were added — ValueError on every run
- **Summary tab broken**: `app.js:375` used undefined `id` variable instead of `conversation.id` — Summary tab in Under the Hood always showed "No summary yet"
- **Logger shadowing**: `routes.py:582` re-assigned `_log` inside `setup()` with a different logger name, causing inconsistent log routing — removed duplicate, kept module-level `"rp.routes"` logger
- **`generate_examples` limit ignored**: `generate_examples.py:379` hardcoded `limit=0` instead of using `args.limit`
- **`save-partial` missing role**: added `role` field to `SavePartialRequest` so user messages can be saved
- **Scene state always empty**: qwen3.6 thinks by default, burning all `num_predict` tokens on thinking. Added `think: False` to scene state and first message generation
- **OllamaClient never sent `think: false`**: the client only added `think: true` to request bodies (via `if think:`), never `think: false`. Models that think by default were never actually told to stop. Fixed with `None` sentinel — `None` = "not specified", `True`/`False` = explicit
- **Summary hallucination**: upgraded summary model from q25 (qwen2.5:7b) to q8 (qwen3:8b) — q25 would narrate/continue the story instead of summarizing, ignoring the "do NOT narrate" instruction

## Test plan
- `pytest projects/rp/tests/` — 387 passed
- `pytest projects/aiserver/tests/` — 22 passed
- Manually verified scene state generates for conversation 105 (was empty, now shows correct location/clothing/mood)
- Manually verified q8 produces factual summaries (not narrative continuation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)