### PR TITLE
fix(joon): clear resource pool on graph switch

### DIFF
--- a/projects/joon/gui/app.cpp
+++ b/projects/joon/gui/app.cpp
@@ -105,6 +105,18 @@ void App::bind_viewport() {
 
 void App::reparse() {
     eval_error.clear();
+    eval.reset();
+    if (viewport_desc) {
+        vkDeviceWaitIdle(ctx->device().device);
+        ImGui_ImplVulkan_RemoveTexture(viewport_desc);
+        viewport_desc = VK_NULL_HANDLE;
+    }
+    if (preview_desc) {
+        vkDeviceWaitIdle(ctx->device().device);
+        ImGui_ImplVulkan_RemoveTexture(preview_desc);
+        preview_desc = VK_NULL_HANDLE;
+    }
+    ctx->pool().clear();
     try {
         graph = ctx->parse_string(dsl_source.c_str());
         for (auto& d : graph.diagnostics()) {


### PR DESCRIPTION
## Summary
- Clears the ResourcePool before creating a new evaluator in `reparse()`
- Invalidates ImGui texture descriptors that reference pool images before clearing
- Fixes black output when switching to Sponza (or any graph that uses render targets after a compute-only graph was loaded)

**Root cause:** The ResourcePool caches images by node ID. When switching graphs, a new graph's `pass` node could get an ID previously used by a compute node (allocated via `alloc_image` without `COLOR_ATTACHMENT_BIT`). The cache hit check only validated dimensions/format, not usage flags.

## Test plan
- [ ] Build in VS
- [ ] Load 3D Scene, then switch to Sponza — verify no validation errors and non-black output
- [ ] Switch between all graphs rapidly — no crashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)