### PR TITLE
fix(rp): stale summary crash and continue not appending

### DIFF
--- a/projects/rp/context.py
+++ b/projects/rp/context.py
@@ -67,15 +67,16 @@ class SummaryBuffer(ContextStrategy):
         summary_msg = None
 
         if summary:
+            max_seq = max((m.get("_sequence", 0) for m in messages), default=0)
+            stale = summary_through > 0 and summary_through >= max_seq
             summary_tokens = count(summary)
             cap = int(max_tokens * 0.25)
-            if summary_tokens <= cap:
+            if not stale and summary_tokens <= cap:
                 summary_msg = {
                     "role": "system",
                     "content": f"[Story so far]\n{summary}",
                 }
                 budget -= summary_tokens
-                # Exclude messages already covered by the summary
                 rest = [m for m in rest
                         if m.get("_sequence", 0) > summary_through]
 

--- a/projects/rp/prompt_builder.py
+++ b/projects/rp/prompt_builder.py
@@ -104,6 +104,8 @@ async def build_pipeline_ctx(conv, messages, *, pipeline, template_path: Path):
     for m in messages:
         d = {"role": m["role"], "content": m["content"]}
         d["_sequence"] = m.get("sequence", 0)
+        if "id" in m:
+            d["_id"] = m["id"]
         msg_dicts.append(d)
 
     ctx = {

--- a/projects/rp/routes.py
+++ b/projects/rp/routes.py
@@ -977,7 +977,21 @@ def setup(app: FastAPI, ollama, resolve_model=None):
         # Tell Ollama to load the model with its real context window
         ollama_options = {**ollama_options, "num_ctx": ctx["_num_ctx"]}
 
+        # For continue: use the last assistant message as priming prefix
+        # so the model continues mid-sentence instead of starting fresh.
+        prefix_text = ""
+        continue_msg_id = None
+        budgeted_msgs = ctx["messages"]
+        if budgeted_msgs and budgeted_msgs[-1].get("role") == "assistant":
+            last_asst = budgeted_msgs[-1]
+            prefix_text = last_asst.get("content", "")
+            continue_msg_id = last_asst.get("_id")
+            ctx["messages"] = budgeted_msgs[:-1]
+
         chat_messages = build_chat_messages(ctx)
+        if prefix_text:
+            chat_messages[-1] = {"role": "assistant", "content": prefix_text}
+
         user_name = get_user_name(ctx)
         conv_log.log_prompt(conv_id, "continue", model,
                             ctx["system_prompt"], ctx.get("post_prompt", ""),
@@ -1013,16 +1027,19 @@ def setup(app: FastAPI, ollama, resolve_model=None):
                 response_text = "".join(tokens)
                 post_ctx = {"response": response_text, "ai_name": get_ai_name(ctx), "_char_pronouns": get_ai_pronouns(ctx)}
                 post_ctx = await _pipeline.run_post(post_ctx)
-                await db.add_message(
-                    conv_id, "assistant", post_ctx["response"], raw_response=raw,
-                    system_prompt=ctx.get("system_prompt", ""),
-                    scene_state=conv.get("scene_state", ""),
-                    post_prompt=ctx.get("post_prompt", ""),
-                    budget_json=budget_to_json(ctx),
-                    prompt_json=chat_messages,
-                )
+                full_text = prefix_text + post_ctx["response"]
+                if continue_msg_id:
+                    await db.update_message(continue_msg_id, full_text)
+                else:
+                    await db.add_message(
+                        conv_id, "assistant", full_text, raw_response=raw,
+                        system_prompt=ctx.get("system_prompt", ""),
+                        scene_state=conv.get("scene_state", ""),
+                        post_prompt=ctx.get("post_prompt", ""),
+                        budget_json=budget_to_json(ctx),
+                        prompt_json=chat_messages,
+                    )
                 conv_log.log_response(conv_id, "assistant", post_ctx["response"], raw)
-                # Update scene state and maybe generate summary in background
                 asyncio.create_task(_auto_update_scene_state(conv_id, model,
                                                 get_ai_name(ctx), get_user_name(ctx), get_ai_personality(ctx)))
                 asyncio.create_task(_maybe_summarize(conv_id, model,

--- a/projects/rp/tests/test_context.py
+++ b/projects/rp/tests/test_context.py
@@ -180,6 +180,18 @@ class TestSummaryBuffer:
         # greeting is kept separately, msg1 should be filtered
         assert len(result) == 2  # summary + greeting
 
+    def test_stale_summary_ignored(self):
+        """Summary covering sequences beyond current messages is ignored."""
+        msgs = [
+            _seq_msg("assistant", "greeting", 1),
+            _seq_msg("user", "recent msg", 2),
+        ]
+        ctx = {"_summary": "Old summary from before reset.", "_summary_through_sequence": 11}
+        result = SummaryBuffer().fit(msgs, 10000, ctx=ctx)
+        contents = [m["content"] for m in result]
+        assert "recent msg" in contents
+        assert not any("[Story so far]" in c for c in contents)
+
 
 class TestGetStrategy:
     def test_returns_sliding_window(self):


### PR DESCRIPTION
## Summary

- **Stale summary crash**: When a conversation is reset (messages deleted), stale summaries with `through_sequence` higher than max message sequence caused `SummaryBuffer.fit()` to filter out all messages as "already covered", triggering `BudgetError` even though the prompt fits. Fix: detect stale summaries and ignore them.
- **Continue doesn't continue**: Pressing continue started a fresh response instead of picking up from the truncated text. The model got the truncated message in chat history but a fresh `"Amber "` priming, so it began a new scene. Fix: use the last assistant message content as priming prefix and append new tokens to the existing DB message.

## Test plan
```bash
cd /mnt/d/prg/plum-rp-stale-summary
source projects/aiserver/.venv/bin/activate
pytest projects/rp/tests/test_context.py -v -k stale
# Should pass: test_stale_summary_ignored
pytest projects/rp/tests/ -q
# 388 passed
```

Manual verification:
- Conv 105 was failing with "Prompt does not fit" due to stale summary — now works after fix
- Continue should now append to the truncated message instead of creating a new one

🤖 Generated with [Claude Code](https://claude.com/claude-code)