### PR TITLE
fix(rp): raise num_predict floor from 256 to 1024

### DIFF
--- a/projects/rp/prompt_builder.py
+++ b/projects/rp/prompt_builder.py
@@ -59,7 +59,7 @@ def build_ollama_options(settings: dict) -> dict:
 
 def scale_num_predict(opts: dict, user_message: str) -> dict:
     user_tokens = count_tokens(user_message)
-    scaled = max(256, min(1024, user_tokens * 2))
+    scaled = max(1024, min(2048, user_tokens * 2))
     return {**opts, "num_predict": scaled}
 
 

--- a/projects/rp/tests/test_prompt_builder.py
+++ b/projects/rp/tests/test_prompt_builder.py
@@ -100,12 +100,12 @@ class TestBuildOllamaOptions:
 class TestScaleNumPredict:
     def test_short_message(self):
         opts = scale_num_predict({"num_predict": 768}, "hi")
-        assert opts["num_predict"] == 256
+        assert opts["num_predict"] == 1024
 
     def test_long_message(self):
-        long_msg = "word " * 600
+        long_msg = "word " * 5000
         opts = scale_num_predict({"num_predict": 768}, long_msg)
-        assert opts["num_predict"] == 1024
+        assert opts["num_predict"] == 2048
 
     def test_preserves_other_keys(self):
         opts = scale_num_predict({"num_predict": 768, "temperature": 0.8}, "hello")


### PR DESCRIPTION
## Summary

- `scale_num_predict` had a floor of 256 tokens, which truncated RP responses mid-sentence when user messages were short
- Raised floor to 1024 and ceiling to 2048 — RP responses typically need 300-600 tokens regardless of input length

## Test plan
```bash
pytest projects/rp/tests/test_prompt_builder.py -v -k scale
# 3 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)