### PR TITLE
feat(joon): add Windows menu to toggle panel visibility

### DIFF
--- a/projects/joon/gui/app.h
+++ b/projects/joon/gui/app.h
@@ -25,6 +25,13 @@ struct App {
     VkSampler sampler = VK_NULL_HANDLE;
     VkDescriptorPool imgui_desc_pool = VK_NULL_HANDLE;
 
+    bool show_code = true;
+    bool show_tree = true;
+    bool show_properties = true;
+    bool show_viewport = true;
+    bool show_preview = true;
+    bool show_log = true;
+
     void init();
     void shutdown();
     void reparse();

--- a/projects/joon/gui/main.cpp
+++ b/projects/joon/gui/main.cpp
@@ -434,6 +434,15 @@ int main() {
                     reset_layout = true;
                 ImGui::EndMenu();
             }
+            if (ImGui::BeginMenu("Windows")) {
+                ImGui::MenuItem("Code Editor", nullptr, &app.show_code);
+                ImGui::MenuItem("Graph Tree", nullptr, &app.show_tree);
+                ImGui::MenuItem("Properties", nullptr, &app.show_properties);
+                ImGui::MenuItem("Viewport", nullptr, &app.show_viewport);
+                ImGui::MenuItem("Node Preview", nullptr, &app.show_preview);
+                ImGui::MenuItem("Output Log", nullptr, &app.show_log);
+                ImGui::EndMenu();
+            }
             ImGui::EndMainMenuBar();
         }
 
@@ -471,12 +480,12 @@ int main() {
         }
 
         app.update();
-        app.draw_tree();
-        app.draw_properties();
-        app.draw_code();
-        app.draw_viewport();
-        app.draw_preview();
-        app.draw_log();
+        if (app.show_tree) app.draw_tree();
+        if (app.show_properties) app.draw_properties();
+        if (app.show_code) app.draw_code();
+        if (app.show_viewport) app.draw_viewport();
+        if (app.show_preview) app.draw_preview();
+        if (app.show_log) app.draw_log();
 
         ImGui::Render();
         ImGui_ImplVulkan_RenderDrawData(ImGui::GetDrawData(), cmd);

--- a/projects/joon/gui/panel_code.cpp
+++ b/projects/joon/gui/panel_code.cpp
@@ -4,7 +4,7 @@
 #include <algorithm>
 
 void App::draw_code() {
-    ImGui::Begin("Code Editor");
+    ImGui::Begin("Code Editor", &show_code);
 
     if (ImGui::IsWindowHovered() && ImGui::GetIO().KeyCtrl) {
         float wheel = ImGui::GetIO().MouseWheel;

--- a/projects/joon/gui/panel_log.cpp
+++ b/projects/joon/gui/panel_log.cpp
@@ -2,7 +2,7 @@
 #include <imgui.h>
 
 void App::draw_log() {
-    ImGui::Begin("Output Log");
+    ImGui::Begin("Output Log", &show_log);
 
     if (!eval_error.empty()) {
         ImGui::TextColored(ImVec4(1.0f, 0.3f, 0.3f, 1.0f),

--- a/projects/joon/gui/panel_preview.cpp
+++ b/projects/joon/gui/panel_preview.cpp
@@ -2,7 +2,7 @@
 #include <imgui.h>
 
 void App::draw_preview() {
-    ImGui::Begin("Node Preview");
+    ImGui::Begin("Node Preview", &show_preview);
 
     if (eval && selected_node_id != UINT32_MAX) {
         auto* node = graph.ir().find_node(selected_node_id);

--- a/projects/joon/gui/panel_properties.cpp
+++ b/projects/joon/gui/panel_properties.cpp
@@ -3,7 +3,7 @@
 #include <imgui.h>
 
 void App::draw_properties() {
-    ImGui::Begin("Properties");
+    ImGui::Begin("Properties", &show_properties);
 
     if (eval && !graph.has_errors()) {
         for (auto& p : graph.ir().params) {

--- a/projects/joon/gui/panel_tree.cpp
+++ b/projects/joon/gui/panel_tree.cpp
@@ -2,7 +2,7 @@
 #include <imgui.h>
 
 void App::draw_tree() {
-    ImGui::Begin("Graph Tree");
+    ImGui::Begin("Graph Tree", &show_tree);
 
     if (!graph.has_errors()) {
         auto& ir = graph.ir();

--- a/projects/joon/gui/panel_viewport.cpp
+++ b/projects/joon/gui/panel_viewport.cpp
@@ -2,7 +2,7 @@
 #include <imgui.h>
 
 void App::draw_viewport() {
-    ImGui::Begin("Viewport");
+    ImGui::Begin("Viewport", &show_viewport);
 
     if (eval && !graph.has_errors() && !graph.ir().outputs.empty()) {
         auto result = eval->result("output");


### PR DESCRIPTION
## Summary
- Adds a "Windows" menu to the menu bar with toggle items for all 6 panels
- Panels can be closed via their X button or unchecked from the menu
- Re-selecting a closed panel in the menu reopens it

## Test plan
- [ ] Build in Visual Studio
- [ ] Verify "Windows" menu appears in menu bar
- [ ] Toggle each panel off/on via menu
- [ ] Close a panel via X button, verify menu unchecks it
- [ ] Reopen via menu, verify it docks back

🤖 Generated with [Claude Code](https://claude.com/claude-code)