### PR TITLE
feat(joon): G-buffer normals for deferred lighting

### DIFF
--- a/projects/joon/shaders/deferred_default.frag.hlsl
+++ b/projects/joon/shaders/deferred_default.frag.hlsl
@@ -14,6 +14,7 @@ struct LightUBO {
 [[vk::binding(0, 0)]] Texture2D gbuf_albedo;
 [[vk::binding(1, 0)]] SamplerState samp;
 [[vk::binding(2, 0)]] ConstantBuffer<LightUBO> light_ubo;
+[[vk::binding(3, 0)]] Texture2D gbuf_normal;
 
 struct PSIn {
     float4 sv : SV_POSITION;
@@ -24,6 +25,7 @@ float4 main(PSIn i) : SV_TARGET {
     float4 albedo = gbuf_albedo.Sample(samp, i.uv);
     if (albedo.a < 0.01) discard;
 
+    float3 normal = gbuf_normal.Sample(samp, i.uv).xyz * 2.0 - 1.0;
     float3 result = albedo.rgb * 0.1;
 
     for (int li = 0; li < light_ubo.light_count; li++) {
@@ -37,7 +39,7 @@ float4 main(PSIn i) : SV_TARGET {
             light_dir = normalize(light_ubo.lights[li].position_type.xyz);
         }
 
-        float ndotl = saturate(dot(float3(0, 1, 0), light_dir));
+        float ndotl = saturate(dot(normal, light_dir));
         result += albedo.rgb * light_color * ndotl;
     }
 

--- a/projects/joon/src/scene/geometry_pass.cpp
+++ b/projects/joon/src/scene/geometry_pass.cpp
@@ -32,14 +32,24 @@ void exec_pass(const Node& n, EvalContext& ctx) {
     // When materials are active, G-buffer goes to an intermediate slot and
     // the lighting pass writes the final lit output to n.id.
     uint32_t color_id = has_materials ? (n.id ^ 0x40000000u) : n.id;
+    uint32_t normal_id = n.id ^ 0x20000000u;
     uint32_t depth_id = n.id ^ 0x80000000u;
 
     auto* albedo = ctx.pool.alloc_render_target(color_id, ctx.default_width, ctx.default_height);
     auto* depth  = ctx.pool.alloc_depth        (depth_id, ctx.default_width, ctx.default_height);
 
+    GpuImage* normal_buf = nullptr;
+    std::vector<VkFormat> color_formats = { albedo->format };
+    std::vector<VkImageView> color_views = { albedo->view };
+    if (has_materials) {
+        normal_buf = ctx.pool.alloc_render_target(normal_id, ctx.default_width, ctx.default_height);
+        color_formats.push_back(normal_buf->format);
+        color_views.push_back(normal_buf->view);
+    }
+
     // Render pass + framebuffer — created per-evaluate (caching is a follow-up).
-    RenderPass rp = create_color_depth_renderpass(ctx.device, { albedo->format });
-    VkFramebuffer fb = create_framebuffer(ctx.device, rp, { albedo->view }, depth->view,
+    RenderPass rp = create_color_depth_renderpass(ctx.device, color_formats);
+    VkFramebuffer fb = create_framebuffer(ctx.device, rp, color_views, depth->view,
                                            ctx.default_width, ctx.default_height);
 
     const auto& gp = ctx.pipelines.get_graphics("scene_basic", rp.pass, sizeof(PushLight));
@@ -172,23 +182,29 @@ void exec_pass(const Node& n, EvalContext& ctx) {
 
     // Transition color attachment from COLOR_ATTACHMENT_OPTIMAL → GENERAL so
     // downstream compute and the GUI viewport can read it.
-    VkImageMemoryBarrier barrier{};
-    barrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
-    barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-    barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-    barrier.oldLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
-    barrier.newLayout = VK_IMAGE_LAYOUT_GENERAL;
-    barrier.image = albedo->image;
-    barrier.subresourceRange = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1 };
-    barrier.srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
-    barrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_SHADER_WRITE_BIT
-                          | VK_ACCESS_TRANSFER_READ_BIT;
+    VkImageMemoryBarrier barriers[2]{};
+    uint32_t barrier_count = 1;
+    barriers[0].sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+    barriers[0].srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    barriers[0].dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    barriers[0].oldLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+    barriers[0].newLayout = VK_IMAGE_LAYOUT_GENERAL;
+    barriers[0].image = albedo->image;
+    barriers[0].subresourceRange = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1 };
+    barriers[0].srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+    barriers[0].dstAccessMask = VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_SHADER_WRITE_BIT
+                              | VK_ACCESS_TRANSFER_READ_BIT;
+    if (normal_buf) {
+        barriers[1] = barriers[0];
+        barriers[1].image = normal_buf->image;
+        barrier_count = 2;
+    }
     vkCmdPipelineBarrier(cmd,
                           VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
                           VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT
                               | VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT
                               | VK_PIPELINE_STAGE_TRANSFER_BIT,
-                          0, 0, nullptr, 0, nullptr, 1, &barrier);
+                          0, 0, nullptr, 0, nullptr, barrier_count, barriers);
 
     ctx.device.end_single_command(cmd);
 
@@ -205,7 +221,7 @@ void exec_pass(const Node& n, EvalContext& ctx) {
         LightingPassConfig lcfg{
             ctx.device, ctx.pipelines, ctx.pool, ctx.desc_pool,
             ctx.scene, ctx.default_width, ctx.default_height,
-            albedo, n.id, brdf
+            albedo, normal_buf, n.id, brdf
         };
         dispatch_lighting_pass(lcfg);
     }

--- a/projects/joon/src/scene/lighting_pass.cpp
+++ b/projects/joon/src/scene/lighting_pass.cpp
@@ -70,6 +70,10 @@ void dispatch_lighting_pass(const LightingPassConfig& cfg) {
     img_info.imageView = cfg.albedo_target->view;
     img_info.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
 
+    VkDescriptorImageInfo normal_img_info{};
+    normal_img_info.imageView = cfg.normal_target->view;
+    normal_img_info.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
+
     VkSamplerCreateInfo samp_info{};
     samp_info.sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
     samp_info.magFilter = VK_FILTER_LINEAR;
@@ -88,7 +92,7 @@ void dispatch_lighting_pass(const LightingPassConfig& cfg) {
     buf_info.offset = 0;
     buf_info.range = sizeof(LightUBO);
 
-    VkWriteDescriptorSet writes[3]{};
+    VkWriteDescriptorSet writes[4]{};
     writes[0].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
     writes[0].dstSet = ds;
     writes[0].dstBinding = 0;
@@ -110,7 +114,14 @@ void dispatch_lighting_pass(const LightingPassConfig& cfg) {
     writes[2].descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
     writes[2].pBufferInfo = &buf_info;
 
-    vkUpdateDescriptorSets(cfg.device.device, 3, writes, 0, nullptr);
+    writes[3].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+    writes[3].dstSet = ds;
+    writes[3].dstBinding = 3;
+    writes[3].descriptorCount = 1;
+    writes[3].descriptorType = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
+    writes[3].pImageInfo = &normal_img_info;
+
+    vkUpdateDescriptorSets(cfg.device.device, 4, writes, 0, nullptr);
 
     VkCommandBuffer cmd = cfg.device.begin_single_command();
 

--- a/projects/joon/src/scene/lighting_pass.h
+++ b/projects/joon/src/scene/lighting_pass.h
@@ -16,6 +16,7 @@ struct LightingPassConfig {
     const SceneCollection& scene;
     uint32_t width, height;
     GpuImage* albedo_target;
+    GpuImage* normal_target;
     uint32_t output_node_id;
     const ShaderFnIR* brdf = nullptr;
 };

--- a/projects/joon/src/scene/material_executor.cpp
+++ b/projects/joon/src/scene/material_executor.cpp
@@ -46,8 +46,9 @@ void exec_shader(const Node& n, EvalContext& ctx) {
     }
 
     std::string key = "mat_" + std::to_string(n.id);
-    uint32_t num_outputs = ir.fragment
+    uint32_t user_outputs = ir.fragment
         ? static_cast<uint32_t>(ir.fragment->outputs.size()) : 1;
+    uint32_t num_outputs = user_outputs + 1;
 
     std::vector<VkFormat> formats(num_outputs, VK_FORMAT_R32G32B32A32_SFLOAT);
     auto rp = create_color_depth_renderpass(ctx.device, formats);

--- a/projects/joon/src/shader/brdf_emitter.cpp
+++ b/projects/joon/src/shader/brdf_emitter.cpp
@@ -9,7 +9,8 @@ std::string BrdfEmitter::emit_lighting_shader(const ShaderFnIR& brdf) {
     std::ostringstream ss;
 
     ss << "[[vk::binding(0, 0)]] Texture2D gbuf_albedo;\n";
-    ss << "[[vk::binding(1, 0)]] SamplerState samp;\n\n";
+    ss << "[[vk::binding(1, 0)]] SamplerState samp;\n";
+    ss << "[[vk::binding(3, 0)]] Texture2D gbuf_normal;\n\n";
 
     ss << "struct LightData { float4 position_type; float4 color_intensity; float4 spot_params; };\n";
     ss << "struct LightUBO { LightData lights[16]; int light_count; float3 camera_pos; float4x4 inv_view_proj; };\n";
@@ -21,7 +22,7 @@ std::string BrdfEmitter::emit_lighting_shader(const ShaderFnIR& brdf) {
     ss << "    float4 albedo = gbuf_albedo.Sample(samp, i.uv);\n";
     ss << "    if (albedo.a < 0.01) discard;\n\n";
 
-    ss << "    float3 normal = float3(0, 1, 0);\n";
+    ss << "    float3 normal = gbuf_normal.Sample(samp, i.uv).xyz * 2.0 - 1.0;\n";
     ss << "    float3 view_dir = normalize(light_ubo.camera_pos);\n";
     ss << "    float3 result = float3(0, 0, 0);\n\n";
 

--- a/projects/joon/src/shader/hlsl_emitter.cpp
+++ b/projects/joon/src/shader/hlsl_emitter.cpp
@@ -98,6 +98,7 @@ std::string HlslEmitter::emit_dot(const ShaderDotAccess& da) {
 std::string HlslEmitter::emit_fragment(const ShaderFnIR& fn, uint32_t prepass_count) {
     std::ostringstream ss;
 
+    uint32_t user_outputs = static_cast<uint32_t>(fn.outputs.size());
     ss << "struct PSOut {\n";
     for (size_t i = 0; i < fn.outputs.size(); i++) {
         std::string hlsl_type = (fn.outputs[i].type_name == "vec4") ? "float4" :
@@ -106,6 +107,7 @@ std::string HlslEmitter::emit_fragment(const ShaderFnIR& fn, uint32_t prepass_co
         ss << "    " << hlsl_type << " " << fn.outputs[i].name
            << " : SV_TARGET" << i << ";\n";
     }
+    ss << "    float4 gbuf_normal : SV_TARGET" << user_outputs << ";\n";
     ss << "};\n\n";
 
     ss << "struct PSIn {\n"
@@ -138,6 +140,7 @@ std::string HlslEmitter::emit_fragment(const ShaderFnIR& fn, uint32_t prepass_co
         ss << "    " << emit_expr(*stmt) << ";\n";
     }
 
+    ss << "    o.gbuf_normal = float4(normal * 0.5 + 0.5, 1.0);\n";
     ss << "    return o;\n";
     ss << "}\n";
     return ss.str();


### PR DESCRIPTION
## Summary
- Material fragment shaders now auto-emit world-space normals as a second render target (`SV_TARGET1`)
- Geometry pass allocates a normal G-buffer and creates a 2-color-attachment framebuffer when materials are active
- Lighting pass binds the normal texture at binding 3 and computes per-pixel N·L shading
- Fixes flat shading where all surfaces used a hardcoded up-vector normal

## Test plan
- [ ] Build in VS2022 (Release config)
- [ ] Load Sponza graph — verify surfaces show directional shading based on geometry normals
- [ ] Load other graphs (Noise+Invert, Levels) — verify no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)