### PR TITLE
fix(joon): resolve G-buffer validation errors

### DIFF
--- a/projects/joon/src/scene/geometry_pass.cpp
+++ b/projects/joon/src/scene/geometry_pass.cpp
@@ -52,7 +52,8 @@ void exec_pass(const Node& n, EvalContext& ctx) {
     VkFramebuffer fb = create_framebuffer(ctx.device, rp, color_views, depth->view,
                                            ctx.default_width, ctx.default_height);
 
-    const auto& gp = ctx.pipelines.get_graphics("scene_basic", rp.pass, sizeof(PushLight));
+    uint32_t num_color = static_cast<uint32_t>(color_formats.size());
+    const auto& gp = ctx.pipelines.get_graphics("scene_basic", rp.pass, sizeof(PushLight), num_color);
 
     // Camera matrices — fall back to defaults if no camera was set.
     const auto& cam = ctx.scene.camera;
@@ -79,16 +80,21 @@ void exec_pass(const Node& n, EvalContext& ctx) {
 
     VkCommandBuffer cmd = ctx.device.begin_single_command();
 
-    VkClearValue clears[2];
+    VkClearValue clears[3]{};
     clears[0].color = {{ 0.0f, 0.0f, 0.0f, 1.0f }};
-    clears[1].depthStencil = { 1.0f, 0 };
+    clears[1].color = {{ 0.0f, 0.0f, 0.0f, 0.0f }};
+    clears[2].depthStencil = { 1.0f, 0 };
+    uint32_t clear_count = has_materials ? 3u : 2u;
+    if (!has_materials) {
+        clears[1].depthStencil = { 1.0f, 0 };
+    }
 
     VkRenderPassBeginInfo rpi{};
     rpi.sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;
     rpi.renderPass = rp.pass;
     rpi.framebuffer = fb;
     rpi.renderArea.extent = { ctx.default_width, ctx.default_height };
-    rpi.clearValueCount = 2;
+    rpi.clearValueCount = clear_count;
     rpi.pClearValues = clears;
 
     vkCmdBeginRenderPass(cmd, &rpi, VK_SUBPASS_CONTENTS_INLINE);

--- a/projects/joon/src/vulkan/pipeline_cache.cpp
+++ b/projects/joon/src/vulkan/pipeline_cache.cpp
@@ -187,9 +187,11 @@ const ComputePipeline& PipelineCache::get(const std::string& name,
 
 const GraphicsPipeline& PipelineCache::get_graphics(const std::string& name,
                                                      VkRenderPass render_pass,
-                                                     uint32_t push_constant_size) {
+                                                     uint32_t push_constant_size,
+                                                     uint32_t num_color_attachments) {
     std::string key = name + ":" + std::to_string(reinterpret_cast<uintptr_t>(render_pass))
-                    + ":" + std::to_string(push_constant_size);
+                    + ":" + std::to_string(push_constant_size)
+                    + ":" + std::to_string(num_color_attachments);
     auto it = m_graphics_pipelines.find(key);
     if (it != m_graphics_pipelines.end()) return it->second;
 
@@ -245,7 +247,7 @@ const GraphicsPipeline& PipelineCache::get_graphics(const std::string& name,
     if (vkCreatePipelineLayout(m_device.device, &layout_info, nullptr, &p.layout) != VK_SUCCESS)
         throw std::runtime_error("graphics: vkCreatePipelineLayout failed");
 
-    p.pipeline = build_graphics_pipeline(p.vert_module, p.frag_module, p.layout, render_pass, 1);
+    p.pipeline = build_graphics_pipeline(p.vert_module, p.frag_module, p.layout, render_pass, num_color_attachments);
 
     m_graphics_pipelines[key] = p;
     return m_graphics_pipelines[key];
@@ -461,7 +463,7 @@ const GraphicsPipeline& PipelineCache::get_fullscreen(const std::string& frag_na
     p.vert_module = make_module(vs_spirv, "fullscreen.vert");
     p.frag_module = make_module(fs_spirv, (frag_name + ".frag").c_str());
 
-    VkDescriptorSetLayoutBinding bindings[3]{};
+    VkDescriptorSetLayoutBinding bindings[4]{};
     bindings[0].binding = 0;
     bindings[0].descriptorType = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
     bindings[0].descriptorCount = 1;
@@ -474,10 +476,14 @@ const GraphicsPipeline& PipelineCache::get_fullscreen(const std::string& frag_na
     bindings[2].descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
     bindings[2].descriptorCount = 1;
     bindings[2].stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
+    bindings[3].binding = 3;
+    bindings[3].descriptorType = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
+    bindings[3].descriptorCount = 1;
+    bindings[3].stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
 
     VkDescriptorSetLayoutCreateInfo desc_info{};
     desc_info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
-    desc_info.bindingCount = 3;
+    desc_info.bindingCount = 4;
     desc_info.pBindings = bindings;
     if (vkCreateDescriptorSetLayout(m_device.device, &desc_info, nullptr, &p.desc_layout) != VK_SUCCESS)
         throw std::runtime_error("fullscreen: vkCreateDescriptorSetLayout failed");
@@ -600,7 +606,7 @@ const GraphicsPipeline& PipelineCache::get_fullscreen_from_source(
     p.vert_module = make_module(vs_spirv, "fullscreen.vert");
     p.frag_module = make_module(fs_spirv, (key + ".frag").c_str());
 
-    VkDescriptorSetLayoutBinding bindings[3]{};
+    VkDescriptorSetLayoutBinding bindings[4]{};
     bindings[0].binding = 0;
     bindings[0].descriptorType = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
     bindings[0].descriptorCount = 1;
@@ -613,10 +619,14 @@ const GraphicsPipeline& PipelineCache::get_fullscreen_from_source(
     bindings[2].descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
     bindings[2].descriptorCount = 1;
     bindings[2].stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
+    bindings[3].binding = 3;
+    bindings[3].descriptorType = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
+    bindings[3].descriptorCount = 1;
+    bindings[3].stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
 
     VkDescriptorSetLayoutCreateInfo desc_info{};
     desc_info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
-    desc_info.bindingCount = 3;
+    desc_info.bindingCount = 4;
     desc_info.pBindings = bindings;
     if (vkCreateDescriptorSetLayout(m_device.device, &desc_info, nullptr, &p.desc_layout) != VK_SUCCESS)
         throw std::runtime_error("fullscreen_from_source: vkCreateDescriptorSetLayout failed");

--- a/projects/joon/src/vulkan/pipeline_cache.h
+++ b/projects/joon/src/vulkan/pipeline_cache.h
@@ -38,7 +38,8 @@ public:
     // Push constants in `push_constant_size` bytes go to the FRAGMENT stage.
     const GraphicsPipeline& get_graphics(const std::string& name,
                                           VkRenderPass render_pass,
-                                          uint32_t push_constant_size = 0);
+                                          uint32_t push_constant_size = 0,
+                                          uint32_t num_color_attachments = 1);
 
     const GraphicsPipeline& get_graphics_from_source(
         const std::string& key,
@@ -50,7 +51,8 @@ public:
 
     // Fullscreen triangle pipeline — uses fullscreen.vert.hlsl + frag_name.frag.hlsl.
     // No vertex input, no depth test, no backface culling.
-    // Descriptor layout: binding 0 = SAMPLED_IMAGE, binding 1 = SAMPLER, binding 2 = UNIFORM_BUFFER.
+    // Descriptor layout: binding 0 = SAMPLED_IMAGE (albedo), binding 1 = SAMPLER,
+    //   binding 2 = UNIFORM_BUFFER, binding 3 = SAMPLED_IMAGE (normal).
     const GraphicsPipeline& get_fullscreen(const std::string& frag_name,
                                             VkRenderPass render_pass);
 


### PR DESCRIPTION
## Summary
- Add binding 3 (gbuf_normal) to fullscreen descriptor set layouts in pipeline cache
- Add `num_color_attachments` parameter to `get_graphics()` so scene_basic pipeline matches the 2-attachment render pass
- Fix clear values array to use 3 entries (2 color + 1 depth) when normal attachment is present

## Test plan
- [ ] Build in VS2022 (Release)
- [ ] Load Sponza graph — verify no validation errors in joon-gui.log
- [ ] Verify per-pixel normal shading is visible on Sponza surfaces
- [ ] Load 3D Scene and other non-material graphs — verify no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)