### PR TITLE
fix(joon): remove UV Y-flip causing upside-down deferred output

### DIFF
--- a/projects/joon/shaders/fullscreen.vert.hlsl
+++ b/projects/joon/shaders/fullscreen.vert.hlsl
@@ -7,6 +7,5 @@ VSOut main(uint vid : SV_VertexID) {
     VSOut o;
     o.uv = float2((vid << 1) & 2, vid & 2);
     o.sv = float4(o.uv * 2.0 - 1.0, 0.0, 1.0);
-    o.uv.y = 1.0 - o.uv.y;
     return o;
 }


### PR DESCRIPTION
## Summary
- Remove `o.uv.y = 1.0 - o.uv.y` from fullscreen vertex shader
- `perspective_vk` already negates Y for Vulkan clip space, so the G-buffer is right-side-up — the UV flip was a double-inversion

## Test plan
- [ ] Build in VS2022 (Release)
- [ ] Load Sponza — verify scene is right-side-up with correct lighting direction

🤖 Generated with [Claude Code](https://claude.com/claude-code)