### PR TITLE
fix(joon): tone down Sponza lighting to avoid whiteout

### DIFF
--- a/projects/joon/gui/app.cpp
+++ b/projects/joon/gui/app.cpp
@@ -38,11 +38,11 @@ void App::init() {
         {"Sponza", R"(; Sponza atrium
 (def mat (shader
   :fragment (fn [normal uv] -> [albedo vec4]
-    (set albedo [0.7 0.7 0.7 1]))))
+    (set albedo [0.5 0.45 0.4 1]))))
 
 (def sponza (mesh "assets/scenes/sponza/sponza.obj" :material mat))
 (def cam (camera :fov 75 :position [-500 400 0] :target [500 400 0] :near 1 :far 5000))
-(def sun (light :direction [-0.5 -1 -0.3] :intensity 1.5))
+(def sun (light :direction [-0.5 -1 -0.3] :intensity 0.7))
 (def gbuf (pass))
 (output gbuf)
 )"},


### PR DESCRIPTION
## Summary
- Deferred shader uses hardcoded normal `(0,1,0)` for all surfaces, so all pixels get the same N·L
- Previous values: albedo 0.7, intensity 1.5 → result ~0.97 (white)
- New values: albedo 0.5/0.45/0.4 (warm stone), intensity 0.7 → result ~0.35 (visible)

## Test plan
- [ ] Build, select Sponza — verify visible geometry (not white/black)

🤖 Generated with [Claude Code](https://claude.com/claude-code)