### PR TITLE
feat(joon): interactive camera controls

### DIFF
--- a/projects/joon/gui/app.cpp
+++ b/projects/joon/gui/app.cpp
@@ -1,7 +1,9 @@
 #include "app.h"
 #include "log.h"
+#include <joon/math.h>
 #include <imgui.h>
 #include <imgui_impl_vulkan.h>
+#include <cmath>
 
 void App::init() {
     ctx = joon::Context::create();
@@ -126,6 +128,7 @@ void App::reparse() {
         if (!graph.has_errors()) {
             eval = ctx->create_evaluator(graph);
             eval->evaluate();
+            init_camera_from_scene();
         } else {
             eval.reset();
         }
@@ -135,6 +138,41 @@ void App::reparse() {
         joon_log::write("[EVAL] %s\n", eval_error.c_str());
     }
     source_dirty = false;
+}
+
+void App::init_camera_from_scene() {
+    if (!eval) return;
+    const auto& cam = eval->scene_for_test().camera;
+    cam_pos = cam.position;
+    cam_fov = cam.fov_deg;
+    cam_near = cam.near_z;
+    cam_far = cam.far_z;
+    cam_roll = 0;
+    cam_active = false;
+
+    joon::vec3 dir = joon::vec3_normalize(cam.target - cam.position);
+    cam_pitch = std::asin(std::clamp(dir.y, -1.0f, 1.0f));
+    cam_yaw = std::atan2(dir.x, -dir.z);
+}
+
+void App::apply_camera() {
+    if (!eval) return;
+    using namespace joon;
+    mat4 rot = mul(rotate_y(cam_yaw), mul(rotate_x(cam_pitch), rotate_z(cam_roll)));
+    vec3 forward{-rot.m[8], -rot.m[9], -rot.m[10]};
+    vec3 up{rot.m[4], rot.m[5], rot.m[6]};
+
+    Camera cam;
+    cam.position = cam_pos;
+    cam.target = cam_pos + forward;
+    cam.up = up;
+    cam.fov_deg = cam_fov;
+    cam.near_z = cam_near;
+    cam.far_z = cam_far;
+
+    eval->set_camera(cam);
+    eval->evaluate();
+    viewport_dirty = true;
 }
 
 void App::update() {

--- a/projects/joon/gui/app.h
+++ b/projects/joon/gui/app.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <joon/joon.h>
+#include <joon/math.h>
 #include "ir/ir_graph.h"
 #include "vulkan/device.h"
 #include "vulkan/resource_pool.h"
@@ -42,11 +43,24 @@ struct App {
     std::vector<GraphEntry> graph_entries;
     size_t active_graph_index = 0;
 
+    joon::vec3 cam_pos{0, 0, 5};
+    float cam_yaw = 0;
+    float cam_pitch = 0;
+    float cam_roll = 0;
+    float cam_speed = 200.0f;
+    float cam_mouse_sens = 0.003f;
+    float cam_fov = 60.0f;
+    float cam_near = 0.1f;
+    float cam_far = 100.0f;
+    bool cam_active = false;
+
     void init();
     void shutdown();
     void reparse();
     void bind_viewport();
     void update();
+    void init_camera_from_scene();
+    void apply_camera();
 
     void draw_tree();
     void draw_properties();

--- a/projects/joon/gui/panel_viewport.cpp
+++ b/projects/joon/gui/panel_viewport.cpp
@@ -1,15 +1,55 @@
 #include "app.h"
+#include <joon/math.h>
 #include <imgui.h>
+#include <cmath>
 
 void App::draw_viewport() {
     ImGui::Begin("Viewport", &show_viewport);
+
+    bool hovered = ImGui::IsWindowHovered(ImGuiHoveredFlags_None);
+    bool wants_kb = ImGui::GetIO().WantCaptureKeyboard;
+
+    if (eval && hovered && !wants_kb) {
+        using namespace joon;
+        float dt = ImGui::GetIO().DeltaTime;
+
+        mat4 rot = mul(rotate_y(cam_yaw), mul(rotate_x(cam_pitch), rotate_z(cam_roll)));
+        vec3 forward{-rot.m[8], -rot.m[9], -rot.m[10]};
+        vec3 right{rot.m[0], rot.m[1], rot.m[2]};
+
+        bool moved = false;
+        float speed = cam_speed * dt;
+
+        if (ImGui::IsKeyDown(ImGuiKey_W)) { cam_pos = cam_pos + forward * speed; moved = true; }
+        if (ImGui::IsKeyDown(ImGuiKey_R)) { cam_pos = cam_pos - forward * speed; moved = true; }
+        if (ImGui::IsKeyDown(ImGuiKey_A)) { cam_pos = cam_pos - right * speed; moved = true; }
+        if (ImGui::IsKeyDown(ImGuiKey_S)) { cam_pos = cam_pos + right * speed; moved = true; }
+        if (ImGui::IsKeyDown(ImGuiKey_P)) { cam_pos.y += speed; moved = true; }
+        if (ImGui::IsKeyDown(ImGuiKey_T)) { cam_pos.y -= speed; moved = true; }
+        if (ImGui::IsKeyDown(ImGuiKey_Q)) { cam_roll -= 1.5f * dt; moved = true; }
+        if (ImGui::IsKeyDown(ImGuiKey_F)) { cam_roll += 1.5f * dt; moved = true; }
+
+        if (ImGui::IsMouseDown(ImGuiMouseButton_Right) && hovered) {
+            ImVec2 delta = ImGui::GetIO().MouseDelta;
+            if (delta.x != 0 || delta.y != 0) {
+                cam_yaw += delta.x * cam_mouse_sens;
+                cam_pitch -= delta.y * cam_mouse_sens;
+                cam_pitch = std::clamp(cam_pitch, -1.5f, 1.5f);
+                moved = true;
+            }
+        }
+
+        if (moved) {
+            cam_active = true;
+            apply_camera();
+        }
+    }
 
     if (eval && !graph.has_errors() && !graph.ir().outputs.empty()) {
         auto result = eval->result("output");
         if (result.width() > 0) {
             ImVec2 avail = ImGui::GetContentRegionAvail();
             if (viewport_desc) {
-                // Maintain aspect ratio
                 float aspect = static_cast<float>(result.width()) / result.height();
                 float display_w = avail.x;
                 float display_h = avail.x / aspect;

--- a/projects/joon/include/joon/evaluator.h
+++ b/projects/joon/include/joon/evaluator.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <joon/types.h>
+#include <joon/scene.h>
 #include <memory>
 #include <string>
 #include <vector>
@@ -57,9 +58,9 @@ public:
 
     const std::vector<Diagnostic>& diagnostics() const;
 
-    // Test-only accessor returning the most recent SceneCollection populated
-    // during evaluate(). Sub-project 2 exposes this so unit tests can verify
-    // scene-tier executors without going through the renderer.
+    void set_camera(const Camera& cam);
+    void clear_camera_override();
+
     const SceneCollection& scene_for_test() const;
 
 private:

--- a/projects/joon/src/evaluator.cpp
+++ b/projects/joon/src/evaluator.cpp
@@ -104,6 +104,8 @@ struct Evaluator::Impl {
     std::unique_ptr<PipelineCache> pipelines;
     VkDescriptorPool desc_pool = VK_NULL_HANDLE;
     SceneCollection scene;
+    Camera camera_override_storage;
+    bool has_camera_override = false;
 
     Impl(Context& ctx, const Graph& source_graph)
         : ctx(ctx),
@@ -159,7 +161,9 @@ void Evaluator::evaluate() {
         m_impl->desc_pool,
         m_impl->scene,
         &m_impl->graph.ir().shader_defs,
-        {}
+        {},
+        {},
+        m_impl->has_camera_override ? &m_impl->camera_override_storage : nullptr
     };
 
     Interpreter interp(eval_ctx, m_impl->registry);
@@ -197,6 +201,15 @@ Result Evaluator::node_result(const std::string& name) {
 
 const std::vector<Diagnostic>& Evaluator::diagnostics() const {
     return m_impl->graph.ir().diagnostics;
+}
+
+void Evaluator::set_camera(const Camera& cam) {
+    m_impl->camera_override_storage = cam;
+    m_impl->has_camera_override = true;
+}
+
+void Evaluator::clear_camera_override() {
+    m_impl->has_camera_override = false;
 }
 
 const SceneCollection& Evaluator::scene_for_test() const {

--- a/projects/joon/src/nodes/node_registry.h
+++ b/projects/joon/src/nodes/node_registry.h
@@ -6,6 +6,7 @@
 #include "vulkan/device.h"
 #include "vulkan/resource_pool.h"
 #include "vulkan/pipeline_cache.h"
+#include <joon/scene.h>
 #include <functional>
 #include <string>
 #include <unordered_map>
@@ -25,6 +26,7 @@ struct EvalContext {
     std::unordered_map<uint32_t, ShaderDef>* shader_defs = nullptr;
     std::unordered_map<uint32_t, const GraphicsPipeline*> material_pipelines;
     std::unordered_map<uint32_t, ShaderFnIR> material_brdfs;
+    const Camera* camera_override = nullptr;
 };
 
 using NodeExecutor = std::function<void(const Node& node, EvalContext& ctx)>;

--- a/projects/joon/src/scene/scene_executors.cpp
+++ b/projects/joon/src/scene/scene_executors.cpp
@@ -94,6 +94,10 @@ void exec_light(const Node& n, EvalContext& ctx) {
 }
 
 void exec_camera(const Node& n, EvalContext& ctx) {
+    if (ctx.camera_override) {
+        ctx.scene.set_camera(*ctx.camera_override);
+        return;
+    }
     Camera c;
     c.fov_deg  = kwarg_float(n, "fov", 60.0f);
     c.position = kwarg_vec3(n, "position", {0, 0, 5});


### PR DESCRIPTION
## Summary
- Add flythrough camera controls to the Viewport panel
- Key bindings: W/R forward/back, A/S strafe left/right, P/T up/down, Q/F roll
- Right-mouse-drag for yaw/pitch
- Camera initializes from DSL `(camera ...)` node on graph load
- New `Evaluator::set_camera()` API overrides the DSL camera during evaluate

## Test plan
- [ ] Build in VS2022 (Release)
- [ ] Load Sponza — hover Viewport, press W to move forward, R to move back
- [ ] Hold right mouse button and drag to look around
- [ ] Press Q/F to roll the camera
- [ ] Switch to a different graph (e.g., 3D Scene) — camera should reset to DSL values
- [ ] Verify keyboard only affects camera when Viewport is hovered (not when typing in Code Editor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)