### PR TITLE
fix(joon): correct Sponza camera for centimeter-scale OBJ

### DIFF
--- a/projects/joon/gui/app.cpp
+++ b/projects/joon/gui/app.cpp
@@ -41,7 +41,7 @@ void App::init() {
     (set albedo [0.7 0.7 0.7 1]))))
 
 (def sponza (mesh "assets/scenes/sponza/sponza.obj" :material mat))
-(def cam (camera :fov 75 :position [0 5 0] :target [10 5 0] :near 0.1 :far 100))
+(def cam (camera :fov 75 :position [-500 400 0] :target [500 400 0] :near 1 :far 5000))
 (def sun (light :direction [-0.5 -1 -0.3] :intensity 1.5))
 (def gbuf (pass))
 (output gbuf)


### PR DESCRIPTION
## Summary
- Sponza OBJ spans ~3700 units in X, ~1550 in Y — standard centimeter scale
- Camera was at [0,5,0] with far=100, completely outside the model bounds
- Moved to [-500,400,0] looking at [500,400,0] with far=5000

## Test plan
- [ ] Build and select Sponza graph — verify non-black viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)