### PR TITLE
feat(joon): add Graphs panel with example graph list

### DIFF
--- a/projects/joon/gui/app.cpp
+++ b/projects/joon/gui/app.cpp
@@ -7,7 +7,8 @@ void App::init() {
     ctx = joon::Context::create();
     ctx->device().log_fn = joon_log::write;
 
-    dsl_source = R"(; Joon - 3D scene with materials
+    graph_entries = {
+        {"3D Scene", R"(; Joon - 3D scene with materials
 (def red_mat (shader
   :fragment (fn [normal uv] -> [albedo vec4]
     (set albedo [0.8 0.2 0.1 1]))))
@@ -19,7 +20,25 @@ void App::init() {
 (param contrast float 1.0 :min 0.0 :max 3.0)
 (def final (levels gbuf :contrast contrast))
 (output final)
-)";
+)"},
+        {"Noise + Invert", R"(; Simple noise pipeline
+(def a (noise :scale 4.0 :octaves 3))
+(def b (invert a))
+(output b)
+)"},
+        {"Levels", R"(; Parameterized levels
+(def base (noise :scale 4.0 :octaves 3))
+(param contrast float 1.0 :min 0.0 :max 3.0)
+(def result (levels base :contrast contrast))
+(output result)
+)"},
+        {"Constant", R"(; Constant output
+(output 0.5)
+)"},
+    };
+
+    active_graph_index = 0;
+    dsl_source = graph_entries[0].source;
 
     VkSamplerCreateInfo sampler_info{};
     sampler_info.sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;

--- a/projects/joon/gui/app.h
+++ b/projects/joon/gui/app.h
@@ -5,8 +5,14 @@
 #include "vulkan/device.h"
 #include "vulkan/resource_pool.h"
 #include <string>
+#include <vector>
 #include <memory>
 #include <vulkan/vulkan.h>
+
+struct GraphEntry {
+    std::string name;
+    std::string source;
+};
 
 struct App {
     std::unique_ptr<joon::Context> ctx;
@@ -31,6 +37,10 @@ struct App {
     bool show_viewport = true;
     bool show_preview = true;
     bool show_log = true;
+    bool show_graphs = true;
+
+    std::vector<GraphEntry> graph_entries;
+    size_t active_graph_index = 0;
 
     void init();
     void shutdown();
@@ -44,4 +54,5 @@ struct App {
     void draw_viewport();
     void draw_preview();
     void draw_log();
+    void draw_graphs();
 };

--- a/projects/joon/gui/main.cpp
+++ b/projects/joon/gui/main.cpp
@@ -441,6 +441,7 @@ int main() {
                 ImGui::MenuItem("Viewport", nullptr, &app.show_viewport);
                 ImGui::MenuItem("Node Preview", nullptr, &app.show_preview);
                 ImGui::MenuItem("Output Log", nullptr, &app.show_log);
+                ImGui::MenuItem("Graphs", nullptr, &app.show_graphs);
                 ImGui::EndMenu();
             }
             ImGui::EndMainMenuBar();
@@ -469,6 +470,7 @@ int main() {
             ImGuiID dock_right = ImGui::DockBuilderSplitNode(dock_main, ImGuiDir_Right, 0.55f, nullptr, &dock_main);
             ImGuiID dock_right_bottom = ImGui::DockBuilderSplitNode(dock_right, ImGuiDir_Down, 0.36f, nullptr, &dock_right);
 
+            ImGui::DockBuilderDockWindow("Graphs", dock_left);
             ImGui::DockBuilderDockWindow("Properties", dock_left);
             ImGui::DockBuilderDockWindow("Graph Tree", dock_left);
             ImGui::DockBuilderDockWindow("Code Editor", dock_main);
@@ -486,6 +488,7 @@ int main() {
         if (app.show_viewport) app.draw_viewport();
         if (app.show_preview) app.draw_preview();
         if (app.show_log) app.draw_log();
+        if (app.show_graphs) app.draw_graphs();
 
         ImGui::Render();
         ImGui_ImplVulkan_RenderDrawData(ImGui::GetDrawData(), cmd);

--- a/projects/joon/gui/panel_graphs.cpp
+++ b/projects/joon/gui/panel_graphs.cpp
@@ -1,0 +1,17 @@
+#include "app.h"
+#include <imgui.h>
+
+void App::draw_graphs() {
+    ImGui::Begin("Graphs", &show_graphs);
+
+    for (size_t i = 0; i < graph_entries.size(); i++) {
+        bool selected = (i == active_graph_index);
+        if (ImGui::Selectable(graph_entries[i].name.c_str(), selected)) {
+            active_graph_index = i;
+            dsl_source = graph_entries[i].source;
+            source_dirty = true;
+        }
+    }
+
+    ImGui::End();
+}


### PR DESCRIPTION
## Summary
- Adds a new "Graphs" panel listing built-in example graphs (3D Scene, Noise + Invert, Levels, Constant)
- Clicking an entry loads its DSL source into the code editor and triggers reparse
- Panel is toggleable via Windows menu and has an X-close button
- Docks in the left column by default alongside Properties and Graph Tree

## Test plan
- [ ] Build in Visual Studio
- [ ] Verify "Graphs" panel appears in left dock
- [ ] Click each graph entry, verify code editor updates and viewport re-renders
- [ ] Close panel via X, reopen via Windows > Graphs

🤖 Generated with [Claude Code](https://claude.com/claude-code)