### PR TITLE
feat(joon): add Sponza graph + fix premake5 WSL Vulkan paths

### DIFF
--- a/projects/joon/gui/app.cpp
+++ b/projects/joon/gui/app.cpp
@@ -35,6 +35,17 @@ void App::init() {
         {"Constant", R"(; Constant output
 (output 0.5)
 )"},
+        {"Sponza", R"(; Sponza atrium
+(def mat (shader
+  :fragment (fn [normal uv] -> [albedo vec4]
+    (set albedo [0.7 0.7 0.7 1]))))
+
+(def sponza (mesh "assets/scenes/sponza/sponza.obj" :material mat))
+(def cam (camera :fov 75 :position [0 5 0] :target [10 5 0] :near 0.1 :far 100))
+(def sun (light :direction [-0.5 -1 -0.3] :intensity 1.5))
+(def gbuf (pass))
+(output gbuf)
+)"},
     };
 
     active_graph_index = 0;

--- a/projects/joon/premake5.lua
+++ b/projects/joon/premake5.lua
@@ -38,8 +38,10 @@ workspace "Joon"
 
     -- LunarG layout differs between Windows (Include/Lib, vulkan-1.lib) and
     -- Linux (include/lib, libvulkan.so). Resolve once here and reuse below.
+    -- Use action target rather than os.host() so WSL can generate vs2022 projects.
     local vulkan_include, vulkan_libdir, vulkan_libname
-    if os.host() == "windows" then
+    local target_windows = os.host() == "windows" or _ACTION:find("vs")
+    if target_windows then
         vulkan_include = vulkan_sdk .. "/Include"
         vulkan_libdir  = vulkan_sdk .. "/Lib"
         vulkan_libname = "vulkan-1"


### PR DESCRIPTION
## Summary
- Adds "Sponza" entry to the built-in graphs list, loading `assets/scenes/sponza/sponza.obj` with a grey material, positioned camera, and directional light
- Fixes `premake5.lua` to detect `vs2022` action when running from WSL so it uses Windows Vulkan SDK paths (`/Lib`, `vulkan-1`) instead of Linux paths

## Test plan
- [ ] Run `VULKAN_SDK="C:/VulkanSDK/1.4.341.1" premake5 vs2022` from WSL
- [ ] Build in Visual Studio (should link without vulkan.lib errors)
- [ ] Select "Sponza" in the Graphs panel
- [ ] Verify the scene renders in the viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)