### PR TITLE
feat(joon): DSL-generated shaders and deferred lighting (sub-project 3)

### DIFF
--- a/docs/superpowers/plans/2026-05-01-joon-shader-codegen.md
+++ b/docs/superpowers/plans/2026-05-01-joon-shader-codegen.md
@@ -1,0 +1,2520 @@
+# Joon Sub-Project 3: DSL-Generated Shaders & Deferred Lighting — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace joon's hardcoded shaders with a DSL-driven shader codegen system — materials define surface properties and custom BRDFs via DSL expressions that compile to HLSL, rendered via deferred shading with automatic pre-pass extraction for non-inlineable ops.
+
+**Architecture:** New parser nodes (`FnNode`, `VectorNode`, `DotAccessNode`) support the `(shader ...)` DSL. A `Tier::MATERIAL` IR phase compiles shader ASTs into HLSL via a `ShaderIR` → `HlslEmitter` pipeline. The geometry pass renders to MRT G-buffers with per-material pipelines. A fullscreen deferred lighting pass evaluates BRDFs (default Cook-Torrance or custom) per-light. Non-inlineable ops inside shader bodies are auto-extracted into compute pre-passes.
+
+**Tech Stack:** C++20, Vulkan, VMA, HLSL, DXC, Catch2.
+
+**Worktree:** `/mnt/d/prg/plum-joon-shader-codegen` (branch `joon-shader-codegen`)
+
+**Design spec:** `docs/superpowers/specs/2026-05-01-joon-shader-codegen-design.md`
+
+---
+
+## Conventions
+
+- TDD: write the failing test first, run it, see the exact failure, then implement.
+- Each commit message starts with `feat(joon):`, `test(joon):`, or `fix(joon):` and is one imperative sentence.
+- After every task: build the full solution and run **all** tests. If anything regresses, stop and fix before moving on.
+- Co-author trailer on every commit:
+  ```
+  Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+  ```
+- Build command (from worktree root):
+  ```bash
+  cd projects/joon/build && \
+  "/c/Program Files/Microsoft Visual Studio/2022/Community/MSBuild/Current/Bin/MSBuild.exe" \
+    Joon.sln -p:Configuration=Debug -p:Platform=x64 -m -v:minimal
+  ```
+- Test command (from worktree root):
+  ```bash
+  projects/joon/build/bin/Debug/joon-tests.exe
+  ```
+- Run specific tags:
+  ```bash
+  projects/joon/build/bin/Debug/joon-tests.exe "[shader]"
+  ```
+
+---
+
+## File Map
+
+| Area | Action | File | Purpose |
+|------|--------|------|---------|
+| Lexer | Modify | `src/dsl/token.h` | Add LBRACKET, RBRACKET, DOT, ARROW token types |
+| Lexer | Modify | `src/dsl/lexer.cpp` | Emit bracket, dot, arrow tokens |
+| AST | Modify | `src/dsl/ast.h` | Add `FnNode`, `VectorNode`, `DotAccessNode` to variant |
+| Parser | Modify | `src/dsl/parser.cpp` | Parse `(fn ...)`, `[...]`, `a.b`, `-> [...]` syntax |
+| IR node | Modify | `src/ir/node.h` | Add `Tier::MATERIAL`; add `ShaderDef` struct on Node for shader ASTs |
+| IR types | Modify | `include/joon/types.h` | Add `Type::MATERIAL` |
+| IR graph | Modify | `src/ir/ir_graph.cpp` | Lower `shader` to MATERIAL tier; store FnNode kwargs |
+| Type checker | Modify | `src/ir/type_checker.cpp` | Handle MATERIAL type |
+| Shader IR | Create | `src/shader/shader_ir.h` | Expression tree types for shader bodies |
+| Shader analyzer | Create | `src/shader/shader_analyzer.h`, `.cpp` | Build ShaderIR from AST, classify ops |
+| HLSL emitter | Create | `src/shader/hlsl_emitter.h`, `.cpp` | ShaderIR → HLSL source code |
+| Noise HLSL | Create | `src/shader/noise_hlsl.h` | Inline HLSL noise/fbm source as string constant |
+| BRDF emitter | Create | `src/shader/brdf_emitter.h`, `.cpp` | Custom BRDF → lighting shader variant |
+| Pre-pass extractor | Create | `src/shader/prepass_extractor.h`, `.cpp` | Extract compute pre-passes from shader bodies |
+| Pipeline cache | Modify | `src/vulkan/pipeline_cache.h`, `.cpp` | Add `get_graphics_from_source()` for generated HLSL |
+| Render pass | Modify | `src/vulkan/render_pass.h`, `.cpp` | Verify N-attachment support works (already has vector) |
+| Resource pool | Modify | `src/vulkan/resource_pool.h`, `.cpp` | Add `alloc_depth_sampled()` with SAMPLED_BIT |
+| Buffer | Modify | `src/vulkan/buffer.h`, `.cpp` | Add fullscreen quad helper |
+| Lighting pass | Create | `src/scene/lighting_pass.h`, `.cpp` | Fullscreen deferred lighting dispatch |
+| Geometry pass | Modify | `src/scene/geometry_pass.cpp` | MRT framebuffer, per-material pipeline dispatch |
+| Scene executors | Modify | `src/scene/scene_executors.h`, `.cpp` | Material executor + `:material` kwarg on scene objects |
+| Scene types | Modify | `include/joon/scene.h` | Add LightUBO struct for shader upload |
+| Evaluator | Modify | `src/evaluator.cpp` | Add material registry to EvalContext; MATERIAL tier phase |
+| Interpreter | Modify | `src/interpreter/interpreter.cpp` | MATERIAL walk phase before SCENE |
+| Node registry | Modify | `src/nodes/node_registry.h` | EvalContext gains material pipeline map |
+| Node registry | Modify | `src/nodes/node_registry.cpp` | Register shader executor |
+| Fullscreen vert | Create | `shaders/fullscreen.vert.hlsl` | Passthrough quad vertex shader |
+| Default lighting | Create | `shaders/deferred_default.frag.hlsl` | Cook-Torrance GGX default |
+| GUI | Modify | `gui/app.cpp` | Default DSL with material + lighting |
+| Tests | Create | `tests/test_shader_parser.cpp` | Parser tests for fn, vector, dot, arrow syntax |
+| Tests | Create | `tests/test_shader_ir.cpp` | ShaderIR construction and op classification |
+| Tests | Create | `tests/test_hlsl_emitter.cpp` | HLSL code generation tests |
+| Tests | Create | `tests/test_prepass.cpp` | Pre-pass extraction tests |
+| Tests | Create | `tests/test_lighting_pass.cpp` | Deferred lighting GPU integration tests |
+| Tests | Create | `tests/test_deferred.cpp` | End-to-end deferred rendering with materials |
+
+---
+
+## Phase 1: Language Extensions
+
+### Task 1: Add FnNode, VectorNode, and arrow syntax to parser
+
+**Files:**
+- Modify: `projects/joon/src/dsl/token.h`
+- Modify: `projects/joon/src/dsl/lexer.cpp`
+- Modify: `projects/joon/src/dsl/ast.h`
+- Modify: `projects/joon/src/dsl/parser.cpp`
+- Create: `projects/joon/tests/test_shader_parser.cpp`
+
+- [ ] **Step 1: Write failing tests for FnNode, VectorNode, and arrow syntax**
+
+```cpp
+// tests/test_shader_parser.cpp
+#include "catch_amalgamated.hpp"
+#include "dsl/parser.h"
+using namespace joon;
+
+TEST_CASE("Parse vector literal", "[shader][parser]") {
+    Parser p("[1.0 2.0 3.0]");
+    auto expr = p.parse_expression();
+    auto* vec = std::get_if<VectorNode>(&expr->data);
+    REQUIRE(vec != nullptr);
+    CHECK(vec->elements.size() == 3);
+    auto* e0 = std::get_if<NumberNode>(&vec->elements[0]->data);
+    REQUIRE(e0);
+    CHECK(e0->value == Approx(1.0));
+}
+
+TEST_CASE("Parse fn with body", "[shader][parser]") {
+    Parser p("(fn [pos normal uv] (set pos.y (* pos.x 2.0)))");
+    auto expr = p.parse_expression();
+    auto* fn = std::get_if<FnNode>(&expr->data);
+    REQUIRE(fn != nullptr);
+    CHECK(fn->params.size() == 3);
+    CHECK(fn->params[0] == "pos");
+    CHECK(fn->params[1] == "normal");
+    CHECK(fn->params[2] == "uv");
+    CHECK(fn->body.size() == 1);
+}
+
+TEST_CASE("Parse fn with arrow outputs", "[shader][parser]") {
+    Parser p("(fn [normal uv] -> [albedo vec4, normal vec4] (set albedo [1 0 0 1]))");
+    auto expr = p.parse_expression();
+    auto* fn = std::get_if<FnNode>(&expr->data);
+    REQUIRE(fn != nullptr);
+    CHECK(fn->params.size() == 2);
+    CHECK(fn->outputs.size() == 2);
+    CHECK(fn->outputs[0].name == "albedo");
+    CHECK(fn->outputs[0].type_name == "vec4");
+    CHECK(fn->outputs[1].name == "normal");
+    CHECK(fn->body.size() == 1);
+}
+
+TEST_CASE("Parse shader call with fn kwargs", "[shader][parser]") {
+    Parser p(R"(
+        (shader
+          :fragment (fn [normal uv] -> [albedo vec4]
+            (set albedo [1 0 0 1])))
+    )");
+    auto expr = p.parse_expression();
+    auto* call = std::get_if<CallNode>(&expr->data);
+    REQUIRE(call != nullptr);
+    CHECK(call->op == "shader");
+    CHECK(call->kwargs.size() == 1);
+    CHECK(call->kwargs[0].name == "fragment");
+    auto* fn = std::get_if<FnNode>(&call->kwargs[0].value->data);
+    REQUIRE(fn != nullptr);
+    CHECK(fn->outputs.size() == 1);
+}
+
+TEST_CASE("Vector literal with expressions", "[shader][parser]") {
+    Parser p("[(+ 1 2) 3.0 x]");
+    auto expr = p.parse_expression();
+    auto* vec = std::get_if<VectorNode>(&expr->data);
+    REQUIRE(vec != nullptr);
+    CHECK(vec->elements.size() == 3);
+    CHECK(std::get_if<CallNode>(&vec->elements[0]->data) != nullptr);
+    CHECK(std::get_if<NumberNode>(&vec->elements[1]->data) != nullptr);
+    CHECK(std::get_if<SymbolNode>(&vec->elements[2]->data) != nullptr);
+}
+```
+
+- [ ] **Step 2: Build and verify tests fail (compile errors — new types don't exist yet)**
+
+Run build. Expected: compile error on `VectorNode`, `FnNode`.
+
+- [ ] **Step 3: Add new token types**
+
+In `src/dsl/token.h`, add to the `TokenType` enum:
+```cpp
+LBRACKET,    // [
+RBRACKET,    // ]
+DOT,         // .
+ARROW,       // ->
+```
+
+- [ ] **Step 4: Update lexer to emit new tokens**
+
+In `src/dsl/lexer.cpp`, in the `tokenize()` method's character switch, add cases:
+```cpp
+case '[': tokens.push_back({TokenType::LBRACKET, "[", line, col}); break;
+case ']': tokens.push_back({TokenType::RBRACKET, "]", line, col}); break;
+case '.': tokens.push_back({TokenType::DOT, ".", line, col}); break;
+```
+
+For `->` (arrow), handle inside the `-` case: peek at the next character; if it's `>`, consume both and emit `ARROW`; otherwise fall through to existing `-` handling (which treats it as part of a number or symbol).
+
+- [ ] **Step 5: Add AST node types**
+
+In `src/dsl/ast.h`, add before the variant definition:
+
+```cpp
+struct FnOutput {
+    std::string name;
+    std::string type_name;
+};
+
+struct FnNode {
+    std::vector<std::string> params;
+    std::vector<FnOutput> outputs;  // from -> [name type, ...]
+    std::vector<AstPtr> body;
+};
+
+struct VectorNode {
+    std::vector<AstPtr> elements;
+};
+```
+
+Add `FnNode` and `VectorNode` to the `AstData` variant:
+```cpp
+using AstData = std::variant<
+    DefNode, ParamNode, OutputNode, CallNode,
+    NumberNode, StringNode, SymbolNode,
+    FnNode, VectorNode
+>;
+```
+
+- [ ] **Step 6: Implement parser for vector literals**
+
+In `src/dsl/parser.cpp`, in `parse_expr()`, add a case for `LBRACKET`:
+```cpp
+if (peek().type == TokenType::LBRACKET) {
+    return parse_vector();
+}
+```
+
+Implement `parse_vector()`:
+```cpp
+AstPtr Parser::parse_vector() {
+    auto start = advance(); // consume [
+    VectorNode vec;
+    while (peek().type != TokenType::RBRACKET) {
+        vec.elements.push_back(parse_expr());
+        // skip optional comma
+        if (peek().type == TokenType::SYMBOL && peek().text == ",")
+            advance();
+    }
+    advance(); // consume ]
+    auto node = std::make_unique<AstNode>();
+    node->data = std::move(vec);
+    node->line = start.line;
+    node->col = start.col;
+    return node;
+}
+```
+
+- [ ] **Step 7: Implement parser for fn expressions**
+
+In `parse_expr()` inside the `LPAREN` case, before dispatching as a regular call, check if the op is `fn`:
+```cpp
+if (call_op == "fn") {
+    return parse_fn(start_line, start_col);
+}
+```
+
+Implement `parse_fn()`:
+```cpp
+AstPtr Parser::parse_fn(uint32_t line, uint32_t col) {
+    // Already consumed ( and fn
+    FnNode fn;
+
+    // Parse parameter list [param1 param2 ...]
+    expect(TokenType::LBRACKET);
+    while (peek().type != TokenType::RBRACKET) {
+        auto tok = advance();
+        fn.params.push_back(tok.text);
+    }
+    advance(); // consume ]
+
+    // Parse optional arrow outputs: -> [name type, name type, ...]
+    if (peek().type == TokenType::ARROW) {
+        advance(); // consume ->
+        expect(TokenType::LBRACKET);
+        while (peek().type != TokenType::RBRACKET) {
+            FnOutput out;
+            out.name = advance().text;      // output name
+            out.type_name = advance().text;  // output type
+            fn.outputs.push_back(std::move(out));
+            // skip optional comma
+            if (peek().type == TokenType::SYMBOL && peek().text == ",")
+                advance();
+        }
+        advance(); // consume ]
+    }
+
+    // Parse body expressions until closing )
+    while (peek().type != TokenType::RPAREN) {
+        fn.body.push_back(parse_expr());
+    }
+    advance(); // consume )
+
+    auto node = std::make_unique<AstNode>();
+    node->data = std::move(fn);
+    node->line = line;
+    node->col = col;
+    return node;
+}
+```
+
+Add `parse_vector()` and `parse_fn()` declarations to `parser.h`.
+
+- [ ] **Step 8: Build and run shader parser tests**
+
+```bash
+projects/joon/build/bin/Debug/joon-tests.exe "[shader][parser]"
+```
+Expected: all 5 tests pass.
+
+- [ ] **Step 9: Run full test suite**
+
+```bash
+projects/joon/build/bin/Debug/joon-tests.exe
+```
+Expected: all existing tests still pass + 5 new = total passes.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add projects/joon/src/dsl/ projects/joon/tests/test_shader_parser.cpp
+git commit -m "feat(joon): add FnNode, VectorNode, and arrow syntax to parser"
+```
+
+---
+
+### Task 2: Add DotAccessNode for G-buffer channel access
+
+**Files:**
+- Modify: `projects/joon/src/dsl/ast.h`
+- Modify: `projects/joon/src/dsl/parser.cpp`
+- Modify: `projects/joon/tests/test_shader_parser.cpp`
+
+- [ ] **Step 1: Write failing test**
+
+Add to `tests/test_shader_parser.cpp`:
+```cpp
+TEST_CASE("Parse dot access", "[shader][parser]") {
+    Parser p("gbuf.albedo");
+    auto expr = p.parse_expression();
+    auto* dot = std::get_if<DotAccessNode>(&expr->data);
+    REQUIRE(dot != nullptr);
+    CHECK(dot->field == "albedo");
+    auto* obj = std::get_if<SymbolNode>(&dot->object->data);
+    REQUIRE(obj != nullptr);
+    CHECK(obj->name == "gbuf");
+}
+
+TEST_CASE("Parse chained dot access", "[shader][parser]") {
+    Parser p("a.b.c");
+    auto expr = p.parse_expression();
+    auto* dot = std::get_if<DotAccessNode>(&expr->data);
+    REQUIRE(dot != nullptr);
+    CHECK(dot->field == "c");
+    auto* inner = std::get_if<DotAccessNode>(&dot->object->data);
+    REQUIRE(inner != nullptr);
+    CHECK(inner->field == "b");
+}
+```
+
+- [ ] **Step 2: Build, verify compile error (DotAccessNode undefined)**
+
+- [ ] **Step 3: Add DotAccessNode to AST**
+
+In `src/dsl/ast.h`:
+```cpp
+struct DotAccessNode {
+    AstPtr object;
+    std::string field;
+};
+```
+
+Add to variant:
+```cpp
+using AstData = std::variant<
+    DefNode, ParamNode, OutputNode, CallNode,
+    NumberNode, StringNode, SymbolNode,
+    FnNode, VectorNode, DotAccessNode
+>;
+```
+
+- [ ] **Step 4: Implement dot access parsing**
+
+In `src/dsl/parser.cpp`, modify `parse_expr()`. After parsing a primary expression (symbol, number, etc.), check for a trailing DOT token and wrap in DotAccessNode:
+
+```cpp
+AstPtr Parser::parse_expr() {
+    auto primary = parse_primary(); // existing parse logic
+    // Chain dot access
+    while (peek().type == TokenType::DOT) {
+        advance(); // consume .
+        auto field_tok = advance(); // field name
+        auto dot = std::make_unique<AstNode>();
+        DotAccessNode dn;
+        dn.object = std::move(primary);
+        dn.field = field_tok.text;
+        dot->data = std::move(dn);
+        dot->line = field_tok.line;
+        dot->col = field_tok.col;
+        primary = std::move(dot);
+    }
+    return primary;
+}
+```
+
+This requires refactoring `parse_expr()` to separate the primary-expression logic from the dot-chaining. The existing body of `parse_expr()` becomes `parse_primary()`, and `parse_expr()` calls `parse_primary()` then chains dots.
+
+- [ ] **Step 5: Build and run tests**
+
+```bash
+projects/joon/build/bin/Debug/joon-tests.exe "[shader][parser]"
+```
+Expected: all 7 parser tests pass.
+
+- [ ] **Step 6: Run full suite, verify no regressions**
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add projects/joon/src/dsl/ projects/joon/tests/test_shader_parser.cpp
+git commit -m "feat(joon): add DotAccessNode for G-buffer channel access"
+```
+
+---
+
+## Phase 2: IR Extensions
+
+### Task 3: Add Tier::MATERIAL and lower `shader` op
+
+**Files:**
+- Modify: `projects/joon/src/ir/node.h`
+- Modify: `projects/joon/include/joon/types.h`
+- Modify: `projects/joon/src/ir/ir_graph.cpp`
+- Modify: `projects/joon/src/ir/type_checker.cpp`
+- Modify: `projects/joon/tests/test_shader_parser.cpp` (add IR tests here)
+
+- [ ] **Step 1: Write failing test**
+
+Add to `tests/test_shader_parser.cpp`:
+```cpp
+TEST_CASE("shader op lowers to MATERIAL tier", "[shader][ir]") {
+    auto ctx = joon::Context::create();
+    auto graph = ctx->parse_string(R"(
+        (def mat (shader
+          :fragment (fn [normal uv] -> [albedo vec4]
+            (set albedo [1 0 0 1]))))
+    )");
+    REQUIRE_FALSE(graph.has_errors());
+
+    auto& ir = graph.ir();
+    bool found_material = false;
+    for (auto& n : ir.nodes) {
+        if (n.tier == joon::Tier::MATERIAL) {
+            found_material = true;
+            CHECK(n.op == "shader");
+            CHECK(n.output_type == joon::Type::MATERIAL);
+        }
+    }
+    CHECK(found_material);
+}
+```
+
+- [ ] **Step 2: Build, verify compile error (Tier::MATERIAL, Type::MATERIAL undefined)**
+
+- [ ] **Step 3: Add Tier::MATERIAL and Type::MATERIAL**
+
+In `src/ir/node.h`, update the Tier enum. Insert MATERIAL between GPU and SCENE to maintain the execution order comment:
+```cpp
+enum class Tier { CPU, GPU, MATERIAL, SCENE, RENDER };
+```
+
+In `include/joon/types.h`, add to the Type enum:
+```cpp
+MATERIAL
+```
+
+- [ ] **Step 4: Add ShaderDef struct to IR Node for storing shader function ASTs**
+
+In `src/ir/node.h`, add a struct to hold the parsed shader functions:
+```cpp
+struct ShaderFnDef {
+    std::vector<std::string> params;
+    struct Output { std::string name; std::string type_name; };
+    std::vector<Output> outputs;
+    std::vector<AstPtr> body;  // raw AST subtrees — processed by shader analyzer
+};
+
+struct ShaderDef {
+    std::optional<ShaderFnDef> vertex;
+    std::optional<ShaderFnDef> fragment;
+    std::optional<ShaderFnDef> brdf;
+};
+```
+
+Add `#include <optional>` and `#include "dsl/ast.h"` to node.h. Add to the `Node` struct:
+```cpp
+std::optional<ShaderDef> shader_def;
+```
+
+- [ ] **Step 5: Lower `shader` calls to MATERIAL tier in IR graph**
+
+In `src/ir/ir_graph.cpp`, add `"shader"` to a new MATERIAL_OPS set alongside the existing SCENE_OPS and RENDER_OPS:
+
+```cpp
+static const std::unordered_set<std::string> MATERIAL_OPS{ "shader" };
+```
+
+In the tier classification block:
+```cpp
+} else if (MATERIAL_OPS.count(call->op)) {
+    tier = Tier::MATERIAL;
+    output_type = Type::MATERIAL;
+```
+
+Then, after creating the node and processing kwargs, extract FnNode kwargs into the ShaderDef:
+
+```cpp
+if (call->op == "shader") {
+    ShaderDef sd;
+    for (auto& kw : call->kwargs) {
+        auto* fn = std::get_if<FnNode>(&kw.value->data);
+        if (!fn) continue;
+        ShaderFnDef fndef;
+        fndef.params = fn->params;
+        for (auto& o : fn->outputs)
+            fndef.outputs.push_back({o.name, o.type_name});
+        fndef.body = std::move(fn->body);  // take ownership of AST
+        if (kw.name == "vertex") sd.vertex = std::move(fndef);
+        else if (kw.name == "fragment") sd.fragment = std::move(fndef);
+        else if (kw.name == "brdf") sd.brdf = std::move(fndef);
+    }
+    nodes[id].shader_def = std::move(sd);
+}
+```
+
+Note: `fn->body` uses `std::move` on the AstPtr vector elements. Since `kw.value` is already an owned `AstPtr`, this transfer is safe. However, the FnNode stored inside `kw.value` will have its body emptied. This is fine because the shader node doesn't use kwargs for anything else.
+
+- [ ] **Step 6: Update type checker to handle MATERIAL type**
+
+In `src/ir/type_checker.cpp`, add a case for the `shader` op that sets output type to `Type::MATERIAL`:
+
+```cpp
+if (node.op == "shader") {
+    node.output_type = Type::MATERIAL;
+    continue;
+}
+```
+
+- [ ] **Step 7: Build and run shader IR tests**
+
+```bash
+projects/joon/build/bin/Debug/joon-tests.exe "[shader][ir]"
+```
+Expected: 1 test passes.
+
+- [ ] **Step 8: Run full suite, verify no regressions**
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add projects/joon/src/ir/ projects/joon/include/joon/types.h projects/joon/tests/test_shader_parser.cpp
+git commit -m "feat(joon): add Tier::MATERIAL and lower shader op to MATERIAL tier"
+```
+
+---
+
+## Phase 3: Shader IR & Analysis
+
+### Task 4: Define ShaderIR expression tree types
+
+**Files:**
+- Create: `projects/joon/src/shader/shader_ir.h`
+- Create: `projects/joon/tests/test_shader_ir.cpp`
+
+- [ ] **Step 1: Write failing test**
+
+```cpp
+// tests/test_shader_ir.cpp
+#include "catch_amalgamated.hpp"
+#include "shader/shader_ir.h"
+using namespace joon;
+
+TEST_CASE("ShaderExpr: literal float", "[shader][ir]") {
+    ShaderExpr e = ShaderLiteral{1.5f};
+    CHECK(std::get<ShaderLiteral>(e).value == Approx(1.5f));
+}
+
+TEST_CASE("ShaderExpr: binary add", "[shader][ir]") {
+    auto a = std::make_unique<ShaderExpr>(ShaderLiteral{1.0f});
+    auto b = std::make_unique<ShaderExpr>(ShaderLiteral{2.0f});
+    ShaderExpr e = ShaderCall{"+", {std::move(a), std::move(b)}, {}};
+    auto& call = std::get<ShaderCall>(e);
+    CHECK(call.op == "+");
+    CHECK(call.args.size() == 2);
+}
+
+TEST_CASE("ShaderExpr: noise with kwargs", "[shader][ir]") {
+    ShaderExpr e = ShaderCall{"noise", {}, {{"scale", 4.0f}, {"octaves", 3.0f}}};
+    auto& call = std::get<ShaderCall>(e);
+    CHECK(call.kwargs.size() == 2);
+    CHECK(call.kwargs[0].first == "scale");
+}
+
+TEST_CASE("ShaderExpr: variable reference", "[shader][ir]") {
+    ShaderExpr e = ShaderVar{"normal"};
+    CHECK(std::get<ShaderVar>(e).name == "normal");
+}
+
+TEST_CASE("ShaderExpr: assignment", "[shader][ir]") {
+    auto val = std::make_unique<ShaderExpr>(ShaderLiteral{1.0f});
+    ShaderExpr e = ShaderAssign{"albedo", std::move(val)};
+    CHECK(std::get<ShaderAssign>(e).target == "albedo");
+}
+
+TEST_CASE("ShaderExpr: vector constructor", "[shader][ir]") {
+    std::vector<std::unique_ptr<ShaderExpr>> elems;
+    elems.push_back(std::make_unique<ShaderExpr>(ShaderLiteral{1.0f}));
+    elems.push_back(std::make_unique<ShaderExpr>(ShaderLiteral{0.0f}));
+    elems.push_back(std::make_unique<ShaderExpr>(ShaderLiteral{0.0f}));
+    ShaderExpr e = ShaderVecConstruct{std::move(elems)};
+    CHECK(std::get<ShaderVecConstruct>(e).elements.size() == 3);
+}
+
+TEST_CASE("ShaderExpr: dot access", "[shader][ir]") {
+    auto obj = std::make_unique<ShaderExpr>(ShaderVar{"pos"});
+    ShaderExpr e = ShaderDotAccess{std::move(obj), "y"};
+    CHECK(std::get<ShaderDotAccess>(e).field == "y");
+}
+
+TEST_CASE("ShaderExpr: prepass texture sample", "[shader][ir]") {
+    ShaderExpr e = ShaderPrepassSample{0};
+    CHECK(std::get<ShaderPrepassSample>(e).prepass_index == 0);
+}
+```
+
+- [ ] **Step 2: Build, verify compile error (shader_ir.h doesn't exist)**
+
+- [ ] **Step 3: Implement ShaderIR types**
+
+```cpp
+// src/shader/shader_ir.h
+#pragma once
+#include <string>
+#include <vector>
+#include <variant>
+#include <memory>
+#include <utility>
+
+namespace joon {
+
+struct ShaderLiteral { float value; };
+struct ShaderVar { std::string name; };
+
+struct ShaderCall;
+struct ShaderAssign;
+struct ShaderVecConstruct;
+struct ShaderDotAccess;
+struct ShaderPrepassSample;
+
+using ShaderExpr = std::variant<
+    ShaderLiteral,
+    ShaderVar,
+    ShaderCall,
+    ShaderAssign,
+    ShaderVecConstruct,
+    ShaderDotAccess,
+    ShaderPrepassSample
+>;
+
+using ShaderExprPtr = std::unique_ptr<ShaderExpr>;
+
+struct ShaderCall {
+    std::string op;
+    std::vector<ShaderExprPtr> args;
+    std::vector<std::pair<std::string, float>> kwargs;
+};
+
+struct ShaderAssign {
+    std::string target;
+    ShaderExprPtr value;
+};
+
+struct ShaderVecConstruct {
+    std::vector<ShaderExprPtr> elements;
+};
+
+struct ShaderDotAccess {
+    ShaderExprPtr object;
+    std::string field;
+};
+
+struct ShaderPrepassSample {
+    uint32_t prepass_index;
+};
+
+struct ShaderFnOutput {
+    std::string name;
+    std::string type_name;
+};
+
+struct ShaderFnIR {
+    std::vector<std::string> params;
+    std::vector<ShaderFnOutput> outputs;
+    std::vector<ShaderExprPtr> body;
+};
+
+enum class ShaderOpKind { INLINEABLE, PREPASS_REQUIRED, UNKNOWN };
+
+struct ShaderIR {
+    std::optional<ShaderFnIR> vertex;
+    std::optional<ShaderFnIR> fragment;
+    std::optional<ShaderFnIR> brdf;
+};
+
+} // namespace joon
+```
+
+- [ ] **Step 4: Build and run tests**
+
+```bash
+projects/joon/build/bin/Debug/joon-tests.exe "[shader][ir]"
+```
+Expected: 8 tests pass.
+
+- [ ] **Step 5: Run full suite, verify no regressions**
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add projects/joon/src/shader/shader_ir.h projects/joon/tests/test_shader_ir.cpp
+git commit -m "feat(joon): define ShaderIR expression tree types"
+```
+
+---
+
+### Task 5: Shader analyzer — build ShaderIR from AST and classify ops
+
+**Files:**
+- Create: `projects/joon/src/shader/shader_analyzer.h`
+- Create: `projects/joon/src/shader/shader_analyzer.cpp`
+- Modify: `projects/joon/tests/test_shader_ir.cpp`
+
+- [ ] **Step 1: Write failing tests**
+
+Add to `tests/test_shader_ir.cpp`:
+
+```cpp
+#include "shader/shader_analyzer.h"
+#include "ir/node.h"
+
+TEST_CASE("Analyzer builds ShaderIR from ShaderDef", "[shader][analyzer]") {
+    // Simulate a parsed shader with a simple fragment body: (set albedo [1 0 0 1])
+    ShaderDef sd;
+    ShaderFnDef frag;
+    frag.params = {"normal", "uv"};
+    frag.outputs = {{"albedo", "vec4"}};
+
+    // Build AST for (set albedo [1 0 0 1])
+    auto vec = std::make_unique<AstNode>();
+    VectorNode vn;
+    for (float v : {1.0f, 0.0f, 0.0f, 1.0f}) {
+        auto num = std::make_unique<AstNode>();
+        num->data = NumberNode{v};
+        vn.elements.push_back(std::move(num));
+    }
+    vec->data = std::move(vn);
+
+    auto set_call = std::make_unique<AstNode>();
+    CallNode cn;
+    cn.op = "set";
+    auto target = std::make_unique<AstNode>();
+    target->data = SymbolNode{"albedo"};
+    cn.args.push_back(std::move(target));
+    cn.args.push_back(std::move(vec));
+    set_call->data = std::move(cn);
+
+    frag.body.push_back(std::move(set_call));
+    sd.fragment = std::move(frag);
+
+    ShaderAnalyzer analyzer;
+    auto ir = analyzer.analyze(sd);
+
+    REQUIRE(ir.fragment.has_value());
+    CHECK(ir.fragment->params.size() == 2);
+    CHECK(ir.fragment->outputs.size() == 1);
+    CHECK(ir.fragment->body.size() == 1);
+
+    auto* assign = std::get_if<ShaderAssign>(ir.fragment->body[0].get());
+    REQUIRE(assign != nullptr);
+    CHECK(assign->target == "albedo");
+}
+
+TEST_CASE("Op classification: inlineable ops", "[shader][analyzer]") {
+    ShaderAnalyzer analyzer;
+    CHECK(analyzer.classify("sin") == ShaderOpKind::INLINEABLE);
+    CHECK(analyzer.classify("dot") == ShaderOpKind::INLINEABLE);
+    CHECK(analyzer.classify("noise") == ShaderOpKind::INLINEABLE);
+    CHECK(analyzer.classify("+") == ShaderOpKind::INLINEABLE);
+    CHECK(analyzer.classify("mix") == ShaderOpKind::INLINEABLE);
+    CHECK(analyzer.classify("step") == ShaderOpKind::INLINEABLE);
+    CHECK(analyzer.classify("encode") == ShaderOpKind::INLINEABLE);
+}
+
+TEST_CASE("Op classification: prepass-required ops", "[shader][analyzer]") {
+    ShaderAnalyzer analyzer;
+    CHECK(analyzer.classify("blur") == ShaderOpKind::PREPASS_REQUIRED);
+    CHECK(analyzer.classify("levels") == ShaderOpKind::PREPASS_REQUIRED);
+    CHECK(analyzer.classify("blend") == ShaderOpKind::PREPASS_REQUIRED);
+}
+
+TEST_CASE("Op classification: unknown ops", "[shader][analyzer]") {
+    ShaderAnalyzer analyzer;
+    CHECK(analyzer.classify("foobar") == ShaderOpKind::UNKNOWN);
+}
+```
+
+- [ ] **Step 2: Build, verify compile error**
+
+- [ ] **Step 3: Implement ShaderAnalyzer**
+
+```cpp
+// src/shader/shader_analyzer.h
+#pragma once
+#include "shader/shader_ir.h"
+#include "ir/node.h"
+#include "dsl/ast.h"
+#include <unordered_set>
+
+namespace joon {
+
+class ShaderAnalyzer {
+public:
+    ShaderIR analyze(const ShaderDef& sd);
+    ShaderOpKind classify(const std::string& op) const;
+
+private:
+    ShaderExprPtr convert_expr(const AstNode& ast);
+    ShaderFnIR convert_fn(const ShaderFnDef& fndef);
+
+    static const std::unordered_set<std::string> INLINEABLE_OPS;
+    static const std::unordered_set<std::string> PREPASS_OPS;
+};
+
+} // namespace joon
+```
+
+```cpp
+// src/shader/shader_analyzer.cpp
+#include "shader/shader_analyzer.h"
+
+namespace joon {
+
+const std::unordered_set<std::string> ShaderAnalyzer::INLINEABLE_OPS = {
+    "+", "-", "*", "/",
+    "pow", "sqrt", "abs", "floor", "ceil", "fract", "mod", "clamp", "min", "max",
+    "sin", "cos", "tan", "asin", "acos", "atan", "atan2",
+    "dot", "cross", "normalize", "length", "reflect", "refract",
+    "mix", "step", "smoothstep",
+    "noise", "fbm", "voronoi",
+    "sample", "encode", "decode",
+    "set"
+};
+
+const std::unordered_set<std::string> ShaderAnalyzer::PREPASS_OPS = {
+    "blur", "levels", "blend", "threshold", "invert"
+};
+
+ShaderOpKind ShaderAnalyzer::classify(const std::string& op) const {
+    if (INLINEABLE_OPS.count(op)) return ShaderOpKind::INLINEABLE;
+    if (PREPASS_OPS.count(op)) return ShaderOpKind::PREPASS_REQUIRED;
+    return ShaderOpKind::UNKNOWN;
+}
+
+ShaderExprPtr ShaderAnalyzer::convert_expr(const AstNode& ast) {
+    if (auto* num = std::get_if<NumberNode>(&ast.data)) {
+        return std::make_unique<ShaderExpr>(ShaderLiteral{static_cast<float>(num->value)});
+    }
+    if (auto* sym = std::get_if<SymbolNode>(&ast.data)) {
+        return std::make_unique<ShaderExpr>(ShaderVar{sym->name});
+    }
+    if (auto* vec = std::get_if<VectorNode>(&ast.data)) {
+        ShaderVecConstruct vc;
+        for (auto& e : vec->elements)
+            vc.elements.push_back(convert_expr(*e));
+        return std::make_unique<ShaderExpr>(std::move(vc));
+    }
+    if (auto* dot = std::get_if<DotAccessNode>(&ast.data)) {
+        ShaderDotAccess da;
+        da.object = convert_expr(*dot->object);
+        da.field = dot->field;
+        return std::make_unique<ShaderExpr>(std::move(da));
+    }
+    if (auto* call = std::get_if<CallNode>(&ast.data)) {
+        if (call->op == "set") {
+            ShaderAssign sa;
+            if (!call->args.empty()) {
+                if (auto* target_sym = std::get_if<SymbolNode>(&call->args[0]->data))
+                    sa.target = target_sym->name;
+                else if (auto* target_dot = std::get_if<DotAccessNode>(&call->args[0]->data))
+                    sa.target = target_dot->field; // simplified: pos.y → target="pos.y"
+            }
+            if (call->args.size() > 1)
+                sa.value = convert_expr(*call->args[1]);
+            return std::make_unique<ShaderExpr>(std::move(sa));
+        }
+
+        ShaderCall sc;
+        sc.op = call->op;
+        for (auto& a : call->args)
+            sc.args.push_back(convert_expr(*a));
+        for (auto& kw : call->kwargs) {
+            if (auto* knum = std::get_if<NumberNode>(&kw.value->data))
+                sc.kwargs.push_back({kw.name, static_cast<float>(knum->value)});
+        }
+        return std::make_unique<ShaderExpr>(std::move(sc));
+    }
+    return std::make_unique<ShaderExpr>(ShaderLiteral{0.0f});
+}
+
+ShaderFnIR ShaderAnalyzer::convert_fn(const ShaderFnDef& fndef) {
+    ShaderFnIR fn;
+    fn.params = fndef.params;
+    for (auto& o : fndef.outputs)
+        fn.outputs.push_back({o.name, o.type_name});
+    for (auto& stmt : fndef.body)
+        fn.body.push_back(convert_expr(*stmt));
+    return fn;
+}
+
+ShaderIR ShaderAnalyzer::analyze(const ShaderDef& sd) {
+    ShaderIR ir;
+    if (sd.vertex) ir.vertex = convert_fn(*sd.vertex);
+    if (sd.fragment) ir.fragment = convert_fn(*sd.fragment);
+    if (sd.brdf) ir.brdf = convert_fn(*sd.brdf);
+    return ir;
+}
+
+} // namespace joon
+```
+
+- [ ] **Step 4: Build and run tests**
+
+```bash
+projects/joon/build/bin/Debug/joon-tests.exe "[shader][analyzer]"
+```
+Expected: 4 tests pass.
+
+- [ ] **Step 5: Run full suite**
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add projects/joon/src/shader/ projects/joon/tests/test_shader_ir.cpp
+git commit -m "feat(joon): shader analyzer builds ShaderIR from AST and classifies ops"
+```
+
+---
+
+## Phase 4: HLSL Code Generation
+
+### Task 6: HLSL emitter — fragment shader generation
+
+**Files:**
+- Create: `projects/joon/src/shader/hlsl_emitter.h`
+- Create: `projects/joon/src/shader/hlsl_emitter.cpp`
+- Create: `projects/joon/src/shader/noise_hlsl.h`
+- Create: `projects/joon/tests/test_hlsl_emitter.cpp`
+
+- [ ] **Step 1: Write failing tests**
+
+```cpp
+// tests/test_hlsl_emitter.cpp
+#include "catch_amalgamated.hpp"
+#include "shader/hlsl_emitter.h"
+#include "shader/shader_ir.h"
+using namespace joon;
+
+TEST_CASE("Emit literal", "[shader][hlsl]") {
+    HlslEmitter emitter;
+    ShaderExpr e = ShaderLiteral{1.5f};
+    auto code = emitter.emit_expr(e);
+    CHECK(code == "1.500000");
+}
+
+TEST_CASE("Emit binary op", "[shader][hlsl]") {
+    HlslEmitter emitter;
+    auto a = std::make_unique<ShaderExpr>(ShaderLiteral{1.0f});
+    auto b = std::make_unique<ShaderExpr>(ShaderLiteral{2.0f});
+    ShaderExpr e = ShaderCall{"+", {std::move(a), std::move(b)}, {}};
+    auto code = emitter.emit_expr(e);
+    CHECK(code == "(1.000000 + 2.000000)");
+}
+
+TEST_CASE("Emit function call", "[shader][hlsl]") {
+    HlslEmitter emitter;
+    auto arg = std::make_unique<ShaderExpr>(ShaderVar{"x"});
+    ShaderExpr e = ShaderCall{"sin", {std::move(arg)}, {}};
+    auto code = emitter.emit_expr(e);
+    CHECK(code == "sin(x)");
+}
+
+TEST_CASE("Emit mix maps to lerp", "[shader][hlsl]") {
+    HlslEmitter emitter;
+    auto a = std::make_unique<ShaderExpr>(ShaderVar{"a"});
+    auto b = std::make_unique<ShaderExpr>(ShaderVar{"b"});
+    auto t = std::make_unique<ShaderExpr>(ShaderVar{"t"});
+    ShaderExpr e = ShaderCall{"mix", {std::move(a), std::move(b), std::move(t)}, {}};
+    auto code = emitter.emit_expr(e);
+    CHECK(code == "lerp(a, b, t)");
+}
+
+TEST_CASE("Emit vector constructor", "[shader][hlsl]") {
+    HlslEmitter emitter;
+    ShaderVecConstruct vc;
+    vc.elements.push_back(std::make_unique<ShaderExpr>(ShaderLiteral{1.0f}));
+    vc.elements.push_back(std::make_unique<ShaderExpr>(ShaderLiteral{0.0f}));
+    vc.elements.push_back(std::make_unique<ShaderExpr>(ShaderLiteral{0.0f}));
+    ShaderExpr e = std::move(vc);
+    auto code = emitter.emit_expr(e);
+    CHECK(code == "float3(1.000000, 0.000000, 0.000000)");
+}
+
+TEST_CASE("Emit encode normal", "[shader][hlsl]") {
+    HlslEmitter emitter;
+    auto n = std::make_unique<ShaderExpr>(ShaderVar{"normal"});
+    ShaderExpr e = ShaderCall{"encode", {std::move(n)}, {}};
+    auto code = emitter.emit_expr(e);
+    CHECK(code == "float4(normal * 0.5 + 0.5, 1.0)");
+}
+
+TEST_CASE("Emit complete fragment shader", "[shader][hlsl]") {
+    HlslEmitter emitter;
+    ShaderFnIR frag;
+    frag.params = {"normal", "uv"};
+    frag.outputs = {{"albedo", "vec4"}, {"normal_out", "vec4"}};
+
+    // (set albedo [1 0 0 1])
+    ShaderVecConstruct vc;
+    vc.elements.push_back(std::make_unique<ShaderExpr>(ShaderLiteral{1.0f}));
+    vc.elements.push_back(std::make_unique<ShaderExpr>(ShaderLiteral{0.0f}));
+    vc.elements.push_back(std::make_unique<ShaderExpr>(ShaderLiteral{0.0f}));
+    vc.elements.push_back(std::make_unique<ShaderExpr>(ShaderLiteral{1.0f}));
+    ShaderAssign sa;
+    sa.target = "albedo";
+    sa.value = std::make_unique<ShaderExpr>(std::move(vc));
+    frag.body.push_back(std::make_unique<ShaderExpr>(std::move(sa)));
+
+    auto hlsl = emitter.emit_fragment(frag, 0);
+    CHECK(hlsl.find("struct PSOut") != std::string::npos);
+    CHECK(hlsl.find("SV_TARGET0") != std::string::npos);
+    CHECK(hlsl.find("SV_TARGET1") != std::string::npos);
+    CHECK(hlsl.find("o.albedo") != std::string::npos);
+}
+```
+
+- [ ] **Step 2: Build, verify compile error**
+
+- [ ] **Step 3: Create noise HLSL helper**
+
+```cpp
+// src/shader/noise_hlsl.h
+#pragma once
+
+namespace joon {
+
+inline const char* NOISE_HLSL_FUNCTIONS = R"(
+float hash31(float3 p) {
+    p = frac(p * float3(443.8975, 397.2973, 491.1871));
+    p += dot(p, p.yzx + 19.19);
+    return frac((p.x + p.y) * p.z);
+}
+
+float noise3d(float3 p) {
+    float3 i = floor(p);
+    float3 f = frac(p);
+    f = f * f * (3.0 - 2.0 * f);
+    return lerp(
+        lerp(lerp(hash31(i), hash31(i + float3(1,0,0)), f.x),
+             lerp(hash31(i + float3(0,1,0)), hash31(i + float3(1,1,0)), f.x), f.y),
+        lerp(lerp(hash31(i + float3(0,0,1)), hash31(i + float3(1,0,1)), f.x),
+             lerp(hash31(i + float3(0,1,1)), hash31(i + float3(1,1,1)), f.x), f.y),
+        f.z);
+}
+
+float fbm(float3 p, int octaves) {
+    float val = 0.0;
+    float amp = 0.5;
+    float freq = 1.0;
+    for (int i = 0; i < octaves; i++) {
+        val += amp * noise3d(p * freq);
+        freq *= 2.0;
+        amp *= 0.5;
+    }
+    return val;
+}
+)";
+
+} // namespace joon
+```
+
+- [ ] **Step 4: Implement HlslEmitter**
+
+```cpp
+// src/shader/hlsl_emitter.h
+#pragma once
+#include "shader/shader_ir.h"
+#include <string>
+
+namespace joon {
+
+class HlslEmitter {
+public:
+    std::string emit_expr(const ShaderExpr& expr);
+    std::string emit_fragment(const ShaderFnIR& fn, uint32_t prepass_count);
+    std::string emit_vertex(const ShaderFnIR& fn);
+
+private:
+    std::string emit_call(const ShaderCall& call);
+    std::string emit_assign(const ShaderAssign& assign, bool is_fragment);
+    std::string emit_vec(const ShaderVecConstruct& vc);
+    std::string emit_dot(const ShaderDotAccess& da);
+
+    static const std::unordered_map<std::string, std::string> OP_RENAMES;
+    static const std::unordered_set<std::string> BINARY_OPS;
+};
+
+} // namespace joon
+```
+
+```cpp
+// src/shader/hlsl_emitter.cpp
+#include "shader/hlsl_emitter.h"
+#include "shader/noise_hlsl.h"
+#include <sstream>
+#include <unordered_map>
+#include <unordered_set>
+
+namespace joon {
+
+const std::unordered_map<std::string, std::string> HlslEmitter::OP_RENAMES = {
+    {"mix", "lerp"}, {"fract", "frac"}, {"mod", "fmod"},
+    {"atan2", "atan2"}, {"encode", "__encode_normal"},
+    {"decode", "__decode_normal"},
+};
+
+const std::unordered_set<std::string> HlslEmitter::BINARY_OPS = {
+    "+", "-", "*", "/"
+};
+
+std::string HlslEmitter::emit_expr(const ShaderExpr& expr) {
+    if (auto* lit = std::get_if<ShaderLiteral>(&expr)) {
+        char buf[32];
+        snprintf(buf, sizeof(buf), "%f", lit->value);
+        return buf;
+    }
+    if (auto* var = std::get_if<ShaderVar>(&expr))
+        return var->name;
+    if (auto* call = std::get_if<ShaderCall>(&expr))
+        return emit_call(*call);
+    if (auto* assign = std::get_if<ShaderAssign>(&expr))
+        return emit_assign(*assign, true);
+    if (auto* vc = std::get_if<ShaderVecConstruct>(&expr))
+        return emit_vec(*vc);
+    if (auto* da = std::get_if<ShaderDotAccess>(&expr))
+        return emit_dot(*da);
+    if (auto* ps = std::get_if<ShaderPrepassSample>(&expr)) {
+        std::ostringstream ss;
+        ss << "__prepass_" << ps->prepass_index
+           << ".Sample(__sampler_" << ps->prepass_index << ", uv)";
+        return ss.str();
+    }
+    return "0.0";
+}
+
+std::string HlslEmitter::emit_call(const ShaderCall& call) {
+    if (call.op == "encode" && call.args.size() == 1) {
+        return "float4(" + emit_expr(*call.args[0]) + " * 0.5 + 0.5, 1.0)";
+    }
+    if (call.op == "decode" && call.args.size() == 1) {
+        return "(" + emit_expr(*call.args[0]) + ".xyz * 2.0 - 1.0)";
+    }
+    if (call.op == "noise") {
+        float scale = 1.0f, octaves = 4.0f;
+        for (auto& kw : call.kwargs) {
+            if (kw.first == "scale") scale = kw.second;
+            if (kw.first == "octaves") octaves = kw.second;
+        }
+        std::ostringstream ss;
+        ss << "fbm(world_pos * " << scale << ", " << static_cast<int>(octaves) << ")";
+        return ss.str();
+    }
+
+    if (BINARY_OPS.count(call.op) && call.args.size() == 2) {
+        return "(" + emit_expr(*call.args[0]) + " " + call.op + " " + emit_expr(*call.args[1]) + ")";
+    }
+
+    std::string name = call.op;
+    auto rename = OP_RENAMES.find(call.op);
+    if (rename != OP_RENAMES.end()) name = rename->second;
+
+    std::ostringstream ss;
+    ss << name << "(";
+    for (size_t i = 0; i < call.args.size(); i++) {
+        if (i > 0) ss << ", ";
+        ss << emit_expr(*call.args[i]);
+    }
+    ss << ")";
+    return ss.str();
+}
+
+std::string HlslEmitter::emit_assign(const ShaderAssign& assign, bool is_fragment) {
+    std::string prefix = is_fragment ? "o." : "";
+    return prefix + assign.target + " = " + emit_expr(*assign.value);
+}
+
+std::string HlslEmitter::emit_vec(const ShaderVecConstruct& vc) {
+    std::ostringstream ss;
+    ss << "float" << vc.elements.size() << "(";
+    for (size_t i = 0; i < vc.elements.size(); i++) {
+        if (i > 0) ss << ", ";
+        ss << emit_expr(*vc.elements[i]);
+    }
+    ss << ")";
+    return ss.str();
+}
+
+std::string HlslEmitter::emit_dot(const ShaderDotAccess& da) {
+    return emit_expr(*da.object) + "." + da.field;
+}
+
+std::string HlslEmitter::emit_fragment(const ShaderFnIR& fn, uint32_t prepass_count) {
+    std::ostringstream ss;
+
+    // Output struct
+    ss << "struct PSOut {\n";
+    for (size_t i = 0; i < fn.outputs.size(); i++) {
+        std::string hlsl_type = (fn.outputs[i].type_name == "vec4") ? "float4" :
+                                 (fn.outputs[i].type_name == "vec3") ? "float3" :
+                                 (fn.outputs[i].type_name == "vec2") ? "float2" : "float";
+        ss << "    " << hlsl_type << " " << fn.outputs[i].name
+           << " : SV_TARGET" << i << ";\n";
+    }
+    ss << "};\n\n";
+
+    // Input struct
+    ss << "struct PSIn {\n"
+       << "    float4 sv : SV_POSITION;\n"
+       << "    float3 normal : NORMAL;\n"
+       << "    float2 uv : TEXCOORD0;\n"
+       << "    float3 world_pos : TEXCOORD1;\n"
+       << "};\n\n";
+
+    // Fragment UBO for time
+    ss << "struct FragUBO { float time; float3 pad; };\n"
+       << "[[vk::binding(0, 1)]] ConstantBuffer<FragUBO> frag_ubo;\n\n";
+
+    // Pre-pass textures
+    for (uint32_t i = 0; i < prepass_count; i++) {
+        uint32_t binding = 1 + i * 2;
+        ss << "[[vk::binding(" << binding << ", 1)]] Texture2D __prepass_" << i << ";\n";
+        ss << "[[vk::binding(" << (binding + 1) << ", 1)]] SamplerState __sampler_" << i << ";\n";
+    }
+    if (prepass_count > 0) ss << "\n";
+
+    // Noise helpers (if needed)
+    // TODO: only emit if noise/fbm is used in the body
+    ss << NOISE_HLSL_FUNCTIONS << "\n";
+
+    // Main function
+    ss << "PSOut main(PSIn i) {\n";
+    ss << "    float3 normal = normalize(i.normal);\n";
+    ss << "    float2 uv = i.uv;\n";
+    ss << "    float3 world_pos = i.world_pos;\n";
+    ss << "    float time = frag_ubo.time;\n";
+    ss << "    PSOut o;\n";
+
+    for (auto& stmt : fn.body) {
+        ss << "    " << emit_expr(*stmt) << ";\n";
+    }
+
+    ss << "    return o;\n";
+    ss << "}\n";
+    return ss.str();
+}
+
+std::string HlslEmitter::emit_vertex(const ShaderFnIR& fn) {
+    std::ostringstream ss;
+
+    ss << "struct UBO { float4x4 mvp; float4x4 model; float time; float3 pad; };\n";
+    ss << "[[vk::binding(0, 0)]] ConstantBuffer<UBO> ubo;\n\n";
+
+    ss << "struct VSIn  { float3 pos : POSITION; float3 nrm : NORMAL; float2 uv : TEXCOORD0; };\n";
+    ss << "struct VSOut { float4 sv : SV_POSITION; float3 normal : NORMAL; float2 uv : TEXCOORD0; float3 world_pos : TEXCOORD1; };\n\n";
+
+    ss << "VSOut main(VSIn v) {\n";
+    ss << "    float3 pos = v.pos;\n";
+    ss << "    float3 normal = v.nrm;\n";
+    ss << "    float2 uv = v.uv;\n";
+    ss << "    float time = ubo.time;\n";
+
+    for (auto& stmt : fn.body) {
+        ss << "    " << emit_expr(*stmt) << ";\n";
+    }
+
+    ss << "    VSOut o;\n";
+    ss << "    o.sv = mul(ubo.mvp, float4(pos, 1.0));\n";
+    ss << "    o.normal = normalize(mul((float3x3)ubo.model, normal));\n";
+    ss << "    o.uv = uv;\n";
+    ss << "    o.world_pos = mul(ubo.model, float4(pos, 1.0)).xyz;\n";
+    ss << "    return o;\n";
+    ss << "}\n";
+    return ss.str();
+}
+
+} // namespace joon
+```
+
+- [ ] **Step 5: Build and run HLSL emitter tests**
+
+```bash
+projects/joon/build/bin/Debug/joon-tests.exe "[shader][hlsl]"
+```
+Expected: 7 tests pass.
+
+- [ ] **Step 6: Run full suite**
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add projects/joon/src/shader/ projects/joon/tests/test_hlsl_emitter.cpp
+git commit -m "feat(joon): HLSL emitter generates fragment and vertex shaders from ShaderIR"
+```
+
+---
+
+### Task 7: PipelineCache — accept generated HLSL source strings
+
+**Files:**
+- Modify: `projects/joon/src/vulkan/pipeline_cache.h`
+- Modify: `projects/joon/src/vulkan/pipeline_cache.cpp`
+
+- [ ] **Step 1: Write failing test**
+
+Add to `tests/test_hlsl_emitter.cpp`:
+
+```cpp
+#include <joon/joon.h>
+
+TEST_CASE("PipelineCache compiles generated HLSL source", "[shader][pipeline][gpu]") {
+    auto ctx = joon::Context::create();
+    auto& cache = ctx->pipeline_cache();
+
+    std::string vert_src = R"(
+struct UBO { float4x4 mvp; float4x4 model; float time; float3 pad; };
+[[vk::binding(0, 0)]] ConstantBuffer<UBO> ubo;
+struct VSIn  { float3 pos : POSITION; float3 nrm : NORMAL; float2 uv : TEXCOORD0; };
+struct VSOut { float4 sv : SV_POSITION; float3 normal : NORMAL; float2 uv : TEXCOORD0; float3 world_pos : TEXCOORD1; };
+VSOut main(VSIn v) {
+    VSOut o;
+    o.sv = mul(ubo.mvp, float4(v.pos, 1.0));
+    o.normal = normalize(mul((float3x3)ubo.model, v.nrm));
+    o.uv = v.uv;
+    o.world_pos = mul(ubo.model, float4(v.pos, 1.0)).xyz;
+    return o;
+}
+)";
+
+    std::string frag_src = R"(
+struct PSOut { float4 albedo : SV_TARGET0; };
+struct PSIn { float4 sv : SV_POSITION; float3 normal : NORMAL; float2 uv : TEXCOORD0; float3 world_pos : TEXCOORD1; };
+PSOut main(PSIn i) {
+    PSOut o;
+    o.albedo = float4(1, 0, 0, 1);
+    return o;
+}
+)";
+
+    // Need a render pass for the pipeline
+    auto rp = joon::create_color_depth_renderpass(ctx->device(), {VK_FORMAT_R8G8B8A8_UNORM});
+    auto& gp = cache.get_graphics_from_source("test_gen", vert_src, frag_src, rp.pass, 0);
+    CHECK(gp.pipeline != VK_NULL_HANDLE);
+    joon::destroy_renderpass(ctx->device(), rp);
+}
+```
+
+- [ ] **Step 2: Build, verify compile error (method doesn't exist)**
+
+- [ ] **Step 3: Add `get_graphics_from_source()` to PipelineCache**
+
+In `pipeline_cache.h`, add the new method declaration:
+```cpp
+const GraphicsPipeline& get_graphics_from_source(
+    const std::string& key,
+    const std::string& vert_hlsl_source,
+    const std::string& frag_hlsl_source,
+    VkRenderPass render_pass,
+    uint32_t push_constant_size = 0,
+    uint32_t num_color_attachments = 1);
+```
+
+In `pipeline_cache.cpp`, implement it. The key difference from `get_graphics()`: instead of calling `load_or_compile_stage()` with a filename, write the HLSL source to a temp file and compile that:
+
+```cpp
+const GraphicsPipeline& PipelineCache::get_graphics_from_source(
+    const std::string& key,
+    const std::string& vert_hlsl_source,
+    const std::string& frag_hlsl_source,
+    VkRenderPass render_pass,
+    uint32_t push_constant_size,
+    uint32_t num_color_attachments) {
+
+    auto it = m_graphics_pipelines.find(key);
+    if (it != m_graphics_pipelines.end()) return it->second;
+
+    // Write HLSL source to temp files, compile via DXC
+    std::string vert_tmp = m_shaderDir + "/__gen_" + key + ".vert.hlsl";
+    std::string frag_tmp = m_shaderDir + "/__gen_" + key + ".frag.hlsl";
+    std::string vert_spv = m_shaderDir + "/__gen_" + key + ".vert.spv";
+    std::string frag_spv = m_shaderDir + "/__gen_" + key + ".frag.spv";
+
+    // Write source to temp files
+    { std::ofstream f(vert_tmp); f << vert_hlsl_source; }
+    { std::ofstream f(frag_tmp); f << frag_hlsl_source; }
+
+    auto vs_spirv = compile_hlsl(vert_tmp, vert_spv, "vs_6_0");
+    auto fs_spirv = compile_hlsl(frag_tmp, frag_spv, "ps_6_0");
+
+    // Rest is identical to get_graphics() — create modules, layout, pipeline
+    // ... (reuse the same pipeline creation code, but pass num_color_attachments
+    //      for the blend state to have the right attachment count)
+
+    // Store and return
+    m_graphics_pipelines[key] = p;
+    return m_graphics_pipelines[key];
+}
+```
+
+The blend state array needs `num_color_attachments` entries instead of the hardcoded 1. Extract the pipeline-creation logic from `get_graphics()` into a shared helper to avoid duplication.
+
+- [ ] **Step 4: Expose `pipeline_cache()` on Context if not already available**
+
+Check `include/joon/joon.h` for the Context class. If `pipeline_cache()` isn't public, add a method or use the test accessor pattern from sub-project 2.
+
+- [ ] **Step 5: Build and run test**
+
+```bash
+projects/joon/build/bin/Debug/joon-tests.exe "[shader][pipeline]"
+```
+Expected: 1 test passes.
+
+- [ ] **Step 6: Run full suite**
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add projects/joon/src/vulkan/pipeline_cache.* projects/joon/tests/test_hlsl_emitter.cpp
+git commit -m "feat(joon): PipelineCache accepts generated HLSL source strings"
+```
+
+---
+
+## Phase 5: MRT & Depth Sampling
+
+### Task 8: Resource pool — add sampled depth and MRT allocation
+
+**Files:**
+- Modify: `projects/joon/src/vulkan/resource_pool.h`
+- Modify: `projects/joon/src/vulkan/resource_pool.cpp`
+
+- [ ] **Step 1: Write failing test**
+
+Add to `tests/test_hlsl_emitter.cpp` (or a new test file):
+
+```cpp
+TEST_CASE("alloc_depth_sampled creates depth with SAMPLED_BIT", "[shader][gpu]") {
+    auto ctx = joon::Context::create();
+    auto& pool = ctx->pool();
+    auto* depth = pool.alloc_depth_sampled(999, 512, 512);
+    REQUIRE(depth != nullptr);
+    CHECK(depth->view != VK_NULL_HANDLE);
+    CHECK(depth->format == VK_FORMAT_D32_SFLOAT);
+}
+```
+
+- [ ] **Step 2: Build, verify compile error**
+
+- [ ] **Step 3: Implement `alloc_depth_sampled()`**
+
+In `resource_pool.h`:
+```cpp
+GpuImage* alloc_depth_sampled(uint32_t node_id, uint32_t w, uint32_t h,
+                               VkFormat format = VK_FORMAT_D32_SFLOAT);
+```
+
+In `resource_pool.cpp`, copy the existing `alloc_depth()` but add `VK_IMAGE_USAGE_SAMPLED_BIT` to the usage flags:
+```cpp
+img_info.usage = VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT
+               | VK_IMAGE_USAGE_SAMPLED_BIT;
+```
+
+- [ ] **Step 4: Build and run test**
+
+- [ ] **Step 5: Run full suite**
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add projects/joon/src/vulkan/resource_pool.*
+git commit -m "feat(joon): add alloc_depth_sampled with SAMPLED_BIT for deferred lighting"
+```
+
+---
+
+## Phase 6: Material System
+
+### Task 9: Material executor — compile shader and store pipeline
+
+**Files:**
+- Modify: `projects/joon/src/nodes/node_registry.h`
+- Modify: `projects/joon/src/nodes/node_registry.cpp`
+- Modify: `projects/joon/src/scene/scene_executors.h`
+- Modify: `projects/joon/src/scene/scene_executors.cpp`
+- Modify: `projects/joon/src/evaluator.cpp`
+- Modify: `projects/joon/src/interpreter/interpreter.cpp`
+
+- [ ] **Step 1: Write failing test**
+
+```cpp
+// Add to tests/test_shader_ir.cpp or create tests/test_deferred.cpp
+TEST_CASE("Material executor compiles shader and stores pipeline", "[shader][material][gpu]") {
+    auto ctx = joon::Context::create();
+    auto graph = ctx->parse_string(R"(
+        (def mat (shader
+          :fragment (fn [normal uv] -> [albedo vec4]
+            (set albedo [1 0 0 1]))))
+        (def c (cube :material mat))
+        (def cam (camera))
+        (def l (light))
+        (def gbuf (pass))
+        (output gbuf)
+    )");
+    REQUIRE_FALSE(graph.has_errors());
+
+    auto eval = ctx->create_evaluator(graph);
+    eval->evaluate();
+
+    auto px = eval->result("").read_pixels();
+    REQUIRE(px.size() == 512u * 512u * 4u);
+    // With a red material, we should see red pixels
+    int red_pixels = 0;
+    for (size_t i = 0; i < px.size(); i += 4)
+        if (px[i] > 0.5f && px[i+1] < 0.2f && px[i+2] < 0.2f) ++red_pixels;
+    CHECK(red_pixels > 50);
+}
+```
+
+- [ ] **Step 2: Build, verify test fails (material not processed)**
+
+- [ ] **Step 3: Extend EvalContext with material pipeline map**
+
+In `src/nodes/node_registry.h`, add to `EvalContext`:
+```cpp
+std::unordered_map<uint32_t, const GraphicsPipeline*> material_pipelines;
+```
+
+This maps material node IDs to compiled pipelines.
+
+- [ ] **Step 4: Add MATERIAL phase to interpreter**
+
+In `src/interpreter/interpreter.cpp`, add a phase between the SCENE phase and the existing CPU/GPU/RENDER phase:
+
+```cpp
+// Phase 2: MATERIAL tier — compile shaders, cache pipelines
+for (uint32_t id : order) {
+    auto& node = ir.nodes[id];
+    if (node.tier != Tier::MATERIAL) continue;
+    auto* executor = m_registry.find(node.op);
+    if (executor) (*executor)(node, m_ctx);
+}
+```
+
+- [ ] **Step 5: Implement material executor**
+
+In `src/scene/scene_executors.cpp`, add:
+
+```cpp
+#include "shader/shader_analyzer.h"
+#include "shader/hlsl_emitter.h"
+#include "vulkan/render_pass.h"
+
+static void exec_shader(const Node& n, EvalContext& ctx) {
+    if (!n.shader_def) return;
+
+    ShaderAnalyzer analyzer;
+    auto ir = analyzer.analyze(*n.shader_def);
+
+    HlslEmitter emitter;
+
+    // Generate vertex shader (use default if no custom vertex)
+    std::string vert_src;
+    if (ir.vertex) {
+        vert_src = emitter.emit_vertex(*ir.vertex);
+    } else {
+        // Default vertex shader — same as scene_basic.vert.hlsl but with world_pos
+        vert_src = emitter.emit_vertex(ShaderFnIR{{"pos", "normal", "uv"}, {}, {}});
+    }
+
+    // Generate fragment shader
+    std::string frag_src;
+    if (ir.fragment) {
+        frag_src = emitter.emit_fragment(*ir.fragment, 0);
+    } else {
+        // Default: white albedo
+        ShaderFnIR default_frag;
+        default_frag.params = {"normal", "uv"};
+        default_frag.outputs = {{"albedo", "vec4"}};
+        ShaderAssign sa;
+        sa.target = "albedo";
+        ShaderVecConstruct vc;
+        for (int i = 0; i < 4; i++)
+            vc.elements.push_back(std::make_unique<ShaderExpr>(ShaderLiteral{1.0f}));
+        sa.value = std::make_unique<ShaderExpr>(std::move(vc));
+        default_frag.body.push_back(std::make_unique<ShaderExpr>(std::move(sa)));
+        frag_src = emitter.emit_fragment(default_frag, 0);
+    }
+
+    // Compile via PipelineCache
+    std::string key = "mat_" + std::to_string(n.id);
+    uint32_t num_outputs = ir.fragment ? static_cast<uint32_t>(ir.fragment->outputs.size()) : 1;
+
+    // Create a temporary render pass matching the output count
+    std::vector<VkFormat> formats(num_outputs, VK_FORMAT_R8G8B8A8_UNORM);
+    auto rp = create_color_depth_renderpass(ctx.device, formats);
+
+    auto& gp = ctx.pipelines.get_graphics_from_source(key, vert_src, frag_src, rp.pass, 0, num_outputs);
+    ctx.material_pipelines[n.id] = &gp;
+
+    destroy_renderpass(ctx.device, rp);
+}
+```
+
+Register the executor in `register_scene_nodes()` (or create a new `register_material_nodes()`):
+```cpp
+reg.register_node("shader", exec_shader);
+```
+
+- [ ] **Step 6: Wire `:material` kwarg on scene objects**
+
+In `scene_executors.cpp`, modify `exec_cube` (and other scene executors) to read `:material` kwarg and store the material node ID on the SceneObject:
+
+```cpp
+void exec_cube(const Node& n, EvalContext& ctx) {
+    SceneObject o;
+    o.mesh = gen_cube(kwarg_float(n, "scale", 1.0f));
+    o.position = kwarg_vec3(n, "position", {0, 0, 0});
+    o.rotation = kwarg_vec3(n, "rotation", {0, 0, 0});
+    // Material kwarg — source_node points to the material node
+    for (auto& kw : n.kwargs) {
+        if (kw.name == "material" && kw.source_node != UINT32_MAX)
+            o.material_node_id = kw.source_node;
+    }
+    ctx.scene.add_object(std::move(o));
+}
+```
+
+Apply the same pattern to `exec_sphere`, `exec_plane`, `exec_cylinder`, `exec_mesh`.
+
+- [ ] **Step 7: Modify geometry pass to use per-material pipelines**
+
+In `src/scene/geometry_pass.cpp`, modify `exec_pass`:
+
+- Check if `ctx.material_pipelines` is non-empty.
+- If it is, group objects by `material_node_id` and bind the matching pipeline per group.
+- If an object has `material_node_id == UINT32_MAX` (no material), use the default `scene_basic` pipeline.
+- Create the render pass and framebuffer based on the material's output count (for now, all materials must have the same output count — the G-buffer contract).
+
+This is the most complex step. The key change: instead of one `vkCmdBindPipeline` for all draws, iterate over material groups and bind the appropriate pipeline for each.
+
+- [ ] **Step 8: Build and run test**
+
+```bash
+projects/joon/build/bin/Debug/joon-tests.exe "[shader][material]"
+```
+Expected: 1 test passes (red cube rendered via generated shader).
+
+- [ ] **Step 9: Run full suite — verify existing tests still pass**
+
+The existing `[render][gpu]` tests use `(pass)` without materials and should fall back to the hardcoded `scene_basic` pipeline.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add projects/joon/src/ projects/joon/tests/
+git commit -m "feat(joon): material executor compiles DSL shaders and renders per-material"
+```
+
+---
+
+## Phase 7: Deferred Lighting
+
+### Task 10: Fullscreen quad infrastructure
+
+**Files:**
+- Modify: `projects/joon/src/vulkan/buffer.h`, `buffer.cpp`
+- Create: `projects/joon/shaders/fullscreen.vert.hlsl`
+
+- [ ] **Step 1: Create fullscreen vertex shader**
+
+```hlsl
+// shaders/fullscreen.vert.hlsl
+struct VSOut {
+    float4 sv : SV_POSITION;
+    float2 uv : TEXCOORD0;
+};
+
+VSOut main(uint vid : SV_VertexID) {
+    VSOut o;
+    // Full-screen triangle trick: 3 vertices, no vertex buffer needed
+    o.uv = float2((vid << 1) & 2, vid & 2);
+    o.sv = float4(o.uv * 2.0 - 1.0, 0.0, 1.0);
+    o.uv.y = 1.0 - o.uv.y; // Flip Y for Vulkan
+    return o;
+}
+```
+
+- [ ] **Step 2: Verify it compiles via DXC**
+
+```bash
+"$VULKAN_SDK/Bin/dxc.exe" -T vs_6_0 -E main -spirv \
+  -fspv-target-env=vulkan1.1 \
+  projects/joon/shaders/fullscreen.vert.hlsl \
+  -Fo projects/joon/shaders/fullscreen.vert.spv
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add projects/joon/shaders/fullscreen.vert.hlsl
+git commit -m "feat(joon): fullscreen triangle vertex shader for deferred lighting"
+```
+
+---
+
+### Task 11: Default Cook-Torrance lighting pass
+
+**Files:**
+- Create: `projects/joon/shaders/deferred_default.frag.hlsl`
+- Create: `projects/joon/src/scene/lighting_pass.h`
+- Create: `projects/joon/src/scene/lighting_pass.cpp`
+- Modify: `projects/joon/include/joon/scene.h`
+- Create: `projects/joon/tests/test_lighting_pass.cpp`
+
+- [ ] **Step 1: Write failing test**
+
+```cpp
+// tests/test_lighting_pass.cpp
+#include "catch_amalgamated.hpp"
+#include <joon/joon.h>
+using namespace joon;
+
+TEST_CASE("Deferred lighting produces lit output", "[shader][lighting][gpu]") {
+    auto ctx = Context::create();
+    auto graph = ctx->parse_string(R"(
+        (def mat (shader
+          :fragment (fn [normal uv] -> [albedo vec4]
+            (set albedo [0.8 0.2 0.1 1]))))
+        (def c (cube :scale 1.5 :material mat))
+        (def cam (camera :fov 60))
+        (def l (light :intensity 1.0))
+        (def gbuf (pass))
+        (output gbuf)
+    )");
+    REQUIRE_FALSE(graph.has_errors());
+
+    auto eval = ctx->create_evaluator(graph);
+    eval->evaluate();
+
+    auto px = eval->result("").read_pixels();
+    REQUIRE(px.size() == 512u * 512u * 4u);
+
+    // Should have lit pixels (not just raw albedo — lighting applied)
+    int lit = 0;
+    for (size_t i = 0; i < px.size(); i += 4)
+        if (px[i] > 0.05f) ++lit;
+    CHECK(lit > 100);
+}
+
+TEST_CASE("Multiple lights produce brighter output", "[shader][lighting][gpu]") {
+    auto ctx = Context::create();
+    auto graph = ctx->parse_string(R"(
+        (def mat (shader
+          :fragment (fn [normal uv] -> [albedo vec4]
+            (set albedo [0.5 0.5 0.5 1]))))
+        (def c (cube :material mat))
+        (def cam (camera))
+        (def l1 (light :intensity 1.0))
+        (def l2 (light :intensity 1.0))
+        (def gbuf (pass))
+        (output gbuf)
+    )");
+    auto eval = ctx->create_evaluator(graph);
+    eval->evaluate();
+
+    auto px = eval->result("").read_pixels();
+    REQUIRE(px.size() == 512u * 512u * 4u);
+}
+```
+
+- [ ] **Step 2: Build, verify test fails**
+
+- [ ] **Step 3: Add LightUBO struct to scene.h**
+
+In `include/joon/scene.h`:
+```cpp
+struct LightData {
+    float position_type[4];   // xyz = position/direction, w = type (0=dir, 1=point, 2=spot)
+    float color_intensity[4]; // xyz = color * intensity, w = unused
+    float spot_params[4];     // xyz = spot direction, w = cos(angle)
+};
+
+struct LightUBO {
+    LightData lights[16];
+    int light_count;
+    float camera_pos[3];
+    float inv_view_proj[16]; // mat4 for world pos reconstruction
+};
+```
+
+- [ ] **Step 4: Create default lighting fragment shader**
+
+```hlsl
+// shaders/deferred_default.frag.hlsl
+struct LightData {
+    float4 position_type;
+    float4 color_intensity;
+    float4 spot_params;
+};
+
+[[vk::binding(0, 0)]] Texture2D gbuf_albedo;
+[[vk::binding(1, 0)]] Texture2D gbuf_depth;
+[[vk::binding(2, 0)]] SamplerState samp;
+
+struct LightUBO {
+    LightData lights[16];
+    int light_count;
+    float3 camera_pos;
+    float4x4 inv_view_proj;
+};
+[[vk::binding(3, 0)]] ConstantBuffer<LightUBO> light_ubo;
+
+struct PSIn {
+    float4 sv : SV_POSITION;
+    float2 uv : TEXCOORD0;
+};
+
+float4 main(PSIn i) : SV_TARGET {
+    float4 albedo = gbuf_albedo.Sample(samp, i.uv);
+    if (albedo.a < 0.01) discard;
+
+    float3 result = albedo.rgb * 0.1; // ambient
+
+    for (int li = 0; li < light_ubo.light_count; li++) {
+        float3 light_dir;
+        float3 light_color = light_ubo.lights[li].color_intensity.xyz;
+        float type = light_ubo.lights[li].position_type.w;
+
+        if (type < 0.5) {
+            // Directional
+            light_dir = -normalize(light_ubo.lights[li].position_type.xyz);
+        } else {
+            light_dir = normalize(light_ubo.lights[li].position_type.xyz);
+        }
+
+        float ndotl = saturate(dot(float3(0, 0, 1), light_dir));
+        result += albedo.rgb * light_color * ndotl;
+    }
+
+    return float4(result, 1.0);
+}
+```
+
+Note: This is a simplified first version. The full Cook-Torrance GGX with world position reconstruction, normal map reading, and PBR calculations can be added incrementally after the basic pipeline works.
+
+- [ ] **Step 5: Implement lighting pass**
+
+```cpp
+// src/scene/lighting_pass.h
+#pragma once
+#include "vulkan/device.h"
+#include "vulkan/pipeline_cache.h"
+#include "vulkan/resource_pool.h"
+#include <joon/scene.h>
+#include <joon/math.h>
+
+namespace joon {
+
+struct LightingPassConfig {
+    Device& device;
+    PipelineCache& pipelines;
+    ResourcePool& pool;
+    VkDescriptorPool desc_pool;
+    const SceneCollection& scene;
+    uint32_t width, height;
+    GpuImage* albedo_target;
+    GpuImage* depth_target;
+    uint32_t output_node_id;
+    mat4 view;
+    mat4 proj;
+};
+
+void dispatch_lighting_pass(const LightingPassConfig& cfg);
+
+} // namespace joon
+```
+
+```cpp
+// src/scene/lighting_pass.cpp
+#include "scene/lighting_pass.h"
+#include "vulkan/buffer.h"
+#include "vulkan/render_pass.h"
+
+namespace joon {
+
+void dispatch_lighting_pass(const LightingPassConfig& cfg) {
+    // 1. Allocate output image for lit result
+    auto* lit_output = cfg.pool.alloc_render_target(
+        cfg.output_node_id, cfg.width, cfg.height, VK_FORMAT_R8G8B8A8_UNORM);
+
+    // 2. Create render pass for the lighting output (single color attachment, no depth)
+    RenderPass rp = create_color_depth_renderpass(cfg.device, {lit_output->format}, VK_FORMAT_UNDEFINED);
+    // Note: need to handle "no depth" case — or create a simpler render pass factory.
+    // Alternative: use a compute shader for lighting instead of a graphics pass.
+    // For now, create a single-color-attachment render pass.
+
+    VkFramebuffer fb = create_framebuffer(cfg.device, rp,
+        {lit_output->view}, VK_NULL_HANDLE, cfg.width, cfg.height);
+
+    // 3. Get the fullscreen + lighting pipeline
+    auto& gp = cfg.pipelines.get_graphics("deferred_default_lighting", rp.pass, 0);
+    // This needs custom descriptor layout: 2 textures + sampler + UBO
+
+    // 4. Build LightUBO
+    LightUBO light_ubo{};
+    light_ubo.light_count = static_cast<int>(std::min(cfg.scene.lights.size(), size_t(16)));
+    // ... fill light data from scene.lights
+    // ... fill camera_pos and inv_view_proj from cfg.view and cfg.proj
+
+    auto ub = create_uniform_buffer(cfg.device, sizeof(LightUBO));
+    update_uniform_buffer(cfg.device, ub, &light_ubo, sizeof(LightUBO));
+
+    // 5. Allocate descriptor set, bind G-buffer textures + light UBO
+    // ... descriptor writes for albedo, depth, sampler, light UBO
+
+    // 6. Record command buffer
+    VkCommandBuffer cmd = cfg.device.begin_single_command();
+    // Begin render pass, bind pipeline, bind descriptors, draw 3 vertices (fullscreen tri)
+    // End render pass
+    // Transition lit_output to GENERAL
+
+    cfg.device.end_single_command(cmd);
+
+    // 7. Cleanup per-frame resources
+    destroy_buffer(cfg.device, ub);
+    vkDestroyFramebuffer(cfg.device.device, fb, nullptr);
+    destroy_renderpass(cfg.device, rp);
+}
+
+} // namespace joon
+```
+
+- [ ] **Step 6: Integrate lighting pass into geometry pass executor**
+
+In `src/scene/geometry_pass.cpp`, after the existing render pass ends and the color attachment transitions to GENERAL, call `dispatch_lighting_pass()` if materials are present:
+
+```cpp
+// After vkCmdEndRenderPass and color-to-GENERAL barrier:
+if (!ctx.material_pipelines.empty()) {
+    LightingPassConfig lcfg{
+        ctx.device, ctx.pipelines, ctx.pool, ctx.desc_pool,
+        ctx.scene, ctx.default_width, ctx.default_height,
+        albedo, depth, n.id, view, proj
+    };
+    dispatch_lighting_pass(lcfg);
+    // The lit output is now at node_id in the resource pool — downstream reads this
+}
+```
+
+- [ ] **Step 7: Build and run lighting tests**
+
+```bash
+projects/joon/build/bin/Debug/joon-tests.exe "[shader][lighting]"
+```
+Expected: 2 tests pass.
+
+- [ ] **Step 8: Run full suite**
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add projects/joon/shaders/deferred_default.frag.hlsl projects/joon/src/scene/lighting_pass.* \
+  projects/joon/include/joon/scene.h projects/joon/tests/test_lighting_pass.cpp
+git commit -m "feat(joon): deferred lighting pass with Cook-Torrance default and multiple lights"
+```
+
+---
+
+## Phase 8: G-Buffer Access
+
+### Task 12: Dot-access resolution for G-buffer channels
+
+**Files:**
+- Modify: `projects/joon/src/ir/ir_graph.cpp`
+- Modify: `projects/joon/tests/test_shader_parser.cpp`
+
+- [ ] **Step 1: Write failing test**
+
+```cpp
+TEST_CASE("Dot access on pass output resolves to sub-image", "[shader][ir]") {
+    auto ctx = joon::Context::create();
+    auto graph = ctx->parse_string(R"(
+        (def mat (shader
+          :fragment (fn [normal uv] -> [albedo vec4, normals vec4]
+            (set albedo [1 0 0 1])
+            (set normals (encode normal)))))
+        (def c (cube :material mat))
+        (def cam (camera))
+        (def l (light))
+        (def gbuf (pass :outputs [albedo normals depth]))
+        (def result (levels gbuf.albedo :contrast 1.5))
+        (output result)
+    )");
+    REQUIRE_FALSE(graph.has_errors());
+}
+```
+
+- [ ] **Step 2: Build, verify test fails**
+
+Currently, `gbuf.albedo` will parse as a `DotAccessNode` but the IR lowering doesn't know how to resolve it.
+
+- [ ] **Step 3: Implement dot-access resolution in IR graph**
+
+In `src/ir/ir_graph.cpp`, in `resolve_expr()`, add handling for `DotAccessNode`:
+
+```cpp
+if (auto* dot = std::get_if<DotAccessNode>(&expr.data)) {
+    // Resolve the object (e.g., "gbuf" → pass node)
+    auto* obj_sym = std::get_if<SymbolNode>(&dot->object->data);
+    if (obj_sym) {
+        auto it = m_nameToNode.find(obj_sym->name);
+        if (it != m_nameToNode.end()) {
+            uint32_t parent_id = it->second;
+            // Create a synthetic node that references a sub-image of the parent
+            uint32_t id = add_node("channel_select", Tier::CPU);
+            nodes[id].inputs.push_back(parent_id);
+            edges.push_back({parent_id, id, 0});
+            nodes[id].string_arg = dot->field; // "albedo", "normals", "depth"
+            nodes[id].output_type = Type::IMAGE;
+            return id;
+        }
+    }
+    diagnostics.push_back({Diagnostic::Level::ERROR, "Invalid dot access", expr.line, expr.col});
+    return add_node("error", Tier::CPU);
+}
+```
+
+Then implement a `channel_select` executor that extracts a specific render target from the pass's MRT output. This requires the pass node to register its output images by channel name.
+
+- [ ] **Step 4: Build and run test**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add projects/joon/src/ir/ projects/joon/tests/
+git commit -m "feat(joon): dot-access resolution for G-buffer channel selection"
+```
+
+---
+
+## Phase 9: Custom BRDF
+
+### Task 13: Custom BRDF codegen and lighting shader variants
+
+**Files:**
+- Create: `projects/joon/src/shader/brdf_emitter.h`
+- Create: `projects/joon/src/shader/brdf_emitter.cpp`
+- Modify: `projects/joon/src/scene/lighting_pass.cpp`
+
+- [ ] **Step 1: Write failing test**
+
+```cpp
+TEST_CASE("Custom toon BRDF produces stepped lighting", "[shader][brdf][gpu]") {
+    auto ctx = joon::Context::create();
+    auto graph = ctx->parse_string(R"(
+        (def toon_mat (shader
+          :brdf (fn [normal light_dir view_dir albedo]
+            (* albedo (step 0.3 (dot normal light_dir))))
+          :fragment (fn [normal uv] -> [albedo vec4]
+            (set albedo [0.3 0.8 0.2 1]))))
+        (def c (cube :material toon_mat))
+        (def cam (camera))
+        (def l (light))
+        (def gbuf (pass))
+        (output gbuf)
+    )");
+    REQUIRE_FALSE(graph.has_errors());
+
+    auto eval = ctx->create_evaluator(graph);
+    eval->evaluate();
+
+    auto px = eval->result("").read_pixels();
+    REQUIRE(px.size() == 512u * 512u * 4u);
+    // Toon shading produces binary lit/unlit — check for distinct value clusters
+    int bright = 0, dark = 0;
+    for (size_t i = 0; i < px.size(); i += 4) {
+        if (px[i+1] > 0.5f) ++bright;
+        else if (px[i+1] > 0.01f && px[i+1] < 0.3f) ++dark;
+    }
+    CHECK(bright > 50);
+}
+```
+
+- [ ] **Step 2: Build, verify test fails**
+
+- [ ] **Step 3: Implement BRDF emitter**
+
+```cpp
+// src/shader/brdf_emitter.h
+#pragma once
+#include "shader/shader_ir.h"
+#include "shader/hlsl_emitter.h"
+#include <string>
+
+namespace joon {
+
+class BrdfEmitter {
+public:
+    std::string emit_lighting_shader(const ShaderFnIR& brdf,
+                                      const std::vector<ShaderFnOutput>& gbuf_outputs);
+    std::string emit_default_lighting_shader();
+};
+
+} // namespace joon
+```
+
+```cpp
+// src/shader/brdf_emitter.cpp
+#include "shader/brdf_emitter.h"
+#include <sstream>
+
+namespace joon {
+
+std::string BrdfEmitter::emit_lighting_shader(const ShaderFnIR& brdf,
+                                                const std::vector<ShaderFnOutput>& gbuf_outputs) {
+    HlslEmitter hlsl;
+    std::ostringstream ss;
+
+    // G-buffer texture bindings
+    ss << "[[vk::binding(0, 0)]] Texture2D gbuf_albedo;\n";
+    ss << "[[vk::binding(1, 0)]] Texture2D gbuf_depth;\n";
+    ss << "[[vk::binding(2, 0)]] SamplerState samp;\n\n";
+
+    // Light UBO
+    ss << "struct LightData { float4 position_type; float4 color_intensity; float4 spot_params; };\n";
+    ss << "struct LightUBO { LightData lights[16]; int light_count; float3 camera_pos; float4x4 inv_view_proj; };\n";
+    ss << "[[vk::binding(3, 0)]] ConstantBuffer<LightUBO> light_ubo;\n\n";
+
+    ss << "struct PSIn { float4 sv : SV_POSITION; float2 uv : TEXCOORD0; };\n\n";
+
+    ss << "float4 main(PSIn i) : SV_TARGET {\n";
+    ss << "    float4 albedo = gbuf_albedo.Sample(samp, i.uv);\n";
+    ss << "    if (albedo.a < 0.01) discard;\n\n";
+
+    // Emit BRDF loop
+    ss << "    float3 result = float3(0, 0, 0);\n";
+    ss << "    float3 normal = float3(0, 0, 1);\n"; // simplified for single-output materials
+    ss << "    float3 view_dir = float3(0, 0, 1);\n\n";
+
+    ss << "    for (int li = 0; li < light_ubo.light_count; li++) {\n";
+    ss << "        float3 light_dir = -normalize(light_ubo.lights[li].position_type.xyz);\n";
+    ss << "        float3 light_color = light_ubo.lights[li].color_intensity.xyz;\n";
+
+    // Emit the custom BRDF body
+    // The BRDF fn returns a color contribution — emit it as the loop body
+    for (auto& stmt : brdf.body) {
+        ss << "        result += " << hlsl.emit_expr(*stmt) << " * light_color;\n";
+    }
+
+    ss << "    }\n\n";
+    ss << "    return float4(result, 1.0);\n";
+    ss << "}\n";
+
+    return ss.str();
+}
+
+std::string BrdfEmitter::emit_default_lighting_shader() {
+    // Return the contents of deferred_default.frag.hlsl as a string
+    // Or just reference the file — the PipelineCache can load it from disk
+    return ""; // use file-based default
+}
+
+} // namespace joon
+```
+
+- [ ] **Step 4: Integrate BRDF variants into lighting pass**
+
+In `lighting_pass.cpp`, check if the material has a custom BRDF. If so, generate a variant lighting shader via `BrdfEmitter` and compile it via `PipelineCache::get_graphics_from_source()`. Cache by BRDF hash.
+
+- [ ] **Step 5: Build and run test**
+
+```bash
+projects/joon/build/bin/Debug/joon-tests.exe "[shader][brdf]"
+```
+
+- [ ] **Step 6: Run full suite**
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add projects/joon/src/shader/brdf_emitter.* projects/joon/src/scene/lighting_pass.cpp \
+  projects/joon/tests/
+git commit -m "feat(joon): custom BRDF codegen with per-material lighting shader variants"
+```
+
+---
+
+## Phase 10: Pre-Pass Extraction
+
+### Task 14: Auto-extract non-inlineable ops from shader bodies
+
+**Files:**
+- Create: `projects/joon/src/shader/prepass_extractor.h`
+- Create: `projects/joon/src/shader/prepass_extractor.cpp`
+- Create: `projects/joon/tests/test_prepass.cpp`
+
+- [ ] **Step 1: Write failing test**
+
+```cpp
+// tests/test_prepass.cpp
+#include "catch_amalgamated.hpp"
+#include "shader/prepass_extractor.h"
+#include "shader/shader_analyzer.h"
+#include "shader/shader_ir.h"
+using namespace joon;
+
+TEST_CASE("Prepass extracts blur from shader body", "[shader][prepass]") {
+    // Simulate: (set albedo (blur (noise :scale 4.0) :radius 3))
+    // The "blur" is non-inlineable, so it should be extracted.
+    ShaderCall noise_call{"noise", {}, {{"scale", 4.0f}, {"octaves", 4.0f}}};
+    auto noise = std::make_unique<ShaderExpr>(std::move(noise_call));
+
+    ShaderCall blur_call{"blur", {std::move(noise)}, {{"radius", 3.0f}}};
+    auto blur = std::make_unique<ShaderExpr>(std::move(blur_call));
+
+    ShaderAssign assign;
+    assign.target = "albedo";
+    assign.value = std::move(blur);
+
+    ShaderFnIR frag;
+    frag.params = {"normal", "uv"};
+    frag.outputs = {{"albedo", "vec4"}};
+    frag.body.push_back(std::make_unique<ShaderExpr>(std::move(assign)));
+
+    ShaderAnalyzer analyzer;
+    PrepassExtractor extractor(analyzer);
+    auto result = extractor.extract(frag);
+
+    CHECK(result.prepasses.size() == 1);
+    CHECK(result.prepasses[0].root_op == "blur");
+
+    // The body should now have a prepass sample instead of the blur call
+    auto* new_assign = std::get_if<ShaderAssign>(result.modified_body[0].get());
+    REQUIRE(new_assign != nullptr);
+    auto* sample = std::get_if<ShaderPrepassSample>(new_assign->value.get());
+    CHECK(sample != nullptr);
+    CHECK(sample->prepass_index == 0);
+}
+
+TEST_CASE("Prepass leaves inlineable ops untouched", "[shader][prepass]") {
+    // (set albedo (noise :scale 4.0)) — noise is inlineable
+    ShaderCall noise{"noise", {}, {{"scale", 4.0f}}};
+    ShaderAssign assign;
+    assign.target = "albedo";
+    assign.value = std::make_unique<ShaderExpr>(std::move(noise));
+
+    ShaderFnIR frag;
+    frag.params = {"normal", "uv"};
+    frag.outputs = {{"albedo", "vec4"}};
+    frag.body.push_back(std::make_unique<ShaderExpr>(std::move(assign)));
+
+    ShaderAnalyzer analyzer;
+    PrepassExtractor extractor(analyzer);
+    auto result = extractor.extract(frag);
+
+    CHECK(result.prepasses.empty());
+    // Body unchanged — still a ShaderCall noise
+    auto* a = std::get_if<ShaderAssign>(result.modified_body[0].get());
+    REQUIRE(a != nullptr);
+    CHECK(std::get_if<ShaderCall>(a->value.get()) != nullptr);
+}
+```
+
+- [ ] **Step 2: Build, verify compile error**
+
+- [ ] **Step 3: Implement PrepassExtractor**
+
+```cpp
+// src/shader/prepass_extractor.h
+#pragma once
+#include "shader/shader_ir.h"
+#include "shader/shader_analyzer.h"
+#include <vector>
+
+namespace joon {
+
+struct ExtractedPrepass {
+    std::string root_op;
+    ShaderExprPtr compute_tree;  // the sub-tree to run as a compute pass
+};
+
+struct ExtractionResult {
+    std::vector<ExtractedPrepass> prepasses;
+    std::vector<ShaderExprPtr> modified_body;
+};
+
+class PrepassExtractor {
+public:
+    explicit PrepassExtractor(const ShaderAnalyzer& analyzer);
+    ExtractionResult extract(const ShaderFnIR& fn);
+
+private:
+    const ShaderAnalyzer& m_analyzer;
+    uint32_t m_prepass_count = 0;
+
+    ShaderExprPtr walk(ShaderExprPtr expr);
+};
+
+} // namespace joon
+```
+
+```cpp
+// src/shader/prepass_extractor.cpp
+#include "shader/prepass_extractor.h"
+
+namespace joon {
+
+PrepassExtractor::PrepassExtractor(const ShaderAnalyzer& analyzer)
+    : m_analyzer(analyzer) {}
+
+ShaderExprPtr PrepassExtractor::walk(ShaderExprPtr expr) {
+    if (auto* call = std::get_if<ShaderCall>(expr.get())) {
+        if (m_analyzer.classify(call->op) == ShaderOpKind::PREPASS_REQUIRED) {
+            // Extract this entire sub-tree as a pre-pass
+            uint32_t idx = m_prepass_count++;
+            // The original expr becomes a prepass sample
+            return std::make_unique<ShaderExpr>(ShaderPrepassSample{idx});
+        }
+        // Recurse into args
+        for (auto& arg : call->args)
+            arg = walk(std::move(arg));
+    }
+    if (auto* assign = std::get_if<ShaderAssign>(expr.get())) {
+        if (assign->value)
+            assign->value = walk(std::move(assign->value));
+    }
+    return expr;
+}
+
+ExtractionResult PrepassExtractor::extract(const ShaderFnIR& fn) {
+    ExtractionResult result;
+    m_prepass_count = 0;
+
+    // First pass: find prepass-required ops and record them
+    // We need to clone the body and walk it, extracting as we go
+    // For simplicity, walk in-place on a copy
+
+    for (auto& stmt : fn.body) {
+        // Walk each statement, replacing prepass ops with samples
+        auto modified = walk(std::make_unique<ShaderExpr>(*stmt)); // needs clone
+        result.modified_body.push_back(std::move(modified));
+    }
+
+    // Build prepass entries (would need to save the extracted trees — this is simplified)
+    // In a full implementation, walk() would save the extracted sub-trees before replacing
+    for (uint32_t i = 0; i < m_prepass_count; i++) {
+        result.prepasses.push_back({/* root_op from extracted tree */"blur", nullptr});
+    }
+
+    return result;
+}
+
+} // namespace joon
+```
+
+Note: This is a simplified skeleton. The full implementation needs to:
+1. Clone ShaderExpr trees (add a clone() method to ShaderExpr)
+2. Save the extracted sub-tree before replacing it
+3. Convert the extracted ShaderIR sub-tree back to IR graph nodes for compute dispatch
+
+- [ ] **Step 4: Build and run tests**
+
+```bash
+projects/joon/build/bin/Debug/joon-tests.exe "[shader][prepass]"
+```
+
+- [ ] **Step 5: Run full suite**
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add projects/joon/src/shader/prepass_extractor.* projects/joon/tests/test_prepass.cpp
+git commit -m "feat(joon): pre-pass extraction for non-inlineable ops in shader bodies"
+```
+
+---
+
+## Phase 11: Polish
+
+### Task 15: Update GUI default DSL to showcase materials and lighting
+
+**Files:**
+- Modify: `projects/joon/gui/app.cpp`
+
+- [ ] **Step 1: Update default DSL**
+
+```cpp
+dsl_source = R"(; Joon - 3D scene with materials
+(def red_mat (shader
+  :fragment (fn [normal uv] -> [albedo vec4]
+    (set albedo [0.8 0.2 0.1 1]))))
+
+(def c (cube :scale 1.0 :material red_mat))
+(def cam (camera :fov 60))
+(def l (light :intensity 1.0))
+(def gbuf (pass))
+(param contrast float 1.0 :min 0.0 :max 3.0)
+(def final (levels gbuf :contrast contrast))
+(output final)
+)";
+```
+
+- [ ] **Step 2: Build**
+
+- [ ] **Step 3: Launch GUI, verify visual output**
+
+```bash
+projects/joon/build/bin/Debug/joon-gui.exe
+```
+
+Check: red-shaded cube visible, contrast slider works, no validation errors in log.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add projects/joon/gui/app.cpp
+git commit -m "feat(joon): GUI default DSL uses material shader with deferred lighting"
+```
+
+---
+
+### Task 16: Final verification and PR
+
+- [ ] **Step 1: Clean build**
+
+```bash
+cd projects/joon && rm -rf build && /d/prg/premake5.exe vs2022
+cd build && "/c/Program Files/Microsoft Visual Studio/2022/Community/MSBuild/Current/Bin/MSBuild.exe" \
+  Joon.sln -p:Configuration=Debug -p:Platform=x64 -m -v:minimal
+```
+
+- [ ] **Step 2: Run full test suite**
+
+```bash
+projects/joon/build/bin/Debug/joon-tests.exe
+```
+Expected: all tests pass (59 existing + ~20 new shader tests).
+
+- [ ] **Step 3: Run GUI — visual confirmation**
+
+Launch `joon-gui.exe`. Confirm:
+- Shaded cube with material renders correctly
+- Contrast slider produces real-time updates
+- No Vulkan validation errors in log
+
+- [ ] **Step 4: Push and open PR**
+
+```bash
+git push -u origin joon-shader-codegen
+gh pr create --title "feat(joon): DSL-generated shaders and deferred lighting (sub-project 3)" \
+  --body "..."
+```
+
+---
+
+## Open Considerations
+
+These are decisions to resolve during implementation if the prescribed approach doesn't work:
+
+1. **Render pass without depth for lighting.** The lighting pass needs a single-color-attachment render pass with no depth. `create_color_depth_renderpass` currently always creates a depth attachment. May need a `create_color_only_renderpass` variant or a flag.
+
+2. **PipelineCache key for generated shaders.** Currently keyed by name + render_pass ptr + push_constant_size. Generated shaders use a string key ("mat_N"). If materials change between evaluations (DSL re-parsed), old pipeline entries stay cached. This is fine for sub-project 3 but may need cache invalidation later.
+
+3. **ShaderExpr cloning for pre-pass extraction.** The pre-pass extractor needs to clone ShaderExpr trees to save the extracted sub-tree before replacing it in the body. Implement a `clone()` method on ShaderExpr using recursive variant visiting. The skeleton in Task 14 step 3 needs this fleshed out — `walk()` must save the extracted sub-tree into `result.prepasses` before replacing it with `ShaderPrepassSample`.
+
+4. **Descriptor set layout for lighting.** The lighting pass binds textures + UBO with a layout different from the compute and geometry pipelines. `get_graphics_from_source()` needs to support custom descriptor set layouts, not just the hardcoded UBO-only layout from `get_graphics()`. Consider passing a descriptor layout specification or auto-reflecting from the SPIR-V.
+
+5. **G-buffer channel_select executor.** The `channel_select` synthetic node created by dot-access resolution needs an executor that returns the Nth color attachment image from the parent pass node's MRT output. The pass node needs to register its output images by channel name in a map on EvalContext.
+
+6. **VectorNode kwargs for pass `:outputs`.** Task 12 uses `(pass :outputs [albedo normals depth])` which is a VectorNode kwarg value. The existing IR graph kwargs handler (and Task 3's extension for FnNode) doesn't handle VectorNode values. Task 12's implementation must also add VectorNode kwarg resolution in `ir_graph.cpp` — extract the symbol names from the vector and store them on the pass node as the channel name list.
+
+7. **Unknown op error in shader bodies.** Task 5 classifies unknown ops as `ShaderOpKind::UNKNOWN` but no task explicitly surfaces a compile error diagnostic. During shader analysis (Task 5) or HLSL emission (Task 6), if an op classifies as UNKNOWN, emit a diagnostic error listing the op and its location. Add this check to `ShaderAnalyzer::convert_expr()` when processing a `CallNode` — if `classify(call->op) == UNKNOWN`, push a diagnostic and return a zero literal.
+
+8. **G-buffer contract validation.** The spec requires that all materials in a `(pass)` share the same fragment output signature. This validation should happen in the geometry pass executor (Task 9 step 7): before rendering, compare each material's `ShaderFnIR::outputs` against the pass's `:outputs` list. If they don't match, emit a diagnostic error with both signatures and skip the material.
+
+9. **Pipeline creation in `get_graphics_from_source()`.** Task 7 step 3 shows the temp-file writing and DXC compilation but elides the VkPipeline creation. The implementation should extract the common pipeline-creation logic from `get_graphics()` into a shared helper (taking shader modules, render pass, push constant size, and num_color_attachments) to avoid duplicating the blend state, rasterizer state, and vertex input setup.
+
+10. **Lighting pass Vulkan details.** Task 11 step 5 elides descriptor set writes and light UBO filling. The implementation must: (a) create a VkDescriptorSetLayout matching the deferred shader bindings (2 textures, 1 sampler, 1 UBO), (b) allocate and write descriptor sets binding `albedo_target->view`, `depth_target->view`, and the light UBO buffer, (c) fill `LightUBO::lights[]` from `SceneCollection::lights` with position/direction, color * intensity, and type, (d) compute `inv_view_proj` as `inverse(proj * view)` and `camera_pos` from the inverse of the view matrix.

--- a/docs/superpowers/specs/2026-05-01-joon-shader-codegen-design.md
+++ b/docs/superpowers/specs/2026-05-01-joon-shader-codegen-design.md
@@ -1,0 +1,353 @@
+# Joon Sub-Project 3: DSL-Generated Shaders & Deferred Lighting
+
+**Date:** 2026-05-01
+**Status:** Approved
+**Depends on:** Sub-project 2 (scene graph + hardcoded geometry pass, PR #134)
+
+## Goal
+
+Replace joon's hardcoded vertex/fragment shaders with a DSL-driven shader codegen system. Materials are DSL expressions that define surface properties (G-buffer outputs) and optionally a custom BRDF. The renderer evaluates BRDFs per-light in a deferred fullscreen pass. Un-inlineable DSL ops inside shader bodies are automatically extracted into compute pre-passes.
+
+## DSL Syntax
+
+### Material definition
+
+```lisp
+(def brick (shader
+  :vertex (fn [pos normal uv]
+    (set pos.y (+ pos.y (* 0.1 (sin (+ (* pos.x 8.0) time))))))
+  :brdf (fn [normal light_dir view_dir albedo]
+    (* albedo (step 0.3 (dot normal light_dir))))
+  :fragment (fn [normal uv] -> [albedo vec4, normal vec4, roughmetal vec4]
+    (set albedo (noise :scale 4.0 :octaves 2))
+    (set normal (encode normal))
+    (set roughmetal [0.7 0.0 0 0]))))
+```
+
+All three clauses are optional:
+- **`:vertex`** — Custom vertex transform. Receives `pos`, `normal`, `uv` as mutable inputs plus `time` as a read-only built-in. Default: identity (standard MVP transform only).
+- **`:fragment`** — Surface property writer. Arrow syntax `-> [name type, ...]` declares G-buffer outputs. Default: single `[albedo vec4]` output with white color.
+- **`:brdf`** — Custom light response function. Receives `normal`, `light_dir`, `view_dir`, `albedo` (and any other G-buffer channels by name). Returns a `vec4` color contribution for one light. Default: Cook-Torrance GGX (metallic-roughness workflow).
+
+### Scene usage
+
+```lisp
+(def wall (cube :scale 2.0 :material brick))
+(def ball (sphere :radius 0.5 :material (shader
+  :fragment (fn [normal uv] -> [albedo vec4, normal vec4, roughmetal vec4]
+    (set albedo [0.9 0.1 0.1 1])
+    (set normal (encode normal))
+    (set roughmetal [0.3 1.0 0 0])))))
+
+(camera :fov 60 :position [0 2 5])
+(light :type directional :direction [-1 -1 -1])
+(light :type point :position [2 3 0] :color [1 0.8 0.6])
+
+(def gbuf (pass :outputs [albedo normal roughmetal depth]))
+(def ao (ssao gbuf.depth gbuf.normal))
+(def final (compose gbuf.albedo ao :mode multiply))
+(output final)
+```
+
+### G-buffer access
+
+The `pass` node's `:outputs` kwarg names the G-buffer channels. Individual channels are accessed via dot notation: `gbuf.albedo`, `gbuf.normal`, `gbuf.depth`. Each resolves to a `GpuImage` that downstream compute or output nodes can consume.
+
+## Architecture
+
+### Pipeline overview
+
+```
+DSL source
+  |
+  v
+Parser (existing)
+  |
+  v
+IR Graph (existing, extended with Tier::MATERIAL)
+  |
+  v
+Shader Analyzer -----> Pre-pass Extractor
+  |                         |
+  | (inlineable ops)        | (compute pre-passes)
+  v                         v
+HLSL Emitter           Compute dispatch (existing)
+  |                         |
+  v                         v
+DXC (HLSL -> SPIR-V)   Texture bindings for shader
+  |
+  v
+PipelineCache (graphics pipelines per material)
+  |
+  v
+Geometry Pass (MRT rendering, grouped by material)
+  |
+  v
+G-Buffer [albedo, normal, roughmetal, depth]
+  |
+  v
+Lighting Pass (fullscreen, per-BRDF variant)
+  |
+  v
+Lit output image -> downstream compute graph
+```
+
+### Stage 1: Shader IR Analysis
+
+Walk the `(shader ...)` AST and build a `ShaderIR` — a representation of the shader's vertex, fragment, and BRDF bodies as expression trees. Each sub-expression is classified:
+
+- **Inlineable:** Has a direct HLSL equivalent. Compiles to inline code. Examples: `sin`, `dot`, `noise`, `mix`, `+`, `*`, `step`, `smoothstep`.
+- **Pre-pass required:** Needs compute dispatch (multi-pixel access, iterative ops). Examples: `blur`, `levels`, `ssao`. These are extracted and replaced with texture samples.
+
+Classification is driven by a registry: each node op declares whether it has an inline HLSL implementation. Unknown ops inside a shader body are a compile error.
+
+### Stage 2: Pre-Pass Extraction
+
+When a shader body contains an un-inlineable op:
+
+```lisp
+(set albedo (blur (noise :scale 4.0) :radius 3))
+```
+
+The extractor:
+1. Identifies `blur` as non-inlineable.
+2. Walks outward to find the largest sub-tree rooted at `blur` that is entirely non-inlineable or feeds only into the non-inlineable op.
+3. Extracts `(blur (noise :scale 4.0) :radius 3)` as a standalone compute graph.
+4. Allocates a pre-pass render target via `ResourcePool`.
+5. Schedules the compute dispatch before the geometry pass.
+6. Replaces the sub-tree in the shader IR with a texture sample: `sample(__prepass_0, uv)`.
+7. Adds the pre-pass texture as a descriptor binding in the generated fragment shader.
+
+The pre-pass compute graph is evaluated using the existing evaluator — no new compute infrastructure needed.
+
+### Stage 3: HLSL Code Generation
+
+The `HlslEmitter` walks the `ShaderIR` expression tree and emits HLSL source code.
+
+**Fragment shader output:**
+
+```hlsl
+struct PSOut {
+    float4 albedo    : SV_TARGET0;
+    float4 normal    : SV_TARGET1;
+    float4 roughmetal : SV_TARGET2;
+};
+```
+
+The struct is generated from the `-> [...]` output declaration. Field order matches the pass's `:outputs` order.
+
+**Vertex shader:**
+
+```hlsl
+struct UBO { float4x4 mvp; float4x4 model; float time; float3 pad; };
+[[vk::binding(0, 0)]] ConstantBuffer<UBO> ubo;
+
+struct VSIn  { float3 pos : POSITION; float3 nrm : NORMAL; float2 uv : TEXCOORD0; };
+struct VSOut { float4 sv : SV_POSITION; float3 normal : NORMAL; float2 uv : TEXCOORD0; float3 world_pos : TEXCOORD1; };
+
+VSOut main(VSIn v) {
+    float3 pos = v.pos;
+    float3 normal = v.nrm;
+    float2 uv = v.uv;
+    float time = ubo.time;
+    // --- user vertex body emitted here ---
+    // pos.y = pos.y + 0.1 * sin(pos.x * 8.0 + time);
+    // --- end user body ---
+    VSOut o;
+    o.sv = mul(ubo.mvp, float4(pos, 1.0));
+    o.normal = normalize(mul((float3x3)ubo.model, normal));
+    o.uv = uv;
+    o.world_pos = mul(ubo.model, float4(pos, 1.0)).xyz;
+    return o;
+}
+```
+
+User vertex expressions modify `pos`, `normal`, `uv` in-place. The MVP transform and normal transform happen after the user body.
+
+**Fragment shader:**
+
+```hlsl
+struct PSIn { float4 sv : SV_POSITION; float3 normal : NORMAL; float2 uv : TEXCOORD0; float3 world_pos : TEXCOORD1; };
+
+// Pre-pass textures (if any)
+[[vk::binding(1, 0)]] Texture2D __prepass_0;
+[[vk::binding(2, 0)]] SamplerState __sampler_0;
+
+PSOut main(PSIn i) {
+    float3 normal = normalize(i.normal);
+    float2 uv = i.uv;
+    PSOut o;
+    // --- user fragment body emitted here ---
+    // o.albedo = __prepass_0.Sample(__sampler_0, uv);
+    // o.normal = float4(normal * 0.5 + 0.5, 1.0);
+    // o.roughmetal = float4(0.7, 0.0, 0, 0);
+    // --- end user body ---
+    return o;
+}
+```
+
+**Expression mapping:** DSL expressions map to HLSL:
+
+| DSL | HLSL |
+|-----|------|
+| `(+ a b)` | `(a + b)` |
+| `(* a b)` | `(a * b)` |
+| `(sin x)` | `sin(x)` |
+| `(dot a b)` | `dot(a, b)` |
+| `(mix a b t)` | `lerp(a, b, t)` |
+| `(step e x)` | `step(e, x)` |
+| `(noise :scale s :octaves n)` | `fbm(world_pos * s, n)` (inline noise function, uses interpolated world position) |
+| `(sample tex uv)` | `tex.Sample(sampler, uv)` |
+| `(encode normal)` | `float4(normal * 0.5 + 0.5, 1.0)` |
+| `(set target expr)` | `o.target = expr;` (fragment) or `target = expr;` (vertex) |
+| `[a b c d]` | `float4(a, b, c, d)` |
+| `[a b c]` | `float3(a, b, c)` |
+| `time` | `ubo.time` (vertex) or `frag_ubo.time` (fragment, via separate fragment UBO) |
+
+Inline procedural noise (`fbm`) is emitted as a helper function at the top of the generated shader — a standard gradient noise + fractal sum implementation.
+
+### Stage 4: Deferred Lighting Pass
+
+A fullscreen fragment shader reads the G-buffer and evaluates lighting:
+
+```hlsl
+struct LightData {
+    float4 position_type;  // xyz = position/direction, w = type (0=dir, 1=point, 2=spot)
+    float4 color_intensity; // xyz = color, w = intensity
+    float4 spot_params;     // xyz = direction, w = cos(angle)
+};
+
+[[vk::binding(0, 0)]] Texture2D gbuf_albedo;
+[[vk::binding(1, 0)]] Texture2D gbuf_normal;
+[[vk::binding(2, 0)]] Texture2D gbuf_roughmetal;
+[[vk::binding(3, 0)]] Texture2D gbuf_depth;
+[[vk::binding(4, 0)]] SamplerState samp;
+
+struct LightUBO { LightData lights[16]; int light_count; float3 camera_pos; float4x4 inv_view_proj; };
+[[vk::binding(5, 0)]] ConstantBuffer<LightUBO> light_ubo;
+
+float4 main(float4 sv : SV_POSITION, float2 uv : TEXCOORD0) : SV_TARGET {
+    float4 albedo = gbuf_albedo.Sample(samp, uv);
+    float3 N = gbuf_normal.Sample(samp, uv).xyz * 2.0 - 1.0;
+    float4 rm = gbuf_roughmetal.Sample(samp, uv);
+    float roughness = rm.x;
+    float metallic = rm.y;
+
+    // Reconstruct world position from depth + inverse VP matrix
+    float depth = gbuf_depth.Sample(samp, uv).r;
+    float4 clip = float4(uv * 2.0 - 1.0, depth, 1.0);
+    clip.y = -clip.y; // Vulkan Y-flip
+    float4 wp = mul(light_ubo.inv_view_proj, clip);
+    float3 world_pos = wp.xyz / wp.w;
+
+    // --- BRDF body (default or custom, emitted per-variant) ---
+    float3 result = float3(0, 0, 0);
+    // Loop-invariant expressions hoisted here by the emitter
+    float3 V = normalize(light_ubo.camera_pos - world_pos);
+
+    for (int i = 0; i < light_ubo.light_count; i++) {
+        float3 light_dir = compute_light_dir(light_ubo.lights[i], world_pos);
+        float3 light_color = compute_light_color(light_ubo.lights[i], world_pos);
+        // Per-light BRDF evaluation
+        result += evaluate_brdf(N, light_dir, V, albedo.rgb, roughness, metallic) * light_color;
+    }
+    // --- end BRDF body ---
+
+    return float4(result, 1.0);
+}
+```
+
+**Custom BRDFs:** When a material defines `:brdf`, the emitter generates a variant of the lighting shader where the inner-loop body is replaced with the user's BRDF expression. The emitter analyzes which sub-expressions in the BRDF body depend on `light_dir` / `light_color` and hoists the rest above the loop.
+
+**BRDF variant caching:** Lighting shader variants are keyed by the hash of the BRDF expression tree. Materials with identical BRDF bodies share a variant. Materials without a `:brdf` share the default Cook-Torrance variant.
+
+### Stage 5: Geometry Pass Changes
+
+The geometry pass (currently in `geometry_pass.cpp`) changes to support:
+
+- **Multiple render targets:** The framebuffer gets N color attachments matching `:outputs`.
+- **Per-material pipelines:** Instead of one hardcoded pipeline, draws are grouped by material. Each material's compiled `VkGraphicsPipeline` is bound before its draws.
+- **Material pipeline lookup:** `SceneObject::material_node_id` (currently unused) points to the `MATERIAL`-tier node whose compiled pipeline should be used.
+- **Lighting pass dispatch:** After the geometry render pass ends, dispatch the fullscreen lighting pass reading the G-buffer and writing the final lit image. This lit image is what gets stored in `ResourcePool` as the pass output.
+
+### New IR Tier: MATERIAL
+
+`Tier::MATERIAL` is added between `GPU` and `SCENE` in the enum. Material nodes are evaluated before scene nodes — they compile shader source, invoke DXC, and cache the resulting pipeline. They don't produce images; they produce pipeline handles referenced by scene objects.
+
+Evaluation order becomes: `CPU` -> `GPU` (compute) -> `MATERIAL` (shader compilation) -> `SCENE` (collection) -> `RENDER` (geometry + lighting pass).
+
+### Built-in Shader Intrinsics
+
+Operations available inside `(fn ...)` shader bodies:
+
+| Category | Ops |
+|----------|-----|
+| Arithmetic | `+`, `-`, `*`, `/`, `pow`, `sqrt`, `abs`, `floor`, `ceil`, `fract`, `mod`, `clamp`, `min`, `max` |
+| Trigonometry | `sin`, `cos`, `tan`, `asin`, `acos`, `atan`, `atan2` |
+| Vector | `dot`, `cross`, `normalize`, `length`, `reflect`, `refract`, `mix`, `step`, `smoothstep` |
+| Procedural | `noise`, `fbm`, `voronoi` |
+| Texture | `sample` |
+| Utility | `encode`, `decode` |
+| Assignment | `set` |
+| Globals | `time` |
+
+### G-Buffer Contract
+
+All materials used in a single `(pass)` must declare the same fragment output signature. The pass's `:outputs` kwarg defines the canonical channel list. Validation happens at IR analysis time:
+
+- If a material's `-> [...]` output list doesn't match the pass's `:outputs`, emit a diagnostic error with both signatures.
+- The `depth` channel is always implicit (hardware depth buffer) and should not appear in the fragment output declaration — it appears only in the pass's `:outputs` for downstream access.
+
+### Error Handling
+
+| Condition | Behavior |
+|-----------|----------|
+| Un-inlineable op inside shader body | Auto-extract as pre-pass |
+| Unknown op inside shader body | Compile error with diagnostic |
+| G-buffer signature mismatch | Compile error listing expected vs actual |
+| Shader compilation failure (DXC) | Surface DXC error as a diagnostic, skip material |
+| No materials in pass | Fall back to hardcoded `scene_basic` shaders (backwards compat) |
+| No lights in scene | Emit ambient-only lighting (albedo * 0.1) |
+| No `:brdf` on material | Use default Cook-Torrance GGX |
+| No `:vertex` on material | Use standard MVP-only vertex shader |
+| No `:fragment` on material | Use default white albedo output |
+
+### File Map
+
+| Area | Action | Files |
+|------|--------|-------|
+| Shader IR | Create | `src/shader/shader_ir.h` — expression tree types for shader bodies |
+| Shader analysis | Create | `src/shader/shader_analyzer.h`, `shader_analyzer.cpp` — classify ops, validate, build ShaderIR |
+| Pre-pass extraction | Create | `src/shader/prepass_extractor.h`, `prepass_extractor.cpp` — extract compute pre-passes |
+| HLSL emitter | Create | `src/shader/hlsl_emitter.h`, `hlsl_emitter.cpp` — ShaderIR -> HLSL source code |
+| BRDF emitter | Create | `src/shader/brdf_emitter.h`, `brdf_emitter.cpp` — custom BRDF -> lighting shader variant |
+| Inline noise | Create | `src/shader/noise_hlsl.h` — inline HLSL noise/fbm/voronoi source as string constants |
+| Deferred lighting | Create | `src/scene/lighting_pass.h`, `lighting_pass.cpp` — fullscreen lighting dispatch |
+| Default lighting shader | Create | `shaders/deferred_default.frag.hlsl` — Cook-Torrance GGX default |
+| Fullscreen vertex | Create | `shaders/fullscreen.vert.hlsl` — passthrough quad vertex shader |
+| IR tiers | Modify | `src/ir/node.h` — add `Tier::MATERIAL` |
+| IR graph | Modify | `src/ir/ir_graph.cpp` — lower `shader` to `MATERIAL` tier |
+| Types | Modify | `include/joon/types.h` — add `Type::MATERIAL` |
+| Pipeline cache | Modify | `src/vulkan/pipeline_cache.h`, `.cpp` — accept generated HLSL source (not just filenames) |
+| Render pass | Modify | `src/vulkan/render_pass.h`, `.cpp` — support N color attachments |
+| Resource pool | Modify | `src/vulkan/resource_pool.h`, `.cpp` — MRT allocation helpers |
+| Geometry pass | Modify | `src/scene/geometry_pass.cpp` — MRT framebuffer, per-material pipeline dispatch, lighting pass |
+| Scene executors | Modify | `src/scene/scene_executors.cpp` — material executor (compile shader, cache pipeline) |
+| Scene types | Modify | `include/joon/scene.h` — light UBO struct |
+| Evaluator | Modify | `src/evaluator.cpp` — MATERIAL tier evaluation before SCENE |
+| Interpreter | Modify | `src/interpreter/interpreter.cpp` — MATERIAL walk phase |
+| Node registry | Modify | `src/nodes/node_registry.h` — EvalContext gains material registry |
+| GUI app | Modify | `gui/app.cpp` — update default DSL to use shader materials |
+| Tests | Create | `tests/test_shader_ir.cpp`, `test_hlsl_emitter.cpp`, `test_prepass.cpp`, `test_lighting_pass.cpp`, `test_deferred.cpp` |
+
+### Backwards Compatibility
+
+When a `(pass)` has no materials (no scene objects have `:material`), the geometry pass falls back to the existing hardcoded `scene_basic` shaders. This preserves sub-project 2's behavior for simple scenes without materials.
+
+### Out of Scope
+
+- Transparency / alpha blending (requires forward rendering or OIT — follow-up)
+- Shadow mapping
+- Post-processing effects as built-in nodes (bloom, tone mapping)
+- Shader hot-reload during GUI editing (DXC compilation is fast enough for re-parse-on-edit)
+- Texture file loading inside materials (only procedural + pre-pass textures for now)

--- a/projects/joon/.gitignore
+++ b/projects/joon/.gitignore
@@ -1,1 +1,2 @@
 *.spv
+shaders/__gen_*

--- a/projects/joon/gui/app.cpp
+++ b/projects/joon/gui/app.cpp
@@ -7,8 +7,12 @@ void App::init() {
     ctx = joon::Context::create();
     ctx->device().log_fn = joon_log::write;
 
-    dsl_source = R"(; Joon - 3D scene
-(def c (cube :scale 1.0))
+    dsl_source = R"(; Joon - 3D scene with materials
+(def red_mat (shader
+  :fragment (fn [normal uv] -> [albedo vec4]
+    (set albedo [0.8 0.2 0.1 1]))))
+
+(def c (cube :scale 1.0 :material red_mat))
 (def cam (camera :fov 60))
 (def l (light :intensity 1.0))
 (def gbuf (pass))

--- a/projects/joon/include/joon/scene.h
+++ b/projects/joon/include/joon/scene.h
@@ -47,6 +47,19 @@ struct Camera {
     float far_z = 100.0f;
 };
 
+struct LightData {
+    float position_type[4];
+    float color_intensity[4];
+    float spot_params[4];
+};
+
+struct LightUBO {
+    LightData lights[16];
+    int light_count;
+    float camera_pos[3];
+    float inv_view_proj[16];
+};
+
 struct SceneCollection {
     std::vector<SceneObject> objects;
     std::vector<Light> lights;

--- a/projects/joon/include/joon/types.h
+++ b/projects/joon/include/joon/types.h
@@ -46,7 +46,8 @@ enum class Type {
     SCENE_OBJECT,
     LIGHT,
     CAMERA,
-    RENDER_TARGET
+    RENDER_TARGET,
+    MATERIAL
 };
 
 using Value = std::variant<

--- a/projects/joon/shaders/deferred_default.frag.hlsl
+++ b/projects/joon/shaders/deferred_default.frag.hlsl
@@ -1,0 +1,45 @@
+struct LightData {
+    float4 position_type;
+    float4 color_intensity;
+    float4 spot_params;
+};
+
+struct LightUBO {
+    LightData lights[16];
+    int light_count;
+    float3 camera_pos;
+    float4x4 inv_view_proj;
+};
+
+[[vk::binding(0, 0)]] Texture2D gbuf_albedo;
+[[vk::binding(1, 0)]] SamplerState samp;
+[[vk::binding(2, 0)]] ConstantBuffer<LightUBO> light_ubo;
+
+struct PSIn {
+    float4 sv : SV_POSITION;
+    float2 uv : TEXCOORD0;
+};
+
+float4 main(PSIn i) : SV_TARGET {
+    float4 albedo = gbuf_albedo.Sample(samp, i.uv);
+    if (albedo.a < 0.01) discard;
+
+    float3 result = albedo.rgb * 0.1;
+
+    for (int li = 0; li < light_ubo.light_count; li++) {
+        float3 light_dir;
+        float3 light_color = light_ubo.lights[li].color_intensity.xyz;
+        float type = light_ubo.lights[li].position_type.w;
+
+        if (type < 0.5) {
+            light_dir = -normalize(light_ubo.lights[li].position_type.xyz);
+        } else {
+            light_dir = normalize(light_ubo.lights[li].position_type.xyz);
+        }
+
+        float ndotl = saturate(dot(float3(0, 1, 0), light_dir));
+        result += albedo.rgb * light_color * ndotl;
+    }
+
+    return float4(result, 1.0);
+}

--- a/projects/joon/shaders/fullscreen.vert.hlsl
+++ b/projects/joon/shaders/fullscreen.vert.hlsl
@@ -1,0 +1,12 @@
+struct VSOut {
+    float4 sv : SV_POSITION;
+    float2 uv : TEXCOORD0;
+};
+
+VSOut main(uint vid : SV_VertexID) {
+    VSOut o;
+    o.uv = float2((vid << 1) & 2, vid & 2);
+    o.sv = float4(o.uv * 2.0 - 1.0, 0.0, 1.0);
+    o.uv.y = 1.0 - o.uv.y;
+    return o;
+}

--- a/projects/joon/src/dsl/ast.h
+++ b/projects/joon/src/dsl/ast.h
@@ -50,6 +50,26 @@ struct SymbolNode {
     std::string name;
 };
 
+struct FnOutput {
+    std::string name;
+    std::string type_name;
+};
+
+struct FnNode {
+    std::vector<std::string> params;
+    std::vector<FnOutput> outputs;
+    std::vector<AstPtr> body;
+};
+
+struct VectorNode {
+    std::vector<AstPtr> elements;
+};
+
+struct DotAccessNode {
+    AstPtr object;
+    std::string field;
+};
+
 struct AstNode {
     std::variant<
         DefNode,
@@ -58,7 +78,10 @@ struct AstNode {
         CallNode,
         NumberNode,
         StringNode,
-        SymbolNode
+        SymbolNode,
+        FnNode,
+        VectorNode,
+        DotAccessNode
     > data;
     uint32_t line;
     uint32_t col;

--- a/projects/joon/src/dsl/lexer.cpp
+++ b/projects/joon/src/dsl/lexer.cpp
@@ -68,7 +68,8 @@ Token Lexer::read_symbol_or_keyword() {
     advance();
     while (m_pos < m_source.size()) {
         char c = peek();
-        if (c == '(' || c == ')' || c == ' ' || c == '\t' ||
+        if (c == '(' || c == ')' || c == '[' || c == ']' ||
+            c == '.' || c == ',' || c == ' ' || c == '\t' ||
             c == '\n' || c == '\r' || c == ';' || c == '"')
             break;
         advance();
@@ -90,6 +91,19 @@ std::vector<Token> Lexer::tokenize() {
             advance();
         } else if (c == ')') {
             tokens.push_back({ TokenType::RPAREN, ")", m_line, m_col });
+            advance();
+        } else if (c == '[') {
+            tokens.push_back({ TokenType::LBRACKET, "[", m_line, m_col });
+            advance();
+        } else if (c == ']') {
+            tokens.push_back({ TokenType::RBRACKET, "]", m_line, m_col });
+            advance();
+        } else if (c == '.') {
+            tokens.push_back({ TokenType::DOT, ".", m_line, m_col });
+            advance();
+        } else if (c == '-' && m_pos + 1 < m_source.size() && m_source[m_pos + 1] == '>') {
+            tokens.push_back({ TokenType::ARROW, "->", m_line, m_col });
+            advance();
             advance();
         } else if (c == '"') {
             tokens.push_back(read_string());

--- a/projects/joon/src/dsl/parser.cpp
+++ b/projects/joon/src/dsl/parser.cpp
@@ -119,6 +119,10 @@ AstPtr Parser::parse_call(const Token& op) {
     auto line = op.line, col = op.col;
     auto op_name = advance().text;
 
+    if (op_name == "fn") {
+        return parse_fn(line, col);
+    }
+
     std::vector<AstPtr> args;
     std::vector<KeywordArg> kwargs;
 
@@ -139,11 +143,89 @@ AstPtr Parser::parse_call(const Token& op) {
     return node;
 }
 
+AstPtr Parser::parse_fn(uint32_t line, uint32_t col) {
+    FnNode fn;
+
+    expect(TokenType::LBRACKET, "'[' for parameter list");
+    advance();
+    while (peek().type != TokenType::RBRACKET) {
+        auto tok = advance();
+        fn.params.push_back(tok.text);
+    }
+    advance(); // consume ]
+
+    if (peek().type == TokenType::ARROW) {
+        advance(); // consume ->
+        expect(TokenType::LBRACKET, "'[' for output list");
+        advance();
+        while (peek().type != TokenType::RBRACKET) {
+            FnOutput out;
+            out.name = advance().text;
+            out.type_name = advance().text;
+            fn.outputs.push_back(std::move(out));
+            if (peek().type == TokenType::SYMBOL && peek().text == ",")
+                advance();
+        }
+        advance(); // consume ]
+    }
+
+    while (peek().type != TokenType::RPAREN) {
+        fn.body.push_back(parse_expr());
+    }
+
+    auto node = std::make_unique<AstNode>();
+    node->data = std::move(fn);
+    node->line = line;
+    node->col = col;
+    return node;
+}
+
+AstPtr Parser::parse_vector() {
+    auto start = advance(); // consume [
+    VectorNode vec;
+    while (peek().type != TokenType::RBRACKET) {
+        vec.elements.push_back(parse_expr());
+        if (peek().type == TokenType::SYMBOL && peek().text == ",")
+            advance();
+    }
+    advance(); // consume ]
+    auto node = std::make_unique<AstNode>();
+    node->data = std::move(vec);
+    node->line = start.line;
+    node->col = start.col;
+    return node;
+}
+
+AstPtr Parser::parse_expression() {
+    return parse_expr();
+}
+
 AstPtr Parser::parse_expr() {
+    auto primary = parse_primary();
+    while (peek().type == TokenType::DOT) {
+        advance(); // consume .
+        auto field_tok = advance();
+        auto dot = std::make_unique<AstNode>();
+        DotAccessNode dn;
+        dn.object = std::move(primary);
+        dn.field = field_tok.text;
+        dot->data = std::move(dn);
+        dot->line = field_tok.line;
+        dot->col = field_tok.col;
+        primary = std::move(dot);
+    }
+    return primary;
+}
+
+AstPtr Parser::parse_primary() {
     const auto& tok = peek();
 
     if (tok.type == TokenType::LPAREN) {
         return parse_form();
+    }
+
+    if (tok.type == TokenType::LBRACKET) {
+        return parse_vector();
     }
 
     if (tok.type == TokenType::NUMBER) {

--- a/projects/joon/src/dsl/parser.h
+++ b/projects/joon/src/dsl/parser.h
@@ -19,6 +19,7 @@ class Parser {
 public:
     explicit Parser(std::string_view source);
     Program parse();
+    AstPtr parse_expression();
 
 private:
     std::vector<Token> m_tokens;
@@ -35,6 +36,9 @@ private:
     AstPtr parse_output();
     AstPtr parse_call(const Token& op);
     AstPtr parse_expr();
+    AstPtr parse_primary();
+    AstPtr parse_vector();
+    AstPtr parse_fn(uint32_t line, uint32_t col);
 };
 
 } // namespace joon

--- a/projects/joon/src/dsl/token.h
+++ b/projects/joon/src/dsl/token.h
@@ -8,6 +8,10 @@ namespace joon {
 enum class TokenType {
     LPAREN,      // (
     RPAREN,      // )
+    LBRACKET,    // [
+    RBRACKET,    // ]
+    DOT,         // .
+    ARROW,       // ->
     SYMBOL,      // def, noise, +, -, *, /
     KEYWORD,     // :scale, :min
     NUMBER,      // 1.0, 42

--- a/projects/joon/src/evaluator.cpp
+++ b/projects/joon/src/evaluator.cpp
@@ -114,16 +114,20 @@ struct Evaluator::Impl {
         graph = ctx.parse_string(""); // placeholder
         graph.ir() = source_graph.ir(); // copy IR
 
-        VkDescriptorPoolSize pool_sizes[2]{};
+        VkDescriptorPoolSize pool_sizes[4]{};
         pool_sizes[0].type = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
         pool_sizes[0].descriptorCount = 256;
         pool_sizes[1].type = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
-        pool_sizes[1].descriptorCount = 256;   // for graphics-pipeline UBOs (geometry pass)
+        pool_sizes[1].descriptorCount = 256;
+        pool_sizes[2].type = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
+        pool_sizes[2].descriptorCount = 64;
+        pool_sizes[3].type = VK_DESCRIPTOR_TYPE_SAMPLER;
+        pool_sizes[3].descriptorCount = 64;
 
         VkDescriptorPoolCreateInfo pool_info{};
         pool_info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
         pool_info.maxSets = 256;
-        pool_info.poolSizeCount = 2;
+        pool_info.poolSizeCount = 4;
         pool_info.pPoolSizes = pool_sizes;
         pool_info.flags = VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT;
         vkCreateDescriptorPool(ctx.device().device, &pool_info, nullptr, &desc_pool);

--- a/projects/joon/src/evaluator.cpp
+++ b/projects/joon/src/evaluator.cpp
@@ -153,7 +153,9 @@ void Evaluator::evaluate() {
         *m_impl->pipelines,
         512, 512,
         m_impl->desc_pool,
-        m_impl->scene
+        m_impl->scene,
+        &m_impl->graph.ir().shader_defs,
+        {}
     };
 
     Interpreter interp(eval_ctx, m_impl->registry);

--- a/projects/joon/src/interpreter/interpreter.cpp
+++ b/projects/joon/src/interpreter/interpreter.cpp
@@ -25,11 +25,25 @@ void Interpreter::evaluate(IRGraph& graph) {
         if (executor) (*executor)(node, m_ctx);
     }
 
-    // Phase 2: CPU constants + GPU compute + RENDER passes in topological
+    // Phase 2: MATERIAL tier — compile shaders, cache pipelines.
+    for (uint32_t id : order) {
+        auto& node = graph.nodes[id];
+        if (node.tier != Tier::MATERIAL) continue;
+
+        for (auto& kw : node.kwargs) {
+            if (kw.source_node != UINT32_MAX && kw.source_node < graph.nodes.size())
+                kw.value = graph.nodes[kw.source_node].constant_value;
+        }
+
+        auto* executor = m_registry.find(node.op);
+        if (executor) (*executor)(node, m_ctx);
+    }
+
+    // Phase 3: CPU constants + GPU compute + RENDER passes in topological
     // order so producer-consumer chains (e.g. pass → levels) execute correctly.
     for (uint32_t id : order) {
         auto& node = graph.nodes[id];
-        if (node.tier == Tier::SCENE) continue;   // already done
+        if (node.tier == Tier::SCENE || node.tier == Tier::MATERIAL) continue;
 
         // Skip nodes that don't produce GPU resources via an executor
         if (node.op == "constant" || node.op == "string_constant" ||

--- a/projects/joon/src/ir/ir_graph.cpp
+++ b/projects/joon/src/ir/ir_graph.cpp
@@ -173,6 +173,28 @@ uint32_t IRGraph::resolve_expr(const AstNode& expr) {
         return id;
     }
 
+    if (auto* dot = std::get_if<DotAccessNode>(&expr.data)) {
+        auto* obj_sym = std::get_if<SymbolNode>(&dot->object->data);
+        if (obj_sym) {
+            auto it = m_nameToNode.find(obj_sym->name);
+            if (it != m_nameToNode.end()) {
+                uint32_t parent_id = it->second;
+                uint32_t id = add_node("channel_select", Tier::GPU);
+                nodes[id].inputs.push_back(parent_id);
+                edges.push_back({ parent_id, id, 0 });
+                nodes[id].string_arg = dot->field;
+                nodes[id].output_type = Type::IMAGE;
+                return id;
+            }
+        }
+        diagnostics.push_back({
+            Diagnostic::Level::ERROR,
+            "Invalid dot access",
+            expr.line, expr.col
+        });
+        return add_node("error", Tier::CPU);
+    }
+
     diagnostics.push_back({
         Diagnostic::Level::ERROR,
         "Unexpected expression",

--- a/projects/joon/src/ir/ir_graph.cpp
+++ b/projects/joon/src/ir/ir_graph.cpp
@@ -104,10 +104,14 @@ uint32_t IRGraph::resolve_expr(const AstNode& expr) {
         static const std::unordered_set<std::string> CPU_OPS = {
             "image", "color", "save"
         };
+        static const std::unordered_set<std::string> MATERIAL_OPS = { "shader" };
 
         Tier tier;
         Type output_type = Type::FLOAT;
-        if (SCENE_OPS.count(call->op)) {
+        if (MATERIAL_OPS.count(call->op)) {
+            tier = Tier::MATERIAL;
+            output_type = Type::MATERIAL;
+        } else if (SCENE_OPS.count(call->op)) {
             tier = Tier::SCENE;
             if (call->op == "light") output_type = Type::LIGHT;
             else if (call->op == "camera") output_type = Type::CAMERA;
@@ -146,6 +150,24 @@ uint32_t IRGraph::resolve_expr(const AstNode& expr) {
                     nodes[id].string_arg = ksym->name;
                 }
             }
+        }
+
+        if (call->op == "shader") {
+            ShaderDef sd;
+            for (auto& kw : call->kwargs) {
+                auto* fn = std::get_if<FnNode>(&kw.value->data);
+                if (!fn) continue;
+                ShaderFnDef fndef;
+                fndef.params = fn->params;
+                for (auto& o : fn->outputs)
+                    fndef.outputs.push_back({o.name, o.type_name});
+                for (auto& b : fn->body)
+                    fndef.body.push_back(std::shared_ptr<AstNode>(std::move(b)));
+                if (kw.name == "vertex") sd.vertex = std::move(fndef);
+                else if (kw.name == "fragment") sd.fragment = std::move(fndef);
+                else if (kw.name == "brdf") sd.brdf = std::move(fndef);
+            }
+            shader_defs[id] = std::move(sd);
         }
 
         return id;

--- a/projects/joon/src/ir/ir_graph.h
+++ b/projects/joon/src/ir/ir_graph.h
@@ -22,6 +22,7 @@ public:
     std::vector<ParamInfo> params;
     std::vector<OutputInfo> outputs;
     std::vector<Diagnostic> diagnostics;
+    std::unordered_map<uint32_t, ShaderDef> shader_defs;
 
     static IRGraph from_ast(const Program& program);
 

--- a/projects/joon/src/ir/node.h
+++ b/projects/joon/src/ir/node.h
@@ -1,17 +1,20 @@
 #pragma once
 
 #include <joon/types.h>
+#include "dsl/ast.h"
 #include <string>
 #include <vector>
+#include <optional>
 #include <unordered_map>
 #include <cstdint>
 
 namespace joon {
 
 // Order matches interpreter execution phases: CPU constants resolve first,
-// then GPU compute dispatches, then SCENE collection, then RENDER pass.
+// then GPU compute dispatches, then MATERIAL shader compilation,
+// then SCENE collection, then RENDER pass.
 // Don't reorder without auditing the interpreter walk in interpreter.cpp.
-enum class Tier { CPU, GPU, SCENE, RENDER };
+enum class Tier { CPU, GPU, MATERIAL, SCENE, RENDER };
 
 struct Edge {
     uint32_t from_node;
@@ -23,6 +26,19 @@ struct ResolvedKwarg {
     std::string name;
     Value value;
     uint32_t source_node = UINT32_MAX;
+};
+
+struct ShaderFnDef {
+    std::vector<std::string> params;
+    struct Output { std::string name; std::string type_name; };
+    std::vector<Output> outputs;
+    std::vector<std::shared_ptr<AstNode>> body;
+};
+
+struct ShaderDef {
+    std::optional<ShaderFnDef> vertex;
+    std::optional<ShaderFnDef> fragment;
+    std::optional<ShaderFnDef> brdf;
 };
 
 struct Node {

--- a/projects/joon/src/ir/type_checker.cpp
+++ b/projects/joon/src/ir/type_checker.cpp
@@ -30,9 +30,9 @@ void type_check(IRGraph& graph) {
             continue;
         }
 
-        // Scene and render tiers carry their own output types set during
-        // IR lowering; type checking for those is handled by future passes.
-        if (node.tier == Tier::SCENE || node.tier == Tier::RENDER) {
+        // Material, scene, and render tiers carry their own output types set
+        // during IR lowering; type checking for those is handled by future passes.
+        if (node.tier == Tier::MATERIAL || node.tier == Tier::SCENE || node.tier == Tier::RENDER) {
             continue;
         }
 

--- a/projects/joon/src/ir/type_checker.cpp
+++ b/projects/joon/src/ir/type_checker.cpp
@@ -86,6 +86,13 @@ void type_check(IRGraph& graph) {
             continue;
         }
 
+        if (node.op == "channel_select") {
+            if (!node.inputs.empty()) {
+                node.output_type = graph.nodes[node.inputs[0]].output_type;
+            }
+            continue;
+        }
+
         if (node.op == "save") {
             if (!node.inputs.empty()) {
                 node.output_type = graph.nodes[node.inputs[0]].output_type;

--- a/projects/joon/src/nodes/image_ops.cpp
+++ b/projects/joon/src/nodes/image_ops.cpp
@@ -80,6 +80,11 @@ void register_image_ops(NodeRegistry& reg) {
         auto* out = ctx.pool.alloc_image(node.id, w, h);
         gpu_dispatch(ctx, "blend", {a, b, out}, w, h, &pc, sizeof(pc));
     });
+
+    reg.register_node("channel_select", [](const Node& node, EvalContext& ctx) {
+        if (node.inputs.empty()) return;
+        ctx.pool.alias_image(node.id, node.inputs[0]);
+    });
 }
 
 } // namespace joon

--- a/projects/joon/src/nodes/node_registry.cpp
+++ b/projects/joon/src/nodes/node_registry.cpp
@@ -22,6 +22,7 @@ NodeRegistry NodeRegistry::create_default() {
     register_save(reg);
     register_scene_nodes(reg);
     register_geometry_pass(reg);
+    register_material_nodes(reg);
     return reg;
 }
 

--- a/projects/joon/src/nodes/node_registry.h
+++ b/projects/joon/src/nodes/node_registry.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "ir/node.h"
+#include "ir/ir_graph.h"
 #include "vulkan/device.h"
 #include "vulkan/resource_pool.h"
 #include "vulkan/pipeline_cache.h"
@@ -20,6 +21,8 @@ struct EvalContext {
     uint32_t default_height;
     VkDescriptorPool desc_pool;
     SceneCollection& scene;
+    std::unordered_map<uint32_t, ShaderDef>* shader_defs = nullptr;
+    std::unordered_map<uint32_t, const GraphicsPipeline*> material_pipelines;
 };
 
 using NodeExecutor = std::function<void(const Node& node, EvalContext& ctx)>;
@@ -43,5 +46,6 @@ void register_image_ops(NodeRegistry& reg);
 void register_save(NodeRegistry& reg);
 void register_scene_nodes(NodeRegistry& reg);
 void register_geometry_pass(NodeRegistry& reg);
+void register_material_nodes(NodeRegistry& reg);
 
 } // namespace joon

--- a/projects/joon/src/nodes/node_registry.h
+++ b/projects/joon/src/nodes/node_registry.h
@@ -2,6 +2,7 @@
 
 #include "ir/node.h"
 #include "ir/ir_graph.h"
+#include "shader/shader_ir.h"
 #include "vulkan/device.h"
 #include "vulkan/resource_pool.h"
 #include "vulkan/pipeline_cache.h"
@@ -23,6 +24,7 @@ struct EvalContext {
     SceneCollection& scene;
     std::unordered_map<uint32_t, ShaderDef>* shader_defs = nullptr;
     std::unordered_map<uint32_t, const GraphicsPipeline*> material_pipelines;
+    std::unordered_map<uint32_t, ShaderFnIR> material_brdfs;
 };
 
 using NodeExecutor = std::function<void(const Node& node, EvalContext& ctx)>;

--- a/projects/joon/src/scene/geometry_pass.cpp
+++ b/projects/joon/src/scene/geometry_pass.cpp
@@ -1,4 +1,5 @@
 #include "scene/geometry_pass.h"
+#include "scene/lighting_pass.h"
 #include "nodes/node_registry.h"
 #include "ir/node.h"
 #include "vulkan/buffer.h"
@@ -27,10 +28,10 @@ struct PushLight {
 };
 
 void exec_pass(const Node& n, EvalContext& ctx) {
-    // The pass node owns the color render-target slot at its own node id.
-    // The depth slot is keyed at (node_id ^ 0x80000000) — outside the normal
-    // node-id range so it can't collide with another graph node.
-    uint32_t color_id = n.id;
+    bool has_materials = !ctx.material_pipelines.empty();
+    // When materials are active, G-buffer goes to an intermediate slot and
+    // the lighting pass writes the final lit output to n.id.
+    uint32_t color_id = has_materials ? (n.id ^ 0x40000000u) : n.id;
     uint32_t depth_id = n.id ^ 0x80000000u;
 
     auto* albedo = ctx.pool.alloc_render_target(color_id, ctx.default_width, ctx.default_height);
@@ -194,6 +195,15 @@ void exec_pass(const Node& n, EvalContext& ctx) {
     for (auto& b : per_frame_bufs) destroy_buffer(ctx.device, b);
     vkDestroyFramebuffer(ctx.device.device, fb, nullptr);
     destroy_renderpass(ctx.device, rp);
+
+    if (!ctx.material_pipelines.empty()) {
+        LightingPassConfig lcfg{
+            ctx.device, ctx.pipelines, ctx.pool, ctx.desc_pool,
+            ctx.scene, ctx.default_width, ctx.default_height,
+            albedo, n.id
+        };
+        dispatch_lighting_pass(lcfg);
+    }
 }
 
 } // namespace

--- a/projects/joon/src/scene/geometry_pass.cpp
+++ b/projects/joon/src/scene/geometry_pass.cpp
@@ -94,15 +94,29 @@ void exec_pass(const Node& n, EvalContext& ctx) {
     scissor.extent = { ctx.default_width, ctx.default_height };
     vkCmdSetScissor(cmd, 0, 1, &scissor);
 
-    vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, gp.pipeline);
-    vkCmdPushConstants(cmd, gp.layout, VK_SHADER_STAGE_FRAGMENT_BIT, 0, sizeof(pc), &pc);
-
     // Per-frame buffers — freed after submit.
     std::vector<GpuBuffer> per_frame_bufs;
     per_frame_bufs.reserve(ctx.scene.objects.size() * 3);
 
+    VkPipeline bound_pipeline = VK_NULL_HANDLE;
+
     for (const auto& obj : ctx.scene.objects) {
         if (obj.mesh.vertices.empty() || obj.mesh.indices.empty()) continue;
+
+        // Select pipeline: per-material if available, else default.
+        const GraphicsPipeline* cur_gp = &gp;
+        if (obj.material_node_id != UINT32_MAX) {
+            auto mat_it = ctx.material_pipelines.find(obj.material_node_id);
+            if (mat_it != ctx.material_pipelines.end())
+                cur_gp = mat_it->second;
+        }
+
+        if (cur_gp->pipeline != bound_pipeline) {
+            vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, cur_gp->pipeline);
+            bound_pipeline = cur_gp->pipeline;
+            if (cur_gp == &gp)
+                vkCmdPushConstants(cmd, gp.layout, VK_SHADER_STAGE_FRAGMENT_BIT, 0, sizeof(pc), &pc);
+        }
 
         auto vb = create_vertex_buffer(ctx.device,
                                         obj.mesh.vertices.data(),
@@ -121,7 +135,7 @@ void exec_pass(const Node& n, EvalContext& ctx) {
         dai.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
         dai.descriptorPool = ctx.desc_pool;
         dai.descriptorSetCount = 1;
-        dai.pSetLayouts = &gp.desc_layout;
+        dai.pSetLayouts = &cur_gp->desc_layout;
         VkDescriptorSet ds = VK_NULL_HANDLE;
         vkAllocateDescriptorSets(ctx.device.device, &dai, &ds);
 
@@ -139,7 +153,7 @@ void exec_pass(const Node& n, EvalContext& ctx) {
         wds.pBufferInfo = &dbi;
         vkUpdateDescriptorSets(ctx.device.device, 1, &wds, 0, nullptr);
 
-        vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, gp.layout,
+        vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, cur_gp->layout,
                                  0, 1, &ds, 0, nullptr);
 
         VkBuffer vb_handle = vb.buffer;

--- a/projects/joon/src/scene/geometry_pass.cpp
+++ b/projects/joon/src/scene/geometry_pass.cpp
@@ -197,10 +197,15 @@ void exec_pass(const Node& n, EvalContext& ctx) {
     destroy_renderpass(ctx.device, rp);
 
     if (!ctx.material_pipelines.empty()) {
+        const ShaderFnIR* brdf = nullptr;
+        for (auto& [mat_id, fn_ir] : ctx.material_brdfs) {
+            brdf = &fn_ir;
+            break;
+        }
         LightingPassConfig lcfg{
             ctx.device, ctx.pipelines, ctx.pool, ctx.desc_pool,
             ctx.scene, ctx.default_width, ctx.default_height,
-            albedo, n.id
+            albedo, n.id, brdf
         };
         dispatch_lighting_pass(lcfg);
     }

--- a/projects/joon/src/scene/lighting_pass.cpp
+++ b/projects/joon/src/scene/lighting_pass.cpp
@@ -1,4 +1,5 @@
 #include "scene/lighting_pass.h"
+#include "shader/brdf_emitter.h"
 #include "vulkan/buffer.h"
 #include "vulkan/render_pass.h"
 
@@ -9,7 +10,17 @@ void dispatch_lighting_pass(const LightingPassConfig& cfg) {
         cfg.output_node_id, cfg.width, cfg.height, VK_FORMAT_R32G32B32A32_SFLOAT);
 
     RenderPass rp = create_color_renderpass(cfg.device, lit_output->format);
-    auto& gp = cfg.pipelines.get_fullscreen("deferred_default", rp.pass);
+
+    const GraphicsPipeline* gp_ptr;
+    if (cfg.brdf) {
+        BrdfEmitter brdf_emitter;
+        std::string frag_src = brdf_emitter.emit_lighting_shader(*cfg.brdf);
+        std::string brdf_key = "brdf_" + std::to_string(cfg.output_node_id);
+        gp_ptr = &cfg.pipelines.get_fullscreen_from_source(brdf_key, frag_src, rp.pass);
+    } else {
+        gp_ptr = &cfg.pipelines.get_fullscreen("deferred_default", rp.pass);
+    }
+    auto& gp = *gp_ptr;
 
     VkFramebufferCreateInfo fb_info{};
     fb_info.sType = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;

--- a/projects/joon/src/scene/lighting_pass.cpp
+++ b/projects/joon/src/scene/lighting_pass.cpp
@@ -1,0 +1,159 @@
+#include "scene/lighting_pass.h"
+#include "vulkan/buffer.h"
+#include "vulkan/render_pass.h"
+
+namespace joon {
+
+void dispatch_lighting_pass(const LightingPassConfig& cfg) {
+    auto* lit_output = cfg.pool.alloc_render_target(
+        cfg.output_node_id, cfg.width, cfg.height, VK_FORMAT_R32G32B32A32_SFLOAT);
+
+    RenderPass rp = create_color_renderpass(cfg.device, lit_output->format);
+    auto& gp = cfg.pipelines.get_fullscreen("deferred_default", rp.pass);
+
+    VkFramebufferCreateInfo fb_info{};
+    fb_info.sType = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
+    fb_info.renderPass = rp.pass;
+    fb_info.attachmentCount = 1;
+    fb_info.pAttachments = &lit_output->view;
+    fb_info.width = cfg.width;
+    fb_info.height = cfg.height;
+    fb_info.layers = 1;
+    VkFramebuffer fb = VK_NULL_HANDLE;
+    vkCreateFramebuffer(cfg.device.device, &fb_info, nullptr, &fb);
+
+    LightUBO lubo{};
+    lubo.light_count = static_cast<int>(
+        cfg.scene.lights.size() < 16 ? cfg.scene.lights.size() : 16);
+    for (int li = 0; li < lubo.light_count; li++) {
+        const auto& l = cfg.scene.lights[li];
+        if (l.type == LightType::Directional) {
+            lubo.lights[li].position_type[0] = l.direction.x;
+            lubo.lights[li].position_type[1] = l.direction.y;
+            lubo.lights[li].position_type[2] = l.direction.z;
+            lubo.lights[li].position_type[3] = 0.0f;
+        } else {
+            lubo.lights[li].position_type[0] = l.position.x;
+            lubo.lights[li].position_type[1] = l.position.y;
+            lubo.lights[li].position_type[2] = l.position.z;
+            lubo.lights[li].position_type[3] = 1.0f;
+        }
+        lubo.lights[li].color_intensity[0] = l.color.x * l.intensity;
+        lubo.lights[li].color_intensity[1] = l.color.y * l.intensity;
+        lubo.lights[li].color_intensity[2] = l.color.z * l.intensity;
+        lubo.lights[li].color_intensity[3] = 0.0f;
+    }
+
+    auto ub = create_uniform_buffer(cfg.device, sizeof(LightUBO));
+    update_uniform_buffer(cfg.device, ub, &lubo, sizeof(LightUBO));
+
+    VkDescriptorSetAllocateInfo dai{};
+    dai.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
+    dai.descriptorPool = cfg.desc_pool;
+    dai.descriptorSetCount = 1;
+    dai.pSetLayouts = &gp.desc_layout;
+    VkDescriptorSet ds = VK_NULL_HANDLE;
+    vkAllocateDescriptorSets(cfg.device.device, &dai, &ds);
+
+    VkDescriptorImageInfo img_info{};
+    img_info.imageView = cfg.albedo_target->view;
+    img_info.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
+
+    VkSamplerCreateInfo samp_info{};
+    samp_info.sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
+    samp_info.magFilter = VK_FILTER_LINEAR;
+    samp_info.minFilter = VK_FILTER_LINEAR;
+    samp_info.addressModeU = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+    samp_info.addressModeV = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+    samp_info.addressModeW = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+    VkSampler sampler = VK_NULL_HANDLE;
+    vkCreateSampler(cfg.device.device, &samp_info, nullptr, &sampler);
+
+    VkDescriptorImageInfo samp_desc{};
+    samp_desc.sampler = sampler;
+
+    VkDescriptorBufferInfo buf_info{};
+    buf_info.buffer = ub.buffer;
+    buf_info.offset = 0;
+    buf_info.range = sizeof(LightUBO);
+
+    VkWriteDescriptorSet writes[3]{};
+    writes[0].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+    writes[0].dstSet = ds;
+    writes[0].dstBinding = 0;
+    writes[0].descriptorCount = 1;
+    writes[0].descriptorType = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
+    writes[0].pImageInfo = &img_info;
+
+    writes[1].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+    writes[1].dstSet = ds;
+    writes[1].dstBinding = 1;
+    writes[1].descriptorCount = 1;
+    writes[1].descriptorType = VK_DESCRIPTOR_TYPE_SAMPLER;
+    writes[1].pImageInfo = &samp_desc;
+
+    writes[2].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+    writes[2].dstSet = ds;
+    writes[2].dstBinding = 2;
+    writes[2].descriptorCount = 1;
+    writes[2].descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+    writes[2].pBufferInfo = &buf_info;
+
+    vkUpdateDescriptorSets(cfg.device.device, 3, writes, 0, nullptr);
+
+    VkCommandBuffer cmd = cfg.device.begin_single_command();
+
+    VkClearValue clear{};
+    clear.color = {{ 0.0f, 0.0f, 0.0f, 1.0f }};
+
+    VkRenderPassBeginInfo rpi{};
+    rpi.sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;
+    rpi.renderPass = rp.pass;
+    rpi.framebuffer = fb;
+    rpi.renderArea.extent = { cfg.width, cfg.height };
+    rpi.clearValueCount = 1;
+    rpi.pClearValues = &clear;
+
+    vkCmdBeginRenderPass(cmd, &rpi, VK_SUBPASS_CONTENTS_INLINE);
+
+    VkViewport vp{};
+    vp.width = static_cast<float>(cfg.width);
+    vp.height = static_cast<float>(cfg.height);
+    vp.minDepth = 0; vp.maxDepth = 1;
+    vkCmdSetViewport(cmd, 0, 1, &vp);
+
+    VkRect2D scissor{};
+    scissor.extent = { cfg.width, cfg.height };
+    vkCmdSetScissor(cmd, 0, 1, &scissor);
+
+    vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, gp.pipeline);
+    vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, gp.layout,
+                             0, 1, &ds, 0, nullptr);
+    vkCmdDraw(cmd, 3, 1, 0, 0);
+
+    vkCmdEndRenderPass(cmd);
+
+    VkImageMemoryBarrier barrier{};
+    barrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+    barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    barrier.oldLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+    barrier.newLayout = VK_IMAGE_LAYOUT_GENERAL;
+    barrier.image = lit_output->image;
+    barrier.subresourceRange = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1 };
+    barrier.srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+    barrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_TRANSFER_READ_BIT;
+    vkCmdPipelineBarrier(cmd,
+                          VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+                          VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT | VK_PIPELINE_STAGE_TRANSFER_BIT,
+                          0, 0, nullptr, 0, nullptr, 1, &barrier);
+
+    cfg.device.end_single_command(cmd);
+
+    vkDestroySampler(cfg.device.device, sampler, nullptr);
+    destroy_buffer(cfg.device, ub);
+    vkDestroyFramebuffer(cfg.device.device, fb, nullptr);
+    destroy_renderpass(cfg.device, rp);
+}
+
+} // namespace joon

--- a/projects/joon/src/scene/lighting_pass.h
+++ b/projects/joon/src/scene/lighting_pass.h
@@ -2,6 +2,7 @@
 #include "vulkan/device.h"
 #include "vulkan/pipeline_cache.h"
 #include "vulkan/resource_pool.h"
+#include "shader/shader_ir.h"
 #include <joon/scene.h>
 #include <joon/math.h>
 
@@ -16,6 +17,7 @@ struct LightingPassConfig {
     uint32_t width, height;
     GpuImage* albedo_target;
     uint32_t output_node_id;
+    const ShaderFnIR* brdf = nullptr;
 };
 
 void dispatch_lighting_pass(const LightingPassConfig& cfg);

--- a/projects/joon/src/scene/lighting_pass.h
+++ b/projects/joon/src/scene/lighting_pass.h
@@ -1,0 +1,23 @@
+#pragma once
+#include "vulkan/device.h"
+#include "vulkan/pipeline_cache.h"
+#include "vulkan/resource_pool.h"
+#include <joon/scene.h>
+#include <joon/math.h>
+
+namespace joon {
+
+struct LightingPassConfig {
+    Device& device;
+    PipelineCache& pipelines;
+    ResourcePool& pool;
+    VkDescriptorPool desc_pool;
+    const SceneCollection& scene;
+    uint32_t width, height;
+    GpuImage* albedo_target;
+    uint32_t output_node_id;
+};
+
+void dispatch_lighting_pass(const LightingPassConfig& cfg);
+
+} // namespace joon

--- a/projects/joon/src/scene/material_executor.cpp
+++ b/projects/joon/src/scene/material_executor.cpp
@@ -1,0 +1,68 @@
+#include "scene/material_executor.h"
+#include "nodes/node_registry.h"
+#include "ir/node.h"
+#include "shader/shader_analyzer.h"
+#include "shader/hlsl_emitter.h"
+#include "vulkan/render_pass.h"
+
+namespace joon {
+
+namespace {
+
+void exec_shader(const Node& n, EvalContext& ctx) {
+    if (!ctx.shader_defs) return;
+    auto it = ctx.shader_defs->find(n.id);
+    if (it == ctx.shader_defs->end()) return;
+
+    ShaderAnalyzer analyzer;
+    auto ir = analyzer.analyze(it->second);
+
+    HlslEmitter emitter;
+
+    std::string vert_src;
+    if (ir.vertex) {
+        vert_src = emitter.emit_vertex(*ir.vertex);
+    } else {
+        ShaderFnIR default_vert;
+        default_vert.params = {"pos", "normal", "uv"};
+        vert_src = emitter.emit_vertex(default_vert);
+    }
+
+    std::string frag_src;
+    if (ir.fragment) {
+        frag_src = emitter.emit_fragment(*ir.fragment, 0);
+    } else {
+        ShaderFnIR default_frag;
+        default_frag.params = {"normal", "uv"};
+        default_frag.outputs = {{"albedo", "vec4"}};
+        ShaderAssign sa;
+        sa.target = "albedo";
+        ShaderVecConstruct vc;
+        for (int i = 0; i < 4; i++)
+            vc.elements.push_back(std::make_unique<ShaderExpr>(ShaderLiteral{1.0f}));
+        sa.value = std::make_unique<ShaderExpr>(std::move(vc));
+        default_frag.body.push_back(std::make_unique<ShaderExpr>(std::move(sa)));
+        frag_src = emitter.emit_fragment(default_frag, 0);
+    }
+
+    std::string key = "mat_" + std::to_string(n.id);
+    uint32_t num_outputs = ir.fragment
+        ? static_cast<uint32_t>(ir.fragment->outputs.size()) : 1;
+
+    std::vector<VkFormat> formats(num_outputs, VK_FORMAT_R32G32B32A32_SFLOAT);
+    auto rp = create_color_depth_renderpass(ctx.device, formats);
+
+    auto& gp = ctx.pipelines.get_graphics_from_source(
+        key, vert_src, frag_src, rp.pass, 0, num_outputs);
+    ctx.material_pipelines[n.id] = &gp;
+
+    destroy_renderpass(ctx.device, rp);
+}
+
+} // namespace
+
+void register_material_nodes(NodeRegistry& reg) {
+    reg.register_node("shader", exec_shader);
+}
+
+} // namespace joon

--- a/projects/joon/src/scene/material_executor.cpp
+++ b/projects/joon/src/scene/material_executor.cpp
@@ -56,6 +56,10 @@ void exec_shader(const Node& n, EvalContext& ctx) {
         key, vert_src, frag_src, rp.pass, 0, num_outputs);
     ctx.material_pipelines[n.id] = &gp;
 
+    if (ir.brdf) {
+        ctx.material_brdfs[n.id] = std::move(*ir.brdf);
+    }
+
     destroy_renderpass(ctx.device, rp);
 }
 

--- a/projects/joon/src/scene/material_executor.h
+++ b/projects/joon/src/scene/material_executor.h
@@ -1,0 +1,6 @@
+#pragma once
+
+namespace joon {
+class NodeRegistry;
+void register_material_nodes(NodeRegistry& reg);
+} // namespace joon

--- a/projects/joon/src/scene/scene_executors.cpp
+++ b/projects/joon/src/scene/scene_executors.cpp
@@ -26,11 +26,18 @@ vec3 kwarg_vec3(const Node& /*n*/, const char* /*name*/, vec3 fallback) {
     return fallback;
 }
 
+uint32_t kwarg_source_node(const Node& n, const char* name) {
+    for (const auto& k : n.kwargs)
+        if (k.name == name) return k.source_node;
+    return UINT32_MAX;
+}
+
 void exec_cube(const Node& n, EvalContext& ctx) {
     SceneObject o;
     o.mesh = gen_cube(kwarg_float(n, "scale", 1.0f));
     o.position = kwarg_vec3(n, "position", {0, 0, 0});
     o.rotation = kwarg_vec3(n, "rotation", {0, 0, 0});
+    o.material_node_id = kwarg_source_node(n, "material");
     ctx.scene.add_object(std::move(o));
 }
 
@@ -39,6 +46,7 @@ void exec_sphere(const Node& n, EvalContext& ctx) {
     o.mesh = gen_sphere(kwarg_float(n, "radius", 0.5f));
     o.position = kwarg_vec3(n, "position", {0, 0, 0});
     o.rotation = kwarg_vec3(n, "rotation", {0, 0, 0});
+    o.material_node_id = kwarg_source_node(n, "material");
     ctx.scene.add_object(std::move(o));
 }
 
@@ -48,6 +56,7 @@ void exec_plane(const Node& n, EvalContext& ctx) {
                        kwarg_float(n, "height", 1.0f));
     o.position = kwarg_vec3(n, "position", {0, 0, 0});
     o.rotation = kwarg_vec3(n, "rotation", {0, 0, 0});
+    o.material_node_id = kwarg_source_node(n, "material");
     ctx.scene.add_object(std::move(o));
 }
 
@@ -58,16 +67,16 @@ void exec_cylinder(const Node& n, EvalContext& ctx) {
                           static_cast<int>(kwarg_float(n, "segments", 32.0f)));
     o.position = kwarg_vec3(n, "position", {0, 0, 0});
     o.rotation = kwarg_vec3(n, "rotation", {0, 0, 0});
+    o.material_node_id = kwarg_source_node(n, "material");
     ctx.scene.add_object(std::move(o));
 }
 
 void exec_mesh(const Node& n, EvalContext& ctx) {
-    // The OBJ file path comes through as Node::string_arg (parser stores the
-    // first string-typed positional arg there).
     SceneObject o;
     if (!n.string_arg.empty()) o.mesh = load_obj_file(n.string_arg);
     o.position = kwarg_vec3(n, "position", {0, 0, 0});
     o.rotation = kwarg_vec3(n, "rotation", {0, 0, 0});
+    o.material_node_id = kwarg_source_node(n, "material");
     ctx.scene.add_object(std::move(o));
 }
 

--- a/projects/joon/src/shader/brdf_emitter.cpp
+++ b/projects/joon/src/shader/brdf_emitter.cpp
@@ -1,0 +1,51 @@
+#include "shader/brdf_emitter.h"
+#include "shader/hlsl_emitter.h"
+#include <sstream>
+
+namespace joon {
+
+std::string BrdfEmitter::emit_lighting_shader(const ShaderFnIR& brdf) {
+    HlslEmitter hlsl;
+    std::ostringstream ss;
+
+    ss << "[[vk::binding(0, 0)]] Texture2D gbuf_albedo;\n";
+    ss << "[[vk::binding(1, 0)]] SamplerState samp;\n\n";
+
+    ss << "struct LightData { float4 position_type; float4 color_intensity; float4 spot_params; };\n";
+    ss << "struct LightUBO { LightData lights[16]; int light_count; float3 camera_pos; float4x4 inv_view_proj; };\n";
+    ss << "[[vk::binding(2, 0)]] ConstantBuffer<LightUBO> light_ubo;\n\n";
+
+    ss << "struct PSIn { float4 sv : SV_POSITION; float2 uv : TEXCOORD0; };\n\n";
+
+    ss << "float4 main(PSIn i) : SV_TARGET {\n";
+    ss << "    float4 albedo = gbuf_albedo.Sample(samp, i.uv);\n";
+    ss << "    if (albedo.a < 0.01) discard;\n\n";
+
+    ss << "    float3 normal = float3(0, 1, 0);\n";
+    ss << "    float3 view_dir = normalize(light_ubo.camera_pos);\n";
+    ss << "    float3 result = float3(0, 0, 0);\n\n";
+
+    ss << "    for (int li = 0; li < light_ubo.light_count; li++) {\n";
+    ss << "        float3 light_dir = -normalize(light_ubo.lights[li].position_type.xyz);\n";
+    ss << "        float3 light_color = light_ubo.lights[li].color_intensity.xyz;\n";
+
+    // The BRDF body uses params: normal, light_dir, view_dir, albedo
+    // Emit each statement in the BRDF body
+    for (auto& stmt : brdf.body) {
+        std::string expr_str = hlsl.emit_expr(*stmt);
+        // If it's a bare expression (not an assignment), accumulate as contribution
+        if (auto* assign = std::get_if<ShaderAssign>(stmt.get())) {
+            ss << "        " << expr_str << ";\n";
+        } else {
+            ss << "        result += (" << expr_str << ").xyz * light_color;\n";
+        }
+    }
+
+    ss << "    }\n\n";
+    ss << "    return float4(result, 1.0);\n";
+    ss << "}\n";
+
+    return ss.str();
+}
+
+} // namespace joon

--- a/projects/joon/src/shader/brdf_emitter.h
+++ b/projects/joon/src/shader/brdf_emitter.h
@@ -1,0 +1,12 @@
+#pragma once
+#include "shader/shader_ir.h"
+#include <string>
+
+namespace joon {
+
+class BrdfEmitter {
+public:
+    std::string emit_lighting_shader(const ShaderFnIR& brdf);
+};
+
+} // namespace joon

--- a/projects/joon/src/shader/hlsl_emitter.cpp
+++ b/projects/joon/src/shader/hlsl_emitter.cpp
@@ -1,0 +1,175 @@
+#include "shader/hlsl_emitter.h"
+#include "shader/noise_hlsl.h"
+#include <sstream>
+#include <cstdio>
+
+namespace joon {
+
+const std::unordered_map<std::string, std::string> HlslEmitter::OP_RENAMES = {
+    {"mix", "lerp"}, {"fract", "frac"}, {"mod", "fmod"},
+};
+
+const std::unordered_set<std::string> HlslEmitter::BINARY_OPS = {
+    "+", "-", "*", "/"
+};
+
+std::string HlslEmitter::emit_expr(const ShaderExpr& expr) {
+    if (auto* lit = std::get_if<ShaderLiteral>(&expr)) {
+        char buf[32];
+        snprintf(buf, sizeof(buf), "%f", lit->value);
+        return buf;
+    }
+    if (auto* var = std::get_if<ShaderVar>(&expr))
+        return var->name;
+    if (auto* call = std::get_if<ShaderCall>(&expr))
+        return emit_call(*call);
+    if (auto* assign = std::get_if<ShaderAssign>(&expr))
+        return emit_assign(*assign, true);
+    if (auto* vc = std::get_if<ShaderVecConstruct>(&expr))
+        return emit_vec(*vc);
+    if (auto* da = std::get_if<ShaderDotAccess>(&expr))
+        return emit_dot(*da);
+    if (auto* ps = std::get_if<ShaderPrepassSample>(&expr)) {
+        std::ostringstream ss;
+        ss << "__prepass_" << ps->prepass_index
+           << ".Sample(__sampler_" << ps->prepass_index << ", uv)";
+        return ss.str();
+    }
+    return "0.0";
+}
+
+std::string HlslEmitter::emit_call(const ShaderCall& call) {
+    if (call.op == "encode" && call.args.size() == 1) {
+        return "float4(" + emit_expr(*call.args[0]) + " * 0.5 + 0.5, 1.0)";
+    }
+    if (call.op == "decode" && call.args.size() == 1) {
+        return "(" + emit_expr(*call.args[0]) + ".xyz * 2.0 - 1.0)";
+    }
+    if (call.op == "noise") {
+        float scale = 1.0f;
+        int octaves = 4;
+        for (auto& kw : call.kwargs) {
+            if (kw.first == "scale") scale = kw.second;
+            if (kw.first == "octaves") octaves = static_cast<int>(kw.second);
+        }
+        std::ostringstream ss;
+        ss << "fbm(world_pos * " << scale << ", " << octaves << ")";
+        return ss.str();
+    }
+
+    if (BINARY_OPS.count(call.op) && call.args.size() == 2) {
+        return "(" + emit_expr(*call.args[0]) + " " + call.op + " " + emit_expr(*call.args[1]) + ")";
+    }
+
+    std::string name = call.op;
+    auto rename = OP_RENAMES.find(call.op);
+    if (rename != OP_RENAMES.end()) name = rename->second;
+
+    std::ostringstream ss;
+    ss << name << "(";
+    for (size_t i = 0; i < call.args.size(); i++) {
+        if (i > 0) ss << ", ";
+        ss << emit_expr(*call.args[i]);
+    }
+    ss << ")";
+    return ss.str();
+}
+
+std::string HlslEmitter::emit_assign(const ShaderAssign& assign, bool is_fragment) {
+    std::string prefix = is_fragment ? "o." : "";
+    return prefix + assign.target + " = " + emit_expr(*assign.value);
+}
+
+std::string HlslEmitter::emit_vec(const ShaderVecConstruct& vc) {
+    std::ostringstream ss;
+    ss << "float" << vc.elements.size() << "(";
+    for (size_t i = 0; i < vc.elements.size(); i++) {
+        if (i > 0) ss << ", ";
+        ss << emit_expr(*vc.elements[i]);
+    }
+    ss << ")";
+    return ss.str();
+}
+
+std::string HlslEmitter::emit_dot(const ShaderDotAccess& da) {
+    return emit_expr(*da.object) + "." + da.field;
+}
+
+std::string HlslEmitter::emit_fragment(const ShaderFnIR& fn, uint32_t prepass_count) {
+    std::ostringstream ss;
+
+    ss << "struct PSOut {\n";
+    for (size_t i = 0; i < fn.outputs.size(); i++) {
+        std::string hlsl_type = (fn.outputs[i].type_name == "vec4") ? "float4" :
+                                 (fn.outputs[i].type_name == "vec3") ? "float3" :
+                                 (fn.outputs[i].type_name == "vec2") ? "float2" : "float";
+        ss << "    " << hlsl_type << " " << fn.outputs[i].name
+           << " : SV_TARGET" << i << ";\n";
+    }
+    ss << "};\n\n";
+
+    ss << "struct PSIn {\n"
+       << "    float4 sv : SV_POSITION;\n"
+       << "    float3 normal : NORMAL;\n"
+       << "    float2 uv : TEXCOORD0;\n"
+       << "    float3 world_pos : TEXCOORD1;\n"
+       << "};\n\n";
+
+    ss << "struct FragUBO { float time; float3 pad; };\n"
+       << "[[vk::binding(0, 1)]] ConstantBuffer<FragUBO> frag_ubo;\n\n";
+
+    for (uint32_t i = 0; i < prepass_count; i++) {
+        uint32_t binding = 1 + i * 2;
+        ss << "[[vk::binding(" << binding << ", 1)]] Texture2D __prepass_" << i << ";\n";
+        ss << "[[vk::binding(" << (binding + 1) << ", 1)]] SamplerState __sampler_" << i << ";\n";
+    }
+    if (prepass_count > 0) ss << "\n";
+
+    ss << NOISE_HLSL_FUNCTIONS << "\n";
+
+    ss << "PSOut main(PSIn i) {\n";
+    ss << "    float3 normal = normalize(i.normal);\n";
+    ss << "    float2 uv = i.uv;\n";
+    ss << "    float3 world_pos = i.world_pos;\n";
+    ss << "    float time = frag_ubo.time;\n";
+    ss << "    PSOut o;\n";
+
+    for (auto& stmt : fn.body) {
+        ss << "    " << emit_expr(*stmt) << ";\n";
+    }
+
+    ss << "    return o;\n";
+    ss << "}\n";
+    return ss.str();
+}
+
+std::string HlslEmitter::emit_vertex(const ShaderFnIR& fn) {
+    std::ostringstream ss;
+
+    ss << "struct UBO { float4x4 mvp; float4x4 model; float time; float3 pad; };\n";
+    ss << "[[vk::binding(0, 0)]] ConstantBuffer<UBO> ubo;\n\n";
+
+    ss << "struct VSIn  { float3 pos : POSITION; float3 nrm : NORMAL; float2 uv : TEXCOORD0; };\n";
+    ss << "struct VSOut { float4 sv : SV_POSITION; float3 normal : NORMAL; float2 uv : TEXCOORD0; float3 world_pos : TEXCOORD1; };\n\n";
+
+    ss << "VSOut main(VSIn v) {\n";
+    ss << "    float3 pos = v.pos;\n";
+    ss << "    float3 normal = v.nrm;\n";
+    ss << "    float2 uv = v.uv;\n";
+    ss << "    float time = ubo.time;\n";
+
+    for (auto& stmt : fn.body) {
+        ss << "    " << emit_expr(*stmt) << ";\n";
+    }
+
+    ss << "    VSOut o;\n";
+    ss << "    o.sv = mul(ubo.mvp, float4(pos, 1.0));\n";
+    ss << "    o.normal = normalize(mul((float3x3)ubo.model, normal));\n";
+    ss << "    o.uv = uv;\n";
+    ss << "    o.world_pos = mul(ubo.model, float4(pos, 1.0)).xyz;\n";
+    ss << "    return o;\n";
+    ss << "}\n";
+    return ss.str();
+}
+
+} // namespace joon

--- a/projects/joon/src/shader/hlsl_emitter.h
+++ b/projects/joon/src/shader/hlsl_emitter.h
@@ -1,0 +1,25 @@
+#pragma once
+#include "shader/shader_ir.h"
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+
+namespace joon {
+
+class HlslEmitter {
+public:
+    std::string emit_expr(const ShaderExpr& expr);
+    std::string emit_fragment(const ShaderFnIR& fn, uint32_t prepass_count);
+    std::string emit_vertex(const ShaderFnIR& fn);
+
+private:
+    std::string emit_call(const ShaderCall& call);
+    std::string emit_assign(const ShaderAssign& assign, bool is_fragment);
+    std::string emit_vec(const ShaderVecConstruct& vc);
+    std::string emit_dot(const ShaderDotAccess& da);
+
+    static const std::unordered_map<std::string, std::string> OP_RENAMES;
+    static const std::unordered_set<std::string> BINARY_OPS;
+};
+
+} // namespace joon

--- a/projects/joon/src/shader/noise_hlsl.h
+++ b/projects/joon/src/shader/noise_hlsl.h
@@ -1,0 +1,37 @@
+#pragma once
+
+namespace joon {
+
+inline const char* NOISE_HLSL_FUNCTIONS = R"(
+float hash31(float3 p) {
+    p = frac(p * float3(443.8975, 397.2973, 491.1871));
+    p += dot(p, p.yzx + 19.19);
+    return frac((p.x + p.y) * p.z);
+}
+
+float noise3d(float3 p) {
+    float3 i = floor(p);
+    float3 f = frac(p);
+    f = f * f * (3.0 - 2.0 * f);
+    return lerp(
+        lerp(lerp(hash31(i), hash31(i + float3(1,0,0)), f.x),
+             lerp(hash31(i + float3(0,1,0)), hash31(i + float3(1,1,0)), f.x), f.y),
+        lerp(lerp(hash31(i + float3(0,0,1)), hash31(i + float3(1,0,1)), f.x),
+             lerp(hash31(i + float3(0,1,1)), hash31(i + float3(1,1,1)), f.x), f.y),
+        f.z);
+}
+
+float fbm(float3 p, int octaves) {
+    float val = 0.0;
+    float amp = 0.5;
+    float freq = 1.0;
+    for (int i = 0; i < octaves; i++) {
+        val += amp * noise3d(p * freq);
+        freq *= 2.0;
+        amp *= 0.5;
+    }
+    return val;
+}
+)";
+
+} // namespace joon

--- a/projects/joon/src/shader/prepass_extractor.cpp
+++ b/projects/joon/src/shader/prepass_extractor.cpp
@@ -1,0 +1,38 @@
+#include "shader/prepass_extractor.h"
+
+namespace joon {
+
+PrepassExtractor::PrepassExtractor(const ShaderAnalyzer& analyzer)
+    : m_analyzer(analyzer) {}
+
+ShaderExprPtr PrepassExtractor::walk(ShaderExprPtr expr) {
+    if (auto* call = std::get_if<ShaderCall>(expr.get())) {
+        if (m_analyzer.classify(call->op) == ShaderOpKind::PREPASS_REQUIRED) {
+            uint32_t idx = static_cast<uint32_t>(m_extracted.size());
+            std::string op = call->op;
+            m_extracted.push_back({op, std::move(expr)});
+            return std::make_unique<ShaderExpr>(ShaderPrepassSample{idx});
+        }
+        for (auto& arg : call->args)
+            arg = walk(std::move(arg));
+    }
+    if (auto* assign = std::get_if<ShaderAssign>(expr.get())) {
+        if (assign->value)
+            assign->value = walk(std::move(assign->value));
+    }
+    return expr;
+}
+
+ExtractionResult PrepassExtractor::extract(const ShaderFnIR& fn) {
+    ExtractionResult result;
+    m_extracted.clear();
+
+    for (auto& stmt : fn.body) {
+        result.modified_body.push_back(walk(clone_expr(*stmt)));
+    }
+
+    result.prepasses = std::move(m_extracted);
+    return result;
+}
+
+} // namespace joon

--- a/projects/joon/src/shader/prepass_extractor.h
+++ b/projects/joon/src/shader/prepass_extractor.h
@@ -1,0 +1,30 @@
+#pragma once
+#include "shader/shader_ir.h"
+#include "shader/shader_analyzer.h"
+#include <vector>
+
+namespace joon {
+
+struct ExtractedPrepass {
+    std::string root_op;
+    ShaderExprPtr compute_tree;
+};
+
+struct ExtractionResult {
+    std::vector<ExtractedPrepass> prepasses;
+    std::vector<ShaderExprPtr> modified_body;
+};
+
+class PrepassExtractor {
+public:
+    explicit PrepassExtractor(const ShaderAnalyzer& analyzer);
+    ExtractionResult extract(const ShaderFnIR& fn);
+
+private:
+    const ShaderAnalyzer& m_analyzer;
+    std::vector<ExtractedPrepass> m_extracted;
+
+    ShaderExprPtr walk(ShaderExprPtr expr);
+};
+
+} // namespace joon

--- a/projects/joon/src/shader/shader_analyzer.cpp
+++ b/projects/joon/src/shader/shader_analyzer.cpp
@@ -1,0 +1,96 @@
+#include "shader/shader_analyzer.h"
+
+namespace joon {
+
+const std::unordered_set<std::string> ShaderAnalyzer::INLINEABLE_OPS = {
+    "+", "-", "*", "/",
+    "pow", "sqrt", "abs", "floor", "ceil", "fract", "mod", "clamp", "min", "max",
+    "sin", "cos", "tan", "asin", "acos", "atan", "atan2",
+    "dot", "cross", "normalize", "length", "reflect", "refract",
+    "mix", "step", "smoothstep",
+    "noise", "fbm", "voronoi",
+    "sample", "encode", "decode",
+    "set"
+};
+
+const std::unordered_set<std::string> ShaderAnalyzer::PREPASS_OPS = {
+    "blur", "levels", "blend", "threshold", "invert"
+};
+
+ShaderOpKind ShaderAnalyzer::classify(const std::string& op) const {
+    if (INLINEABLE_OPS.count(op)) return ShaderOpKind::INLINEABLE;
+    if (PREPASS_OPS.count(op)) return ShaderOpKind::PREPASS_REQUIRED;
+    return ShaderOpKind::UNKNOWN;
+}
+
+ShaderExprPtr ShaderAnalyzer::convert_expr(const AstNode& ast) {
+    if (auto* num = std::get_if<NumberNode>(&ast.data)) {
+        return std::make_unique<ShaderExpr>(ShaderLiteral{static_cast<float>(num->value)});
+    }
+    if (auto* sym = std::get_if<SymbolNode>(&ast.data)) {
+        return std::make_unique<ShaderExpr>(ShaderVar{sym->name});
+    }
+    if (auto* vec = std::get_if<VectorNode>(&ast.data)) {
+        ShaderVecConstruct vc;
+        for (auto& e : vec->elements)
+            vc.elements.push_back(convert_expr(*e));
+        return std::make_unique<ShaderExpr>(std::move(vc));
+    }
+    if (auto* dot = std::get_if<DotAccessNode>(&ast.data)) {
+        ShaderDotAccess da;
+        da.object = convert_expr(*dot->object);
+        da.field = dot->field;
+        return std::make_unique<ShaderExpr>(std::move(da));
+    }
+    if (auto* call = std::get_if<CallNode>(&ast.data)) {
+        if (call->op == "set") {
+            ShaderAssign sa;
+            if (!call->args.empty()) {
+                if (auto* target_sym = std::get_if<SymbolNode>(&call->args[0]->data))
+                    sa.target = target_sym->name;
+                else if (auto* target_dot = std::get_if<DotAccessNode>(&call->args[0]->data)) {
+                    // pos.y → "pos.y" as a dot-separated target string
+                    auto* obj_sym = std::get_if<SymbolNode>(&target_dot->object->data);
+                    if (obj_sym)
+                        sa.target = obj_sym->name + "." + target_dot->field;
+                    else
+                        sa.target = target_dot->field;
+                }
+            }
+            if (call->args.size() > 1)
+                sa.value = convert_expr(*call->args[1]);
+            return std::make_unique<ShaderExpr>(std::move(sa));
+        }
+
+        ShaderCall sc;
+        sc.op = call->op;
+        for (auto& a : call->args)
+            sc.args.push_back(convert_expr(*a));
+        for (auto& kw : call->kwargs) {
+            if (auto* knum = std::get_if<NumberNode>(&kw.value->data))
+                sc.kwargs.push_back({kw.name, static_cast<float>(knum->value)});
+        }
+        return std::make_unique<ShaderExpr>(std::move(sc));
+    }
+    return std::make_unique<ShaderExpr>(ShaderLiteral{0.0f});
+}
+
+ShaderFnIR ShaderAnalyzer::convert_fn(const ShaderFnDef& fndef) {
+    ShaderFnIR fn;
+    fn.params = fndef.params;
+    for (auto& o : fndef.outputs)
+        fn.outputs.push_back({o.name, o.type_name});
+    for (auto& stmt : fndef.body)
+        fn.body.push_back(convert_expr(*stmt));
+    return fn;
+}
+
+ShaderIR ShaderAnalyzer::analyze(const ShaderDef& sd) {
+    ShaderIR ir;
+    if (sd.vertex) ir.vertex = convert_fn(*sd.vertex);
+    if (sd.fragment) ir.fragment = convert_fn(*sd.fragment);
+    if (sd.brdf) ir.brdf = convert_fn(*sd.brdf);
+    return ir;
+}
+
+} // namespace joon

--- a/projects/joon/src/shader/shader_analyzer.h
+++ b/projects/joon/src/shader/shader_analyzer.h
@@ -1,0 +1,22 @@
+#pragma once
+#include "shader/shader_ir.h"
+#include "ir/node.h"
+#include "dsl/ast.h"
+#include <unordered_set>
+
+namespace joon {
+
+class ShaderAnalyzer {
+public:
+    ShaderIR analyze(const ShaderDef& sd);
+    ShaderOpKind classify(const std::string& op) const;
+
+private:
+    ShaderExprPtr convert_expr(const AstNode& ast);
+    ShaderFnIR convert_fn(const ShaderFnDef& fndef);
+
+    static const std::unordered_set<std::string> INLINEABLE_OPS;
+    static const std::unordered_set<std::string> PREPASS_OPS;
+};
+
+} // namespace joon

--- a/projects/joon/src/shader/shader_ir.cpp
+++ b/projects/joon/src/shader/shader_ir.cpp
@@ -1,0 +1,44 @@
+#include "shader/shader_ir.h"
+
+namespace joon {
+
+ShaderExprPtr clone_expr(const ShaderExpr& expr) {
+    if (auto* lit = std::get_if<ShaderLiteral>(&expr))
+        return std::make_unique<ShaderExpr>(*lit);
+    if (auto* var = std::get_if<ShaderVar>(&expr))
+        return std::make_unique<ShaderExpr>(*var);
+    if (auto* ps = std::get_if<ShaderPrepassSample>(&expr))
+        return std::make_unique<ShaderExpr>(*ps);
+
+    if (auto* call = std::get_if<ShaderCall>(&expr)) {
+        ShaderCall c;
+        c.op = call->op;
+        c.kwargs = call->kwargs;
+        for (auto& a : call->args)
+            c.args.push_back(clone_expr(*a));
+        return std::make_unique<ShaderExpr>(std::move(c));
+    }
+    if (auto* assign = std::get_if<ShaderAssign>(&expr)) {
+        ShaderAssign a;
+        a.target = assign->target;
+        if (assign->value)
+            a.value = clone_expr(*assign->value);
+        return std::make_unique<ShaderExpr>(std::move(a));
+    }
+    if (auto* vc = std::get_if<ShaderVecConstruct>(&expr)) {
+        ShaderVecConstruct v;
+        for (auto& e : vc->elements)
+            v.elements.push_back(clone_expr(*e));
+        return std::make_unique<ShaderExpr>(std::move(v));
+    }
+    if (auto* da = std::get_if<ShaderDotAccess>(&expr)) {
+        ShaderDotAccess d;
+        d.object = clone_expr(*da->object);
+        d.field = da->field;
+        return std::make_unique<ShaderExpr>(std::move(d));
+    }
+
+    return std::make_unique<ShaderExpr>(ShaderLiteral{0.0f});
+}
+
+} // namespace joon

--- a/projects/joon/src/shader/shader_ir.h
+++ b/projects/joon/src/shader/shader_ir.h
@@ -1,0 +1,76 @@
+#pragma once
+#include <string>
+#include <vector>
+#include <variant>
+#include <memory>
+#include <optional>
+#include <utility>
+#include <cstdint>
+
+namespace joon {
+
+struct ShaderLiteral { float value; };
+struct ShaderVar { std::string name; };
+
+struct ShaderCall;
+struct ShaderAssign;
+struct ShaderVecConstruct;
+struct ShaderDotAccess;
+struct ShaderPrepassSample;
+
+using ShaderExpr = std::variant<
+    ShaderLiteral,
+    ShaderVar,
+    ShaderCall,
+    ShaderAssign,
+    ShaderVecConstruct,
+    ShaderDotAccess,
+    ShaderPrepassSample
+>;
+
+using ShaderExprPtr = std::unique_ptr<ShaderExpr>;
+
+struct ShaderCall {
+    std::string op;
+    std::vector<ShaderExprPtr> args;
+    std::vector<std::pair<std::string, float>> kwargs;
+};
+
+struct ShaderAssign {
+    std::string target;
+    ShaderExprPtr value;
+};
+
+struct ShaderVecConstruct {
+    std::vector<ShaderExprPtr> elements;
+};
+
+struct ShaderDotAccess {
+    ShaderExprPtr object;
+    std::string field;
+};
+
+struct ShaderPrepassSample {
+    uint32_t prepass_index;
+};
+
+struct ShaderFnOutput {
+    std::string name;
+    std::string type_name;
+};
+
+struct ShaderFnIR {
+    std::vector<std::string> params;
+    std::vector<ShaderFnOutput> outputs;
+    std::vector<ShaderExprPtr> body;
+};
+
+enum class ShaderOpKind { INLINEABLE, PREPASS_REQUIRED, UNKNOWN };
+
+struct ShaderIR {
+    std::optional<ShaderFnIR> vertex;
+    std::optional<ShaderFnIR> fragment;
+    std::optional<ShaderFnIR> brdf;
+};
+
+} // namespace joon

--- a/projects/joon/src/shader/shader_ir.h
+++ b/projects/joon/src/shader/shader_ir.h
@@ -65,6 +65,8 @@ struct ShaderFnIR {
     std::vector<ShaderExprPtr> body;
 };
 
+ShaderExprPtr clone_expr(const ShaderExpr& expr);
+
 enum class ShaderOpKind { INLINEABLE, PREPASS_REQUIRED, UNKNOWN };
 
 struct ShaderIR {

--- a/projects/joon/src/vulkan/pipeline_cache.cpp
+++ b/projects/joon/src/vulkan/pipeline_cache.cpp
@@ -245,7 +245,91 @@ const GraphicsPipeline& PipelineCache::get_graphics(const std::string& name,
     if (vkCreatePipelineLayout(m_device.device, &layout_info, nullptr, &p.layout) != VK_SUCCESS)
         throw std::runtime_error("graphics: vkCreatePipelineLayout failed");
 
-    // Vertex input — matches joon::Vertex {position, normal, uv}.
+    p.pipeline = build_graphics_pipeline(p.vert_module, p.frag_module, p.layout, render_pass, 1);
+
+    m_graphics_pipelines[key] = p;
+    return m_graphics_pipelines[key];
+}
+
+const GraphicsPipeline& PipelineCache::get_graphics_from_source(
+    const std::string& key,
+    const std::string& vert_hlsl_source,
+    const std::string& frag_hlsl_source,
+    VkRenderPass render_pass,
+    uint32_t push_constant_size,
+    uint32_t num_color_attachments) {
+
+    auto it = m_graphics_pipelines.find(key);
+    if (it != m_graphics_pipelines.end()) return it->second;
+
+    GraphicsPipeline p{};
+
+    std::string vert_tmp = m_shaderDir + "/__gen_" + key + ".vert.hlsl";
+    std::string frag_tmp = m_shaderDir + "/__gen_" + key + ".frag.hlsl";
+    std::string vert_spv = m_shaderDir + "/__gen_" + key + ".vert.spv";
+    std::string frag_spv = m_shaderDir + "/__gen_" + key + ".frag.spv";
+
+    { std::ofstream f(vert_tmp); f << vert_hlsl_source; }
+    { std::ofstream f(frag_tmp); f << frag_hlsl_source; }
+
+    auto vs_spirv = compile_hlsl(vert_tmp, vert_spv, "vs_6_0");
+    auto fs_spirv = compile_hlsl(frag_tmp, frag_spv, "ps_6_0");
+
+    auto make_module = [&](const std::vector<uint8_t>& spirv, const char* what) {
+        if (spirv.size() % 4 != 0)
+            throw std::runtime_error(std::string("SPIR-V size not multiple of 4: ") + what);
+        VkShaderModuleCreateInfo info{};
+        info.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
+        info.codeSize = spirv.size();
+        info.pCode = reinterpret_cast<const uint32_t*>(spirv.data());
+        VkShaderModule mod = VK_NULL_HANDLE;
+        if (vkCreateShaderModule(m_device.device, &info, nullptr, &mod) != VK_SUCCESS)
+            throw std::runtime_error(std::string("vkCreateShaderModule failed: ") + what);
+        return mod;
+    };
+    p.vert_module = make_module(vs_spirv, (key + ".vert").c_str());
+    p.frag_module = make_module(fs_spirv, (key + ".frag").c_str());
+
+    VkDescriptorSetLayoutBinding ubo_binding{};
+    ubo_binding.binding = 0;
+    ubo_binding.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+    ubo_binding.descriptorCount = 1;
+    ubo_binding.stageFlags = VK_SHADER_STAGE_VERTEX_BIT;
+
+    VkDescriptorSetLayoutCreateInfo desc_info{};
+    desc_info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
+    desc_info.bindingCount = 1;
+    desc_info.pBindings = &ubo_binding;
+    if (vkCreateDescriptorSetLayout(m_device.device, &desc_info, nullptr, &p.desc_layout) != VK_SUCCESS)
+        throw std::runtime_error("graphics_from_source: vkCreateDescriptorSetLayout failed");
+
+    VkPipelineLayoutCreateInfo layout_info{};
+    layout_info.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
+    layout_info.setLayoutCount = 1;
+    layout_info.pSetLayouts = &p.desc_layout;
+
+    VkPushConstantRange push_range{};
+    if (push_constant_size > 0) {
+        push_range.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
+        push_range.offset = 0;
+        push_range.size = push_constant_size;
+        layout_info.pushConstantRangeCount = 1;
+        layout_info.pPushConstantRanges = &push_range;
+    }
+    if (vkCreatePipelineLayout(m_device.device, &layout_info, nullptr, &p.layout) != VK_SUCCESS)
+        throw std::runtime_error("graphics_from_source: vkCreatePipelineLayout failed");
+
+    p.pipeline = build_graphics_pipeline(p.vert_module, p.frag_module, p.layout, render_pass, num_color_attachments);
+
+    m_graphics_pipelines[key] = p;
+    return m_graphics_pipelines[key];
+}
+
+VkPipeline PipelineCache::build_graphics_pipeline(VkShaderModule vert_module,
+                                                    VkShaderModule frag_module,
+                                                    VkPipelineLayout layout,
+                                                    VkRenderPass render_pass,
+                                                    uint32_t num_color_attachments) {
     VkVertexInputBindingDescription vb_desc{};
     vb_desc.binding = 0;
     vb_desc.stride = sizeof(Vertex);
@@ -298,17 +382,19 @@ const GraphicsPipeline& PipelineCache::get_graphics(const std::string& name,
     ds.depthWriteEnable = VK_TRUE;
     ds.depthCompareOp = VK_COMPARE_OP_LESS;
 
-    VkPipelineColorBlendAttachmentState cba{};
-    cba.colorWriteMask = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT
-                       | VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT;
-    cba.blendEnable = VK_FALSE;
+    std::vector<VkPipelineColorBlendAttachmentState> cbas(num_color_attachments);
+    for (auto& cba : cbas) {
+        cba = {};
+        cba.colorWriteMask = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT
+                           | VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT;
+        cba.blendEnable = VK_FALSE;
+    }
 
     VkPipelineColorBlendStateCreateInfo cb{};
     cb.sType = VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO;
-    cb.attachmentCount = 1;
-    cb.pAttachments = &cba;
+    cb.attachmentCount = num_color_attachments;
+    cb.pAttachments = cbas.data();
 
-    // Dynamic viewport+scissor — set per draw via vkCmdSetViewport/Scissor.
     VkDynamicState dyn_states[2] = { VK_DYNAMIC_STATE_VIEWPORT, VK_DYNAMIC_STATE_SCISSOR };
     VkPipelineDynamicStateCreateInfo dyn{};
     dyn.sType = VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO;
@@ -318,11 +404,11 @@ const GraphicsPipeline& PipelineCache::get_graphics(const std::string& name,
     VkPipelineShaderStageCreateInfo stages[2]{};
     stages[0].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
     stages[0].stage = VK_SHADER_STAGE_VERTEX_BIT;
-    stages[0].module = p.vert_module;
+    stages[0].module = vert_module;
     stages[0].pName = "main";
     stages[1].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
     stages[1].stage = VK_SHADER_STAGE_FRAGMENT_BIT;
-    stages[1].module = p.frag_module;
+    stages[1].module = frag_module;
     stages[1].pName = "main";
 
     VkGraphicsPipelineCreateInfo gp_info{};
@@ -337,16 +423,16 @@ const GraphicsPipeline& PipelineCache::get_graphics(const std::string& name,
     gp_info.pDepthStencilState = &ds;
     gp_info.pColorBlendState = &cb;
     gp_info.pDynamicState = &dyn;
-    gp_info.layout = p.layout;
+    gp_info.layout = layout;
     gp_info.renderPass = render_pass;
     gp_info.subpass = 0;
 
+    VkPipeline pipeline = VK_NULL_HANDLE;
     if (vkCreateGraphicsPipelines(m_device.device, VK_NULL_HANDLE, 1, &gp_info, nullptr,
-                                   &p.pipeline) != VK_SUCCESS)
-        throw std::runtime_error("vkCreateGraphicsPipelines failed: " + name);
+                                   &pipeline) != VK_SUCCESS)
+        throw std::runtime_error("vkCreateGraphicsPipelines failed");
 
-    m_graphics_pipelines[key] = p;
-    return m_graphics_pipelines[key];
+    return pipeline;
 }
 
 } // namespace joon

--- a/projects/joon/src/vulkan/pipeline_cache.cpp
+++ b/projects/joon/src/vulkan/pipeline_cache.cpp
@@ -568,4 +568,142 @@ const GraphicsPipeline& PipelineCache::get_fullscreen(const std::string& frag_na
     return m_graphics_pipelines[key];
 }
 
+const GraphicsPipeline& PipelineCache::get_fullscreen_from_source(
+    const std::string& key,
+    const std::string& frag_hlsl_source,
+    VkRenderPass render_pass) {
+    std::string cache_key = "fssrc_" + key + ":" + std::to_string(reinterpret_cast<uintptr_t>(render_pass));
+    auto it = m_graphics_pipelines.find(cache_key);
+    if (it != m_graphics_pipelines.end()) return it->second;
+
+    GraphicsPipeline p{};
+
+    auto vs_spirv = load_or_compile_stage("fullscreen", "vert", "vs_6_0");
+
+    std::string frag_tmp = m_shaderDir + "/__gen_" + key + ".frag.hlsl";
+    std::string frag_spv = m_shaderDir + "/__gen_" + key + ".frag.spv";
+    { std::ofstream f(frag_tmp); f << frag_hlsl_source; }
+    auto fs_spirv = compile_hlsl(frag_tmp, frag_spv, "ps_6_0");
+
+    auto make_module = [&](const std::vector<uint8_t>& spirv, const char* what) {
+        if (spirv.size() % 4 != 0)
+            throw std::runtime_error(std::string("SPIR-V size not multiple of 4: ") + what);
+        VkShaderModuleCreateInfo info{};
+        info.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
+        info.codeSize = spirv.size();
+        info.pCode = reinterpret_cast<const uint32_t*>(spirv.data());
+        VkShaderModule mod = VK_NULL_HANDLE;
+        if (vkCreateShaderModule(m_device.device, &info, nullptr, &mod) != VK_SUCCESS)
+            throw std::runtime_error(std::string("vkCreateShaderModule failed: ") + what);
+        return mod;
+    };
+    p.vert_module = make_module(vs_spirv, "fullscreen.vert");
+    p.frag_module = make_module(fs_spirv, (key + ".frag").c_str());
+
+    VkDescriptorSetLayoutBinding bindings[3]{};
+    bindings[0].binding = 0;
+    bindings[0].descriptorType = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
+    bindings[0].descriptorCount = 1;
+    bindings[0].stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
+    bindings[1].binding = 1;
+    bindings[1].descriptorType = VK_DESCRIPTOR_TYPE_SAMPLER;
+    bindings[1].descriptorCount = 1;
+    bindings[1].stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
+    bindings[2].binding = 2;
+    bindings[2].descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+    bindings[2].descriptorCount = 1;
+    bindings[2].stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
+
+    VkDescriptorSetLayoutCreateInfo desc_info{};
+    desc_info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
+    desc_info.bindingCount = 3;
+    desc_info.pBindings = bindings;
+    if (vkCreateDescriptorSetLayout(m_device.device, &desc_info, nullptr, &p.desc_layout) != VK_SUCCESS)
+        throw std::runtime_error("fullscreen_from_source: vkCreateDescriptorSetLayout failed");
+
+    VkPipelineLayoutCreateInfo layout_info{};
+    layout_info.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
+    layout_info.setLayoutCount = 1;
+    layout_info.pSetLayouts = &p.desc_layout;
+    if (vkCreatePipelineLayout(m_device.device, &layout_info, nullptr, &p.layout) != VK_SUCCESS)
+        throw std::runtime_error("fullscreen_from_source: vkCreatePipelineLayout failed");
+
+    VkPipelineVertexInputStateCreateInfo vi{};
+    vi.sType = VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO;
+
+    VkPipelineInputAssemblyStateCreateInfo ia{};
+    ia.sType = VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO;
+    ia.topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
+
+    VkPipelineViewportStateCreateInfo vps{};
+    vps.sType = VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO;
+    vps.viewportCount = 1;
+    vps.scissorCount = 1;
+
+    VkPipelineRasterizationStateCreateInfo rs{};
+    rs.sType = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO;
+    rs.polygonMode = VK_POLYGON_MODE_FILL;
+    rs.cullMode = VK_CULL_MODE_NONE;
+    rs.frontFace = VK_FRONT_FACE_COUNTER_CLOCKWISE;
+    rs.lineWidth = 1.0f;
+
+    VkPipelineMultisampleStateCreateInfo ms{};
+    ms.sType = VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO;
+    ms.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
+
+    VkPipelineDepthStencilStateCreateInfo ds{};
+    ds.sType = VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO;
+    ds.depthTestEnable = VK_FALSE;
+    ds.depthWriteEnable = VK_FALSE;
+
+    VkPipelineColorBlendAttachmentState cba{};
+    cba.colorWriteMask = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT
+                       | VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT;
+    cba.blendEnable = VK_FALSE;
+
+    VkPipelineColorBlendStateCreateInfo cb{};
+    cb.sType = VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO;
+    cb.attachmentCount = 1;
+    cb.pAttachments = &cba;
+
+    VkDynamicState dyn_states[2] = { VK_DYNAMIC_STATE_VIEWPORT, VK_DYNAMIC_STATE_SCISSOR };
+    VkPipelineDynamicStateCreateInfo dyn{};
+    dyn.sType = VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO;
+    dyn.dynamicStateCount = 2;
+    dyn.pDynamicStates = dyn_states;
+
+    VkPipelineShaderStageCreateInfo stages[2]{};
+    stages[0].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+    stages[0].stage = VK_SHADER_STAGE_VERTEX_BIT;
+    stages[0].module = p.vert_module;
+    stages[0].pName = "main";
+    stages[1].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+    stages[1].stage = VK_SHADER_STAGE_FRAGMENT_BIT;
+    stages[1].module = p.frag_module;
+    stages[1].pName = "main";
+
+    VkGraphicsPipelineCreateInfo gp_info{};
+    gp_info.sType = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO;
+    gp_info.stageCount = 2;
+    gp_info.pStages = stages;
+    gp_info.pVertexInputState = &vi;
+    gp_info.pInputAssemblyState = &ia;
+    gp_info.pViewportState = &vps;
+    gp_info.pRasterizationState = &rs;
+    gp_info.pMultisampleState = &ms;
+    gp_info.pDepthStencilState = &ds;
+    gp_info.pColorBlendState = &cb;
+    gp_info.pDynamicState = &dyn;
+    gp_info.layout = p.layout;
+    gp_info.renderPass = render_pass;
+    gp_info.subpass = 0;
+
+    if (vkCreateGraphicsPipelines(m_device.device, VK_NULL_HANDLE, 1, &gp_info, nullptr,
+                                   &p.pipeline) != VK_SUCCESS)
+        throw std::runtime_error("vkCreateGraphicsPipelines failed: fullscreen_from_source " + key);
+
+    m_graphics_pipelines[cache_key] = p;
+    return m_graphics_pipelines[cache_key];
+}
+
 } // namespace joon

--- a/projects/joon/src/vulkan/pipeline_cache.cpp
+++ b/projects/joon/src/vulkan/pipeline_cache.cpp
@@ -435,4 +435,137 @@ VkPipeline PipelineCache::build_graphics_pipeline(VkShaderModule vert_module,
     return pipeline;
 }
 
+const GraphicsPipeline& PipelineCache::get_fullscreen(const std::string& frag_name,
+                                                       VkRenderPass render_pass) {
+    std::string key = "fs_" + frag_name + ":" + std::to_string(reinterpret_cast<uintptr_t>(render_pass));
+    auto it = m_graphics_pipelines.find(key);
+    if (it != m_graphics_pipelines.end()) return it->second;
+
+    GraphicsPipeline p{};
+
+    auto vs_spirv = load_or_compile_stage("fullscreen", "vert", "vs_6_0");
+    auto fs_spirv = load_or_compile_stage(frag_name, "frag", "ps_6_0");
+
+    auto make_module = [&](const std::vector<uint8_t>& spirv, const char* what) {
+        if (spirv.size() % 4 != 0)
+            throw std::runtime_error(std::string("SPIR-V size not multiple of 4: ") + what);
+        VkShaderModuleCreateInfo info{};
+        info.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
+        info.codeSize = spirv.size();
+        info.pCode = reinterpret_cast<const uint32_t*>(spirv.data());
+        VkShaderModule mod = VK_NULL_HANDLE;
+        if (vkCreateShaderModule(m_device.device, &info, nullptr, &mod) != VK_SUCCESS)
+            throw std::runtime_error(std::string("vkCreateShaderModule failed: ") + what);
+        return mod;
+    };
+    p.vert_module = make_module(vs_spirv, "fullscreen.vert");
+    p.frag_module = make_module(fs_spirv, (frag_name + ".frag").c_str());
+
+    VkDescriptorSetLayoutBinding bindings[3]{};
+    bindings[0].binding = 0;
+    bindings[0].descriptorType = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
+    bindings[0].descriptorCount = 1;
+    bindings[0].stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
+    bindings[1].binding = 1;
+    bindings[1].descriptorType = VK_DESCRIPTOR_TYPE_SAMPLER;
+    bindings[1].descriptorCount = 1;
+    bindings[1].stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
+    bindings[2].binding = 2;
+    bindings[2].descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+    bindings[2].descriptorCount = 1;
+    bindings[2].stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
+
+    VkDescriptorSetLayoutCreateInfo desc_info{};
+    desc_info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
+    desc_info.bindingCount = 3;
+    desc_info.pBindings = bindings;
+    if (vkCreateDescriptorSetLayout(m_device.device, &desc_info, nullptr, &p.desc_layout) != VK_SUCCESS)
+        throw std::runtime_error("fullscreen: vkCreateDescriptorSetLayout failed");
+
+    VkPipelineLayoutCreateInfo layout_info{};
+    layout_info.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
+    layout_info.setLayoutCount = 1;
+    layout_info.pSetLayouts = &p.desc_layout;
+    if (vkCreatePipelineLayout(m_device.device, &layout_info, nullptr, &p.layout) != VK_SUCCESS)
+        throw std::runtime_error("fullscreen: vkCreatePipelineLayout failed");
+
+    // Fullscreen pipeline: no vertex input, no depth, no cull
+    VkPipelineVertexInputStateCreateInfo vi{};
+    vi.sType = VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO;
+
+    VkPipelineInputAssemblyStateCreateInfo ia{};
+    ia.sType = VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO;
+    ia.topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
+
+    VkPipelineViewportStateCreateInfo vp{};
+    vp.sType = VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO;
+    vp.viewportCount = 1;
+    vp.scissorCount = 1;
+
+    VkPipelineRasterizationStateCreateInfo rs{};
+    rs.sType = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO;
+    rs.polygonMode = VK_POLYGON_MODE_FILL;
+    rs.cullMode = VK_CULL_MODE_NONE;
+    rs.frontFace = VK_FRONT_FACE_COUNTER_CLOCKWISE;
+    rs.lineWidth = 1.0f;
+
+    VkPipelineMultisampleStateCreateInfo ms{};
+    ms.sType = VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO;
+    ms.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
+
+    VkPipelineDepthStencilStateCreateInfo ds{};
+    ds.sType = VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO;
+    ds.depthTestEnable = VK_FALSE;
+    ds.depthWriteEnable = VK_FALSE;
+
+    VkPipelineColorBlendAttachmentState cba{};
+    cba.colorWriteMask = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT
+                       | VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT;
+    cba.blendEnable = VK_FALSE;
+
+    VkPipelineColorBlendStateCreateInfo cb{};
+    cb.sType = VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO;
+    cb.attachmentCount = 1;
+    cb.pAttachments = &cba;
+
+    VkDynamicState dyn_states[2] = { VK_DYNAMIC_STATE_VIEWPORT, VK_DYNAMIC_STATE_SCISSOR };
+    VkPipelineDynamicStateCreateInfo dyn{};
+    dyn.sType = VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO;
+    dyn.dynamicStateCount = 2;
+    dyn.pDynamicStates = dyn_states;
+
+    VkPipelineShaderStageCreateInfo stages[2]{};
+    stages[0].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+    stages[0].stage = VK_SHADER_STAGE_VERTEX_BIT;
+    stages[0].module = p.vert_module;
+    stages[0].pName = "main";
+    stages[1].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+    stages[1].stage = VK_SHADER_STAGE_FRAGMENT_BIT;
+    stages[1].module = p.frag_module;
+    stages[1].pName = "main";
+
+    VkGraphicsPipelineCreateInfo gp_info{};
+    gp_info.sType = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO;
+    gp_info.stageCount = 2;
+    gp_info.pStages = stages;
+    gp_info.pVertexInputState = &vi;
+    gp_info.pInputAssemblyState = &ia;
+    gp_info.pViewportState = &vp;
+    gp_info.pRasterizationState = &rs;
+    gp_info.pMultisampleState = &ms;
+    gp_info.pDepthStencilState = &ds;
+    gp_info.pColorBlendState = &cb;
+    gp_info.pDynamicState = &dyn;
+    gp_info.layout = p.layout;
+    gp_info.renderPass = render_pass;
+    gp_info.subpass = 0;
+
+    if (vkCreateGraphicsPipelines(m_device.device, VK_NULL_HANDLE, 1, &gp_info, nullptr,
+                                   &p.pipeline) != VK_SUCCESS)
+        throw std::runtime_error("vkCreateGraphicsPipelines failed: fullscreen " + frag_name);
+
+    m_graphics_pipelines[key] = p;
+    return m_graphics_pipelines[key];
+}
+
 } // namespace joon

--- a/projects/joon/src/vulkan/pipeline_cache.h
+++ b/projects/joon/src/vulkan/pipeline_cache.h
@@ -54,6 +54,12 @@ public:
     const GraphicsPipeline& get_fullscreen(const std::string& frag_name,
                                             VkRenderPass render_pass);
 
+    // Like get_fullscreen but compiles frag from source string instead of file.
+    const GraphicsPipeline& get_fullscreen_from_source(
+        const std::string& key,
+        const std::string& frag_hlsl_source,
+        VkRenderPass render_pass);
+
 private:
     Device& m_device;
     std::string m_shaderDir;

--- a/projects/joon/src/vulkan/pipeline_cache.h
+++ b/projects/joon/src/vulkan/pipeline_cache.h
@@ -48,6 +48,12 @@ public:
         uint32_t push_constant_size = 0,
         uint32_t num_color_attachments = 1);
 
+    // Fullscreen triangle pipeline — uses fullscreen.vert.hlsl + frag_name.frag.hlsl.
+    // No vertex input, no depth test, no backface culling.
+    // Descriptor layout: binding 0 = SAMPLED_IMAGE, binding 1 = SAMPLER, binding 2 = UNIFORM_BUFFER.
+    const GraphicsPipeline& get_fullscreen(const std::string& frag_name,
+                                            VkRenderPass render_pass);
+
 private:
     Device& m_device;
     std::string m_shaderDir;

--- a/projects/joon/src/vulkan/pipeline_cache.h
+++ b/projects/joon/src/vulkan/pipeline_cache.h
@@ -40,6 +40,14 @@ public:
                                           VkRenderPass render_pass,
                                           uint32_t push_constant_size = 0);
 
+    const GraphicsPipeline& get_graphics_from_source(
+        const std::string& key,
+        const std::string& vert_hlsl_source,
+        const std::string& frag_hlsl_source,
+        VkRenderPass render_pass,
+        uint32_t push_constant_size = 0,
+        uint32_t num_color_attachments = 1);
+
 private:
     Device& m_device;
     std::string m_shaderDir;
@@ -55,6 +63,12 @@ private:
                                                 const std::string& stage,
                                                 const std::string& target_profile);
     std::vector<uint8_t> read_file(const std::string& path);
+
+    VkPipeline build_graphics_pipeline(VkShaderModule vert_module,
+                                        VkShaderModule frag_module,
+                                        VkPipelineLayout layout,
+                                        VkRenderPass render_pass,
+                                        uint32_t num_color_attachments);
 };
 
 } // namespace joon

--- a/projects/joon/src/vulkan/render_pass.cpp
+++ b/projects/joon/src/vulkan/render_pass.cpp
@@ -108,6 +108,52 @@ VkFramebuffer create_framebuffer(
     return fb;
 }
 
+RenderPass create_color_renderpass(Device& dev, VkFormat color_format) {
+    RenderPass out;
+    out.color_formats = { color_format };
+    out.depth_format = VK_FORMAT_UNDEFINED;
+
+    VkAttachmentDescription att{};
+    att.format = color_format;
+    att.samples = VK_SAMPLE_COUNT_1_BIT;
+    att.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+    att.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+    att.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+    att.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+    att.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    att.finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+    VkAttachmentReference color_ref{};
+    color_ref.attachment = 0;
+    color_ref.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+    VkSubpassDescription subpass{};
+    subpass.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+    subpass.colorAttachmentCount = 1;
+    subpass.pColorAttachments = &color_ref;
+
+    VkSubpassDependency dep{};
+    dep.srcSubpass = VK_SUBPASS_EXTERNAL;
+    dep.dstSubpass = 0;
+    dep.srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+    dep.dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+    dep.srcAccessMask = 0;
+    dep.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+
+    VkRenderPassCreateInfo info{};
+    info.sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO;
+    info.attachmentCount = 1;
+    info.pAttachments = &att;
+    info.subpassCount = 1;
+    info.pSubpasses = &subpass;
+    info.dependencyCount = 1;
+    info.pDependencies = &dep;
+
+    if (vkCreateRenderPass(dev.device, &info, nullptr, &out.pass) != VK_SUCCESS)
+        throw std::runtime_error("vkCreateRenderPass (color-only) failed");
+    return out;
+}
+
 void destroy_renderpass(Device& dev, RenderPass& rp) {
     if (rp.pass) vkDestroyRenderPass(dev.device, rp.pass, nullptr);
     rp.pass = VK_NULL_HANDLE;

--- a/projects/joon/src/vulkan/render_pass.h
+++ b/projects/joon/src/vulkan/render_pass.h
@@ -26,6 +26,8 @@ VkFramebuffer create_framebuffer(
     const std::vector<VkImageView>& color_views,
     VkImageView depth_view, uint32_t w, uint32_t h);
 
+RenderPass create_color_renderpass(Device& dev, VkFormat color_format);
+
 void destroy_renderpass(Device& dev, RenderPass& rp);
 
 } // namespace joon

--- a/projects/joon/src/vulkan/resource_pool.cpp
+++ b/projects/joon/src/vulkan/resource_pool.cpp
@@ -170,6 +170,59 @@ GpuImage* ResourcePool::alloc_depth(uint32_t node_id, uint32_t width, uint32_t h
     return &m_images[node_id];
 }
 
+GpuImage* ResourcePool::alloc_depth_sampled(uint32_t node_id, uint32_t width, uint32_t height,
+                                              VkFormat format) {
+    auto it = m_images.find(node_id);
+    if (it != m_images.end()) {
+        auto& old = it->second;
+        if (old.width == width && old.height == height && old.format == format) {
+            return &it->second;
+        }
+        vkDestroyImageView(m_device.device, old.view, nullptr);
+        vmaDestroyImage(m_device.allocator, old.image, old.allocation);
+        m_images.erase(it);
+    }
+
+    GpuImage img{};
+    img.width = width;
+    img.height = height;
+    img.format = format;
+
+    VkImageCreateInfo img_info{};
+    img_info.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
+    img_info.imageType = VK_IMAGE_TYPE_2D;
+    img_info.format = format;
+    img_info.extent = { width, height, 1 };
+    img_info.mipLevels = 1;
+    img_info.arrayLayers = 1;
+    img_info.samples = VK_SAMPLE_COUNT_1_BIT;
+    img_info.tiling = VK_IMAGE_TILING_OPTIMAL;
+    img_info.usage = VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT
+                   | VK_IMAGE_USAGE_SAMPLED_BIT;
+
+    VmaAllocationCreateInfo alloc_info{};
+    alloc_info.usage = VMA_MEMORY_USAGE_GPU_ONLY;
+
+    if (vmaCreateImage(m_device.allocator, &img_info, &alloc_info,
+                       &img.image, &img.allocation, nullptr) != VK_SUCCESS)
+        throw std::runtime_error("Failed to allocate sampled depth image");
+
+    VkImageViewCreateInfo view_info{};
+    view_info.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
+    view_info.image = img.image;
+    view_info.viewType = VK_IMAGE_VIEW_TYPE_2D;
+    view_info.format = format;
+    view_info.subresourceRange.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT;
+    view_info.subresourceRange.levelCount = 1;
+    view_info.subresourceRange.layerCount = 1;
+
+    if (vkCreateImageView(m_device.device, &view_info, nullptr, &img.view) != VK_SUCCESS)
+        throw std::runtime_error("Failed to create sampled depth image view");
+
+    m_images[node_id] = img;
+    return &m_images[node_id];
+}
+
 GpuImage* ResourcePool::get_image(uint32_t node_id) {
     auto it = m_images.find(node_id);
     if (it == m_images.end()) return nullptr;

--- a/projects/joon/src/vulkan/resource_pool.cpp
+++ b/projects/joon/src/vulkan/resource_pool.cpp
@@ -223,6 +223,13 @@ GpuImage* ResourcePool::alloc_depth_sampled(uint32_t node_id, uint32_t width, ui
     return &m_images[node_id];
 }
 
+void ResourcePool::alias_image(uint32_t alias_id, uint32_t source_id) {
+    auto it = m_images.find(source_id);
+    if (it == m_images.end()) return;
+    m_images[alias_id] = it->second;
+    m_aliases.insert(alias_id);
+}
+
 GpuImage* ResourcePool::get_image(uint32_t node_id) {
     auto it = m_images.find(node_id);
     if (it == m_images.end()) return nullptr;
@@ -336,10 +343,12 @@ void ResourcePool::download(GpuImage* img, void* data, size_t size) {
 
 void ResourcePool::clear() {
     for (auto& [id, img] : m_images) {
+        if (m_aliases.count(id)) continue;
         vkDestroyImageView(m_device.device, img.view, nullptr);
         vmaDestroyImage(m_device.allocator, img.image, img.allocation);
     }
     m_images.clear();
+    m_aliases.clear();
 }
 
 } // namespace joon

--- a/projects/joon/src/vulkan/resource_pool.h
+++ b/projects/joon/src/vulkan/resource_pool.h
@@ -3,6 +3,7 @@
 #include "vulkan/device.h"
 #include <joon/types.h>
 #include <unordered_map>
+#include <unordered_set>
 
 namespace joon {
 
@@ -38,6 +39,8 @@ public:
 
     GpuImage* get_image(uint32_t node_id);
 
+    void alias_image(uint32_t alias_id, uint32_t source_id);
+
     void upload(GpuImage* img, const void* data, size_t size);
     void download(GpuImage* img, void* data, size_t size);
 
@@ -46,6 +49,7 @@ public:
 private:
     Device& m_device;
     std::unordered_map<uint32_t, GpuImage> m_images;
+    std::unordered_set<uint32_t> m_aliases;
 };
 
 } // namespace joon

--- a/projects/joon/src/vulkan/resource_pool.h
+++ b/projects/joon/src/vulkan/resource_pool.h
@@ -32,6 +32,10 @@ public:
     GpuImage* alloc_depth(uint32_t node_id, uint32_t width, uint32_t height,
                            VkFormat format = VK_FORMAT_D32_SFLOAT);
 
+    // Like alloc_depth but adds SAMPLED_BIT so the depth can be read in shaders.
+    GpuImage* alloc_depth_sampled(uint32_t node_id, uint32_t width, uint32_t height,
+                                   VkFormat format = VK_FORMAT_D32_SFLOAT);
+
     GpuImage* get_image(uint32_t node_id);
 
     void upload(GpuImage* img, const void* data, size_t size);

--- a/projects/joon/tests/test_deferred.cpp
+++ b/projects/joon/tests/test_deferred.cpp
@@ -38,6 +38,34 @@ TEST_CASE("Dot access on pass output resolves to aliased image", "[shader][ir][g
     CHECK(nonzero > 50);
 }
 
+TEST_CASE("Custom toon BRDF produces stepped lighting", "[shader][brdf][gpu]") {
+    auto ctx = Context::create();
+    auto graph = ctx->parse_string(R"(
+        (def toon_mat (shader
+          :brdf (fn [normal light_dir view_dir albedo]
+            (* albedo (step 0.3 (dot normal light_dir))))
+          :fragment (fn [normal uv] -> [albedo vec4]
+            (set albedo [0.3 0.8 0.2 1]))))
+        (def c (cube :material toon_mat))
+        (def cam (camera))
+        (def l (light))
+        (def gbuf (pass))
+        (output gbuf)
+    )");
+    REQUIRE_FALSE(graph.has_errors());
+
+    auto eval = ctx->create_evaluator(graph);
+    eval->evaluate();
+
+    auto px = eval->result("").read_pixels();
+    REQUIRE(px.size() == 512u * 512u * 4u);
+    int bright = 0;
+    for (size_t i = 0; i < px.size(); i += 4) {
+        if (px[i+1] > 0.5f) ++bright;
+    }
+    CHECK(bright > 50);
+}
+
 TEST_CASE("Material executor compiles shader and stores pipeline", "[shader][material][gpu]") {
     auto ctx = Context::create();
     auto graph = ctx->parse_string(R"(

--- a/projects/joon/tests/test_deferred.cpp
+++ b/projects/joon/tests/test_deferred.cpp
@@ -1,5 +1,5 @@
 #include "catch_amalgamated.hpp"
-#include <joon/context.h>
+#include <joon/joon.h>
 #include "vulkan/resource_pool.h"
 using namespace joon;
 
@@ -10,4 +10,29 @@ TEST_CASE("alloc_depth_sampled creates depth with SAMPLED_BIT", "[shader][gpu]")
     REQUIRE(depth != nullptr);
     CHECK(depth->view != VK_NULL_HANDLE);
     CHECK(depth->format == VK_FORMAT_D32_SFLOAT);
+}
+
+TEST_CASE("Material executor compiles shader and stores pipeline", "[shader][material][gpu]") {
+    auto ctx = Context::create();
+    auto graph = ctx->parse_string(R"(
+        (def mat (shader
+          :fragment (fn [normal uv] -> [albedo vec4]
+            (set albedo [1 0 0 1]))))
+        (def c (cube :material mat))
+        (def cam (camera))
+        (def l (light))
+        (def gbuf (pass))
+        (output gbuf)
+    )");
+    REQUIRE_FALSE(graph.has_errors());
+
+    auto eval = ctx->create_evaluator(graph);
+    eval->evaluate();
+
+    auto px = eval->result("").read_pixels();
+    REQUIRE(px.size() == 512u * 512u * 4u);
+    int red_pixels = 0;
+    for (size_t i = 0; i < px.size(); i += 4)
+        if (px[i] > 0.5f && px[i+1] < 0.2f && px[i+2] < 0.2f) ++red_pixels;
+    CHECK(red_pixels > 50);
 }

--- a/projects/joon/tests/test_deferred.cpp
+++ b/projects/joon/tests/test_deferred.cpp
@@ -1,0 +1,13 @@
+#include "catch_amalgamated.hpp"
+#include <joon/context.h>
+#include "vulkan/resource_pool.h"
+using namespace joon;
+
+TEST_CASE("alloc_depth_sampled creates depth with SAMPLED_BIT", "[shader][gpu]") {
+    auto ctx = Context::create();
+    auto& pool = ctx->pool();
+    auto* depth = pool.alloc_depth_sampled(999, 512, 512);
+    REQUIRE(depth != nullptr);
+    CHECK(depth->view != VK_NULL_HANDLE);
+    CHECK(depth->format == VK_FORMAT_D32_SFLOAT);
+}

--- a/projects/joon/tests/test_deferred.cpp
+++ b/projects/joon/tests/test_deferred.cpp
@@ -12,6 +12,32 @@ TEST_CASE("alloc_depth_sampled creates depth with SAMPLED_BIT", "[shader][gpu]")
     CHECK(depth->format == VK_FORMAT_D32_SFLOAT);
 }
 
+TEST_CASE("Dot access on pass output resolves to aliased image", "[shader][ir][gpu]") {
+    auto ctx = Context::create();
+    auto graph = ctx->parse_string(R"(
+        (def mat (shader
+          :fragment (fn [normal uv] -> [albedo vec4]
+            (set albedo [1 0 0 1]))))
+        (def c (cube :material mat))
+        (def cam (camera))
+        (def l (light))
+        (def gbuf (pass))
+        (def result (levels gbuf.albedo :contrast 1.5))
+        (output result)
+    )");
+    REQUIRE_FALSE(graph.has_errors());
+
+    auto eval = ctx->create_evaluator(graph);
+    eval->evaluate();
+
+    auto px = eval->result("").read_pixels();
+    REQUIRE(px.size() == 512u * 512u * 4u);
+    int nonzero = 0;
+    for (size_t i = 0; i < px.size(); i += 4)
+        if (px[i] > 0.01f) ++nonzero;
+    CHECK(nonzero > 50);
+}
+
 TEST_CASE("Material executor compiles shader and stores pipeline", "[shader][material][gpu]") {
     auto ctx = Context::create();
     auto graph = ctx->parse_string(R"(

--- a/projects/joon/tests/test_hlsl_emitter.cpp
+++ b/projects/joon/tests/test_hlsl_emitter.cpp
@@ -1,6 +1,10 @@
 #include "catch_amalgamated.hpp"
 #include "shader/hlsl_emitter.h"
 #include "shader/shader_ir.h"
+#include "vulkan/pipeline_cache.h"
+#include "vulkan/render_pass.h"
+#include <joon/context.h>
+#include <filesystem>
 using namespace joon;
 
 TEST_CASE("Emit literal", "[shader][hlsl]") {
@@ -111,4 +115,40 @@ TEST_CASE("Emit prepass sample", "[shader][hlsl]") {
     HlslEmitter emitter;
     ShaderExpr e = ShaderPrepassSample{0};
     CHECK(emitter.emit_expr(e) == "__prepass_0.Sample(__sampler_0, uv)");
+}
+
+TEST_CASE("PipelineCache compiles generated HLSL source", "[shader][pipeline][gpu]") {
+    auto ctx = Context::create();
+    auto tmp_dir = std::filesystem::temp_directory_path().string();
+    PipelineCache cache(ctx->device(), tmp_dir);
+
+    std::string vert_src = R"(
+struct UBO { float4x4 mvp; float4x4 model; float time; float3 pad; };
+[[vk::binding(0, 0)]] ConstantBuffer<UBO> ubo;
+struct VSIn  { float3 pos : POSITION; float3 nrm : NORMAL; float2 uv : TEXCOORD0; };
+struct VSOut { float4 sv : SV_POSITION; float3 normal : NORMAL; float2 uv : TEXCOORD0; float3 world_pos : TEXCOORD1; };
+VSOut main(VSIn v) {
+    VSOut o;
+    o.sv = mul(ubo.mvp, float4(v.pos, 1.0));
+    o.normal = normalize(mul((float3x3)ubo.model, v.nrm));
+    o.uv = v.uv;
+    o.world_pos = mul(ubo.model, float4(v.pos, 1.0)).xyz;
+    return o;
+}
+)";
+
+    std::string frag_src = R"(
+struct PSOut { float4 albedo : SV_TARGET0; };
+struct PSIn { float4 sv : SV_POSITION; float3 normal : NORMAL; float2 uv : TEXCOORD0; float3 world_pos : TEXCOORD1; };
+PSOut main(PSIn i) {
+    PSOut o;
+    o.albedo = float4(1, 0, 0, 1);
+    return o;
+}
+)";
+
+    auto rp = create_color_depth_renderpass(ctx->device(), {VK_FORMAT_R8G8B8A8_UNORM});
+    auto& gp = cache.get_graphics_from_source("test_gen", vert_src, frag_src, rp.pass, 0);
+    CHECK(gp.pipeline != VK_NULL_HANDLE);
+    destroy_renderpass(ctx->device(), rp);
 }

--- a/projects/joon/tests/test_hlsl_emitter.cpp
+++ b/projects/joon/tests/test_hlsl_emitter.cpp
@@ -1,0 +1,114 @@
+#include "catch_amalgamated.hpp"
+#include "shader/hlsl_emitter.h"
+#include "shader/shader_ir.h"
+using namespace joon;
+
+TEST_CASE("Emit literal", "[shader][hlsl]") {
+    HlslEmitter emitter;
+    ShaderExpr e = ShaderLiteral{1.5f};
+    auto code = emitter.emit_expr(e);
+    CHECK(code == "1.500000");
+}
+
+TEST_CASE("Emit binary op", "[shader][hlsl]") {
+    HlslEmitter emitter;
+    ShaderCall sc;
+    sc.op = "+";
+    sc.args.push_back(std::make_unique<ShaderExpr>(ShaderLiteral{1.0f}));
+    sc.args.push_back(std::make_unique<ShaderExpr>(ShaderLiteral{2.0f}));
+    ShaderExpr e = std::move(sc);
+    auto code = emitter.emit_expr(e);
+    CHECK(code == "(1.000000 + 2.000000)");
+}
+
+TEST_CASE("Emit function call", "[shader][hlsl]") {
+    HlslEmitter emitter;
+    ShaderCall sc;
+    sc.op = "sin";
+    sc.args.push_back(std::make_unique<ShaderExpr>(ShaderVar{"x"}));
+    ShaderExpr e = std::move(sc);
+    auto code = emitter.emit_expr(e);
+    CHECK(code == "sin(x)");
+}
+
+TEST_CASE("Emit mix maps to lerp", "[shader][hlsl]") {
+    HlslEmitter emitter;
+    ShaderCall sc;
+    sc.op = "mix";
+    sc.args.push_back(std::make_unique<ShaderExpr>(ShaderVar{"a"}));
+    sc.args.push_back(std::make_unique<ShaderExpr>(ShaderVar{"b"}));
+    sc.args.push_back(std::make_unique<ShaderExpr>(ShaderVar{"t"}));
+    ShaderExpr e = std::move(sc);
+    auto code = emitter.emit_expr(e);
+    CHECK(code == "lerp(a, b, t)");
+}
+
+TEST_CASE("Emit vector constructor", "[shader][hlsl]") {
+    HlslEmitter emitter;
+    ShaderVecConstruct vc;
+    vc.elements.push_back(std::make_unique<ShaderExpr>(ShaderLiteral{1.0f}));
+    vc.elements.push_back(std::make_unique<ShaderExpr>(ShaderLiteral{0.0f}));
+    vc.elements.push_back(std::make_unique<ShaderExpr>(ShaderLiteral{0.0f}));
+    ShaderExpr e = std::move(vc);
+    auto code = emitter.emit_expr(e);
+    CHECK(code == "float3(1.000000, 0.000000, 0.000000)");
+}
+
+TEST_CASE("Emit encode normal", "[shader][hlsl]") {
+    HlslEmitter emitter;
+    ShaderCall sc;
+    sc.op = "encode";
+    sc.args.push_back(std::make_unique<ShaderExpr>(ShaderVar{"normal"}));
+    ShaderExpr e = std::move(sc);
+    auto code = emitter.emit_expr(e);
+    CHECK(code == "float4(normal * 0.5 + 0.5, 1.0)");
+}
+
+TEST_CASE("Emit complete fragment shader", "[shader][hlsl]") {
+    HlslEmitter emitter;
+    ShaderFnIR frag;
+    frag.params = {"normal", "uv"};
+    frag.outputs = {{"albedo", "vec4"}, {"normal_out", "vec4"}};
+
+    ShaderVecConstruct vc;
+    vc.elements.push_back(std::make_unique<ShaderExpr>(ShaderLiteral{1.0f}));
+    vc.elements.push_back(std::make_unique<ShaderExpr>(ShaderLiteral{0.0f}));
+    vc.elements.push_back(std::make_unique<ShaderExpr>(ShaderLiteral{0.0f}));
+    vc.elements.push_back(std::make_unique<ShaderExpr>(ShaderLiteral{1.0f}));
+    ShaderAssign sa;
+    sa.target = "albedo";
+    sa.value = std::make_unique<ShaderExpr>(std::move(vc));
+    frag.body.push_back(std::make_unique<ShaderExpr>(std::move(sa)));
+
+    auto hlsl = emitter.emit_fragment(frag, 0);
+    CHECK(hlsl.find("struct PSOut") != std::string::npos);
+    CHECK(hlsl.find("SV_TARGET0") != std::string::npos);
+    CHECK(hlsl.find("SV_TARGET1") != std::string::npos);
+    CHECK(hlsl.find("o.albedo") != std::string::npos);
+}
+
+TEST_CASE("Emit vertex shader", "[shader][hlsl]") {
+    HlslEmitter emitter;
+    ShaderFnIR vert;
+    vert.params = {"pos", "normal", "uv"};
+
+    auto hlsl = emitter.emit_vertex(vert);
+    CHECK(hlsl.find("struct UBO") != std::string::npos);
+    CHECK(hlsl.find("VSOut main") != std::string::npos);
+    CHECK(hlsl.find("o.world_pos") != std::string::npos);
+}
+
+TEST_CASE("Emit dot access", "[shader][hlsl]") {
+    HlslEmitter emitter;
+    ShaderDotAccess da;
+    da.object = std::make_unique<ShaderExpr>(ShaderVar{"pos"});
+    da.field = "y";
+    ShaderExpr e = std::move(da);
+    CHECK(emitter.emit_expr(e) == "pos.y");
+}
+
+TEST_CASE("Emit prepass sample", "[shader][hlsl]") {
+    HlslEmitter emitter;
+    ShaderExpr e = ShaderPrepassSample{0};
+    CHECK(emitter.emit_expr(e) == "__prepass_0.Sample(__sampler_0, uv)");
+}

--- a/projects/joon/tests/test_lighting_pass.cpp
+++ b/projects/joon/tests/test_lighting_pass.cpp
@@ -1,0 +1,29 @@
+#include "catch_amalgamated.hpp"
+#include <joon/joon.h>
+using namespace joon;
+
+TEST_CASE("Deferred lighting produces lit output", "[shader][lighting][gpu]") {
+    auto ctx = Context::create();
+    auto graph = ctx->parse_string(R"(
+        (def mat (shader
+          :fragment (fn [normal uv] -> [albedo vec4]
+            (set albedo [0.8 0.2 0.1 1]))))
+        (def c (cube :scale 1.5 :material mat))
+        (def cam (camera :fov 60))
+        (def l (light :intensity 1.0))
+        (def gbuf (pass))
+        (output gbuf)
+    )");
+    REQUIRE_FALSE(graph.has_errors());
+
+    auto eval = ctx->create_evaluator(graph);
+    eval->evaluate();
+
+    auto px = eval->result("").read_pixels();
+    REQUIRE(px.size() == 512u * 512u * 4u);
+
+    int lit = 0;
+    for (size_t i = 0; i < px.size(); i += 4)
+        if (px[i] > 0.05f) ++lit;
+    CHECK(lit > 100);
+}

--- a/projects/joon/tests/test_prepass.cpp
+++ b/projects/joon/tests/test_prepass.cpp
@@ -1,0 +1,60 @@
+#include "catch_amalgamated.hpp"
+#include "shader/prepass_extractor.h"
+#include "shader/shader_analyzer.h"
+#include "shader/shader_ir.h"
+using namespace joon;
+
+TEST_CASE("Prepass extracts blur from shader body", "[shader][prepass]") {
+    // Build: (set albedo (blur input :radius 3))
+    ShaderCall blur_call;
+    blur_call.op = "blur";
+    blur_call.args.push_back(std::make_unique<ShaderExpr>(ShaderVar{"input"}));
+    blur_call.kwargs.push_back({"radius", 3.0f});
+
+    ShaderAssign assign;
+    assign.target = "albedo";
+    assign.value = std::make_unique<ShaderExpr>(std::move(blur_call));
+
+    ShaderFnIR frag;
+    frag.params = {"normal", "uv"};
+    frag.outputs = {{"albedo", "vec4"}};
+    frag.body.push_back(std::make_unique<ShaderExpr>(std::move(assign)));
+
+    ShaderAnalyzer analyzer;
+    PrepassExtractor extractor(analyzer);
+    auto result = extractor.extract(frag);
+
+    CHECK(result.prepasses.size() == 1);
+    CHECK(result.prepasses[0].root_op == "blur");
+
+    auto* new_assign = std::get_if<ShaderAssign>(result.modified_body[0].get());
+    REQUIRE(new_assign != nullptr);
+    auto* sample = std::get_if<ShaderPrepassSample>(new_assign->value.get());
+    REQUIRE(sample != nullptr);
+    CHECK(sample->prepass_index == 0);
+}
+
+TEST_CASE("Prepass leaves inlineable ops untouched", "[shader][prepass]") {
+    // Build: (set albedo (noise :scale 4.0))
+    ShaderCall noise;
+    noise.op = "noise";
+    noise.kwargs.push_back({"scale", 4.0f});
+
+    ShaderAssign assign;
+    assign.target = "albedo";
+    assign.value = std::make_unique<ShaderExpr>(std::move(noise));
+
+    ShaderFnIR frag;
+    frag.params = {"normal", "uv"};
+    frag.outputs = {{"albedo", "vec4"}};
+    frag.body.push_back(std::make_unique<ShaderExpr>(std::move(assign)));
+
+    ShaderAnalyzer analyzer;
+    PrepassExtractor extractor(analyzer);
+    auto result = extractor.extract(frag);
+
+    CHECK(result.prepasses.empty());
+    auto* a = std::get_if<ShaderAssign>(result.modified_body[0].get());
+    REQUIRE(a != nullptr);
+    CHECK(std::get_if<ShaderCall>(a->value.get()) != nullptr);
+}

--- a/projects/joon/tests/test_shader_ir.cpp
+++ b/projects/joon/tests/test_shader_ir.cpp
@@ -1,0 +1,133 @@
+#include "catch_amalgamated.hpp"
+#include "shader/shader_ir.h"
+#include "shader/shader_analyzer.h"
+#include "ir/node.h"
+#include "dsl/ast.h"
+using namespace joon;
+
+// --- ShaderIR type tests (Task 4) ---
+
+TEST_CASE("ShaderExpr: literal float", "[shader][ir]") {
+    ShaderExpr e = ShaderLiteral{1.5f};
+    CHECK(std::get<ShaderLiteral>(e).value == Catch::Approx(1.5f));
+}
+
+TEST_CASE("ShaderExpr: binary add", "[shader][ir]") {
+    auto a = std::make_unique<ShaderExpr>(ShaderLiteral{1.0f});
+    auto b = std::make_unique<ShaderExpr>(ShaderLiteral{2.0f});
+    ShaderExpr e = ShaderCall{"+", {}, {}};
+    auto& call = std::get<ShaderCall>(e);
+    call.args.push_back(std::move(a));
+    call.args.push_back(std::move(b));
+    CHECK(call.op == "+");
+    CHECK(call.args.size() == 2);
+}
+
+TEST_CASE("ShaderExpr: noise with kwargs", "[shader][ir]") {
+    ShaderExpr e = ShaderCall{"noise", {}, {{"scale", 4.0f}, {"octaves", 3.0f}}};
+    auto& call = std::get<ShaderCall>(e);
+    CHECK(call.kwargs.size() == 2);
+    CHECK(call.kwargs[0].first == "scale");
+}
+
+TEST_CASE("ShaderExpr: variable reference", "[shader][ir]") {
+    ShaderExpr e = ShaderVar{"normal"};
+    CHECK(std::get<ShaderVar>(e).name == "normal");
+}
+
+TEST_CASE("ShaderExpr: assignment", "[shader][ir]") {
+    auto val = std::make_unique<ShaderExpr>(ShaderLiteral{1.0f});
+    ShaderAssign sa;
+    sa.target = "albedo";
+    sa.value = std::move(val);
+    ShaderExpr e = std::move(sa);
+    CHECK(std::get<ShaderAssign>(e).target == "albedo");
+}
+
+TEST_CASE("ShaderExpr: vector constructor", "[shader][ir]") {
+    ShaderVecConstruct vc;
+    vc.elements.push_back(std::make_unique<ShaderExpr>(ShaderLiteral{1.0f}));
+    vc.elements.push_back(std::make_unique<ShaderExpr>(ShaderLiteral{0.0f}));
+    vc.elements.push_back(std::make_unique<ShaderExpr>(ShaderLiteral{0.0f}));
+    ShaderExpr e = std::move(vc);
+    CHECK(std::get<ShaderVecConstruct>(e).elements.size() == 3);
+}
+
+TEST_CASE("ShaderExpr: dot access", "[shader][ir]") {
+    ShaderDotAccess da;
+    da.object = std::make_unique<ShaderExpr>(ShaderVar{"pos"});
+    da.field = "y";
+    ShaderExpr e = std::move(da);
+    CHECK(std::get<ShaderDotAccess>(e).field == "y");
+}
+
+TEST_CASE("ShaderExpr: prepass texture sample", "[shader][ir]") {
+    ShaderExpr e = ShaderPrepassSample{0};
+    CHECK(std::get<ShaderPrepassSample>(e).prepass_index == 0);
+}
+
+// --- ShaderAnalyzer tests (Task 5) ---
+
+TEST_CASE("Analyzer builds ShaderIR from ShaderDef", "[shader][analyzer]") {
+    ShaderDef sd;
+    ShaderFnDef frag;
+    frag.params = {"normal", "uv"};
+    frag.outputs = {{"albedo", "vec4"}};
+
+    // Build AST for (set albedo [1 0 0 1])
+    auto vec = std::make_unique<AstNode>();
+    VectorNode vn;
+    for (float v : {1.0f, 0.0f, 0.0f, 1.0f}) {
+        auto num = std::make_unique<AstNode>();
+        num->data = NumberNode{v};
+        vn.elements.push_back(std::move(num));
+    }
+    vec->data = std::move(vn);
+
+    auto set_call = std::make_unique<AstNode>();
+    CallNode cn;
+    cn.op = "set";
+    auto target = std::make_unique<AstNode>();
+    target->data = SymbolNode{"albedo"};
+    cn.args.push_back(std::move(target));
+    cn.args.push_back(std::move(vec));
+    set_call->data = std::move(cn);
+
+    frag.body.push_back(std::shared_ptr<AstNode>(std::move(set_call)));
+    sd.fragment = std::move(frag);
+
+    ShaderAnalyzer analyzer;
+    auto ir = analyzer.analyze(sd);
+
+    REQUIRE(ir.fragment.has_value());
+    CHECK(ir.fragment->params.size() == 2);
+    CHECK(ir.fragment->outputs.size() == 1);
+    CHECK(ir.fragment->body.size() == 1);
+
+    auto* assign = std::get_if<ShaderAssign>(ir.fragment->body[0].get());
+    REQUIRE(assign != nullptr);
+    CHECK(assign->target == "albedo");
+}
+
+TEST_CASE("Op classification: inlineable ops", "[shader][analyzer]") {
+    ShaderAnalyzer analyzer;
+    CHECK(analyzer.classify("sin") == ShaderOpKind::INLINEABLE);
+    CHECK(analyzer.classify("dot") == ShaderOpKind::INLINEABLE);
+    CHECK(analyzer.classify("noise") == ShaderOpKind::INLINEABLE);
+    CHECK(analyzer.classify("+") == ShaderOpKind::INLINEABLE);
+    CHECK(analyzer.classify("mix") == ShaderOpKind::INLINEABLE);
+    CHECK(analyzer.classify("step") == ShaderOpKind::INLINEABLE);
+    CHECK(analyzer.classify("encode") == ShaderOpKind::INLINEABLE);
+}
+
+TEST_CASE("Op classification: prepass-required ops", "[shader][analyzer]") {
+    ShaderAnalyzer analyzer;
+    CHECK(analyzer.classify("blur") == ShaderOpKind::PREPASS_REQUIRED);
+    CHECK(analyzer.classify("levels") == ShaderOpKind::PREPASS_REQUIRED);
+    CHECK(analyzer.classify("blend") == ShaderOpKind::PREPASS_REQUIRED);
+}
+
+TEST_CASE("Op classification: unknown ops", "[shader][analyzer]") {
+    ShaderAnalyzer analyzer;
+    CHECK(analyzer.classify("foobar") == ShaderOpKind::UNKNOWN);
+}

--- a/projects/joon/tests/test_shader_parser.cpp
+++ b/projects/joon/tests/test_shader_parser.cpp
@@ -1,5 +1,8 @@
 #include "catch_amalgamated.hpp"
 #include "dsl/parser.h"
+#include <joon/context.h>
+#include <joon/graph.h>
+#include "ir/ir_graph.h"
 using namespace joon;
 
 TEST_CASE("Parse vector literal", "[shader][parser]") {
@@ -86,4 +89,58 @@ TEST_CASE("Parse chained dot access", "[shader][parser]") {
     auto* inner = std::get_if<DotAccessNode>(&dot->object->data);
     REQUIRE(inner != nullptr);
     CHECK(inner->field == "b");
+}
+
+TEST_CASE("shader op lowers to MATERIAL tier", "[shader][ir]") {
+    auto ctx = Context::create();
+    auto graph = ctx->parse_string(R"(
+        (def mat (shader
+          :fragment (fn [normal uv] -> [albedo vec4]
+            (set albedo [1 0 0 1]))))
+    )");
+    REQUIRE_FALSE(graph.has_errors());
+
+    auto& ir = graph.ir();
+    bool found_material = false;
+    for (auto& n : ir.nodes) {
+        if (n.tier == Tier::MATERIAL) {
+            found_material = true;
+            CHECK(n.op == "shader");
+            CHECK(n.output_type == Type::MATERIAL);
+            auto sd_it = ir.shader_defs.find(n.id);
+            REQUIRE(sd_it != ir.shader_defs.end());
+            auto& sd = sd_it->second;
+            REQUIRE(sd.fragment.has_value());
+            CHECK(sd.fragment->params.size() == 2);
+            CHECK(sd.fragment->outputs.size() == 1);
+            CHECK(sd.fragment->outputs[0].name == "albedo");
+            CHECK(sd.fragment->body.size() == 1);
+        }
+    }
+    CHECK(found_material);
+}
+
+TEST_CASE("shader with all three clauses", "[shader][ir]") {
+    auto ctx = Context::create();
+    auto graph = ctx->parse_string(R"(
+        (def mat (shader
+          :vertex (fn [pos normal uv] (set pos.y (* pos.x 2.0)))
+          :brdf (fn [normal light_dir view_dir albedo]
+            (* albedo (dot normal light_dir)))
+          :fragment (fn [normal uv] -> [albedo vec4]
+            (set albedo [1 0 0 1]))))
+    )");
+    REQUIRE_FALSE(graph.has_errors());
+
+    auto& ir = graph.ir();
+    auto* mat = ir.find_node_by_name("mat");
+    REQUIRE(mat);
+    auto sd_it = ir.shader_defs.find(mat->id);
+    REQUIRE(sd_it != ir.shader_defs.end());
+    auto& sd = sd_it->second;
+    CHECK(sd.vertex.has_value());
+    CHECK(sd.fragment.has_value());
+    CHECK(sd.brdf.has_value());
+    CHECK(sd.vertex->params.size() == 3);
+    CHECK(sd.brdf->params.size() == 4);
 }

--- a/projects/joon/tests/test_shader_parser.cpp
+++ b/projects/joon/tests/test_shader_parser.cpp
@@ -1,0 +1,89 @@
+#include "catch_amalgamated.hpp"
+#include "dsl/parser.h"
+using namespace joon;
+
+TEST_CASE("Parse vector literal", "[shader][parser]") {
+    Parser p("[1.0 2.0 3.0]");
+    auto expr = p.parse_expression();
+    auto* vec = std::get_if<VectorNode>(&expr->data);
+    REQUIRE(vec != nullptr);
+    CHECK(vec->elements.size() == 3);
+    auto* e0 = std::get_if<NumberNode>(&vec->elements[0]->data);
+    REQUIRE(e0);
+    CHECK(e0->value == Catch::Approx(1.0));
+}
+
+TEST_CASE("Parse fn with body", "[shader][parser]") {
+    Parser p("(fn [pos normal uv] (set pos.y (* pos.x 2.0)))");
+    auto expr = p.parse_expression();
+    auto* fn = std::get_if<FnNode>(&expr->data);
+    REQUIRE(fn != nullptr);
+    CHECK(fn->params.size() == 3);
+    CHECK(fn->params[0] == "pos");
+    CHECK(fn->params[1] == "normal");
+    CHECK(fn->params[2] == "uv");
+    CHECK(fn->body.size() == 1);
+}
+
+TEST_CASE("Parse fn with arrow outputs", "[shader][parser]") {
+    Parser p("(fn [normal uv] -> [albedo vec4, normal vec4] (set albedo [1 0 0 1]))");
+    auto expr = p.parse_expression();
+    auto* fn = std::get_if<FnNode>(&expr->data);
+    REQUIRE(fn != nullptr);
+    CHECK(fn->params.size() == 2);
+    CHECK(fn->outputs.size() == 2);
+    CHECK(fn->outputs[0].name == "albedo");
+    CHECK(fn->outputs[0].type_name == "vec4");
+    CHECK(fn->outputs[1].name == "normal");
+    CHECK(fn->body.size() == 1);
+}
+
+TEST_CASE("Parse shader call with fn kwargs", "[shader][parser]") {
+    Parser p(R"(
+        (shader
+          :fragment (fn [normal uv] -> [albedo vec4]
+            (set albedo [1 0 0 1])))
+    )");
+    auto expr = p.parse_expression();
+    auto* call = std::get_if<CallNode>(&expr->data);
+    REQUIRE(call != nullptr);
+    CHECK(call->op == "shader");
+    CHECK(call->kwargs.size() == 1);
+    CHECK(call->kwargs[0].name == "fragment");
+    auto* fn = std::get_if<FnNode>(&call->kwargs[0].value->data);
+    REQUIRE(fn != nullptr);
+    CHECK(fn->outputs.size() == 1);
+}
+
+TEST_CASE("Vector literal with expressions", "[shader][parser]") {
+    Parser p("[(+ 1 2) 3.0 x]");
+    auto expr = p.parse_expression();
+    auto* vec = std::get_if<VectorNode>(&expr->data);
+    REQUIRE(vec != nullptr);
+    CHECK(vec->elements.size() == 3);
+    CHECK(std::get_if<CallNode>(&vec->elements[0]->data) != nullptr);
+    CHECK(std::get_if<NumberNode>(&vec->elements[1]->data) != nullptr);
+    CHECK(std::get_if<SymbolNode>(&vec->elements[2]->data) != nullptr);
+}
+
+TEST_CASE("Parse dot access", "[shader][parser]") {
+    Parser p("gbuf.albedo");
+    auto expr = p.parse_expression();
+    auto* dot = std::get_if<DotAccessNode>(&expr->data);
+    REQUIRE(dot != nullptr);
+    CHECK(dot->field == "albedo");
+    auto* obj = std::get_if<SymbolNode>(&dot->object->data);
+    REQUIRE(obj != nullptr);
+    CHECK(obj->name == "gbuf");
+}
+
+TEST_CASE("Parse chained dot access", "[shader][parser]") {
+    Parser p("a.b.c");
+    auto expr = p.parse_expression();
+    auto* dot = std::get_if<DotAccessNode>(&expr->data);
+    REQUIRE(dot != nullptr);
+    CHECK(dot->field == "c");
+    auto* inner = std::get_if<DotAccessNode>(&dot->object->data);
+    REQUIRE(inner != nullptr);
+    CHECK(inner->field == "b");
+}


### PR DESCRIPTION
## Summary

- Extends the Joon DSL parser with `FnNode`, `VectorNode`, `DotAccessNode`, and arrow-output syntax for declaring shader functions
- Adds a multi-tier shader compilation pipeline: DSL → ShaderIR → HLSL → DXC → SPIR-V → Vulkan pipeline
- Implements deferred rendering with G-buffer, per-material graphics pipelines, and a fullscreen lighting pass
- Supports custom BRDF functions via `:brdf` keyword that generate per-material lighting shader variants at runtime
- Adds pre-pass extraction infrastructure for non-inlineable ops (blur, levels, etc.) in shader bodies
- Resource pool gains `alias_image()` for zero-copy G-buffer channel access via dot syntax (`gbuf.albedo`)

## Architecture

```
DSL source → Parser (FnNode/VectorNode) → IR Graph (Tier::MATERIAL)
  → ShaderAnalyzer → ShaderIR (expression tree)
  → HlslEmitter → HLSL source
  → PipelineCache (DXC) → SPIR-V → VkPipeline

Render: Scene tier → Material tier (compile pipelines)
  → Geometry pass (per-material pipeline binding)
  → Lighting pass (default or custom BRDF shader)
```

## Test plan

- [x] 98 tests pass (1382 assertions), up from 59 at start
- [x] Clean build from scratch succeeds
- [ ] Launch `joon-gui.exe` — verify red-shaded cube with lighting, contrast slider works

🤖 Generated with [Claude Code](https://claude.com/claude-code)