### PR TITLE
fix(joon): propagate string_arg to mesh node from positional args

### DIFF
--- a/projects/joon/src/ir/ir_graph.cpp
+++ b/projects/joon/src/ir/ir_graph.cpp
@@ -133,6 +133,8 @@ uint32_t IRGraph::resolve_expr(const AstNode& expr) {
             uint32_t input_slot = static_cast<uint32_t>(nodes[id].inputs.size());
             nodes[id].inputs.push_back(input_id);
             edges.push_back({ input_id, id, input_slot });
+            if (nodes[input_id].op == "string_constant")
+                nodes[id].string_arg = nodes[input_id].string_arg;
         }
 
         for (auto& kw : call->kwargs) {


### PR DESCRIPTION
## Summary
- String positional arguments (e.g. `(mesh "path.obj")`) were resolved into `string_constant` child nodes, but the parent call node's `string_arg` field was never set
- `exec_mesh` reads `n.string_arg` on the mesh node — it was always empty, so `load_obj_file` was never called
- Fix: when a positional arg resolves to a `string_constant`, copy its `string_arg` to the parent node

**Root cause of black Sponza output** (after camera/pool fixes).

## Test plan
- [ ] Build and select Sponza graph — verify geometry renders
- [ ] Verify other graphs (3D Scene, Noise, etc.) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)