### PR TITLE
perf(joon): fast re-render for camera movement

### DIFF
--- a/projects/joon/gui/app.cpp
+++ b/projects/joon/gui/app.cpp
@@ -172,7 +172,7 @@ void App::apply_camera() {
     cam.far_z = cam_far;
 
     eval->set_camera(cam);
-    eval->evaluate();
+    eval->re_render();
     viewport_dirty = true;
 }
 

--- a/projects/joon/include/joon/evaluator.h
+++ b/projects/joon/include/joon/evaluator.h
@@ -49,6 +49,7 @@ public:
     ~Evaluator();
 
     void evaluate();
+    void re_render();
 
     template<typename T>
     Param<T> param(const std::string& name);

--- a/projects/joon/src/evaluator.cpp
+++ b/projects/joon/src/evaluator.cpp
@@ -170,6 +170,29 @@ void Evaluator::evaluate() {
     interp.evaluate(m_impl->graph.ir());
 }
 
+void Evaluator::re_render() {
+    vkResetDescriptorPool(m_impl->ctx.device().device, m_impl->desc_pool, 0);
+
+    if (m_impl->has_camera_override)
+        m_impl->scene.set_camera(m_impl->camera_override_storage);
+
+    EvalContext eval_ctx{
+        m_impl->ctx.device(),
+        m_impl->ctx.pool(),
+        *m_impl->pipelines,
+        512, 512,
+        m_impl->desc_pool,
+        m_impl->scene,
+        &m_impl->graph.ir().shader_defs,
+        {},
+        {},
+        nullptr
+    };
+
+    Interpreter interp(eval_ctx, m_impl->registry);
+    interp.re_render(m_impl->graph.ir());
+}
+
 template<>
 Param<float> Evaluator::param(const std::string& name) {
     auto& ir = m_impl->graph.ir();

--- a/projects/joon/src/interpreter/interpreter.cpp
+++ b/projects/joon/src/interpreter/interpreter.cpp
@@ -72,4 +72,26 @@ void Interpreter::evaluate(IRGraph& graph) {
     }
 }
 
+void Interpreter::re_render(IRGraph& graph) {
+    auto order = graph.topological_order();
+
+    for (uint32_t id : order) {
+        auto& node = graph.nodes[id];
+        if (node.tier == Tier::SCENE || node.tier == Tier::MATERIAL) continue;
+
+        if (node.op == "constant" || node.op == "string_constant" ||
+            node.op == "param" || node.op == "error") {
+            continue;
+        }
+
+        for (auto& kw : node.kwargs) {
+            if (kw.source_node != UINT32_MAX && kw.source_node < graph.nodes.size())
+                kw.value = graph.nodes[kw.source_node].constant_value;
+        }
+
+        auto* executor = m_registry.find(node.op);
+        if (executor) (*executor)(node, m_ctx);
+    }
+}
+
 } // namespace joon

--- a/projects/joon/src/interpreter/interpreter.h
+++ b/projects/joon/src/interpreter/interpreter.h
@@ -10,6 +10,7 @@ public:
     Interpreter(EvalContext& ctx, const NodeRegistry& registry);
 
     void evaluate(IRGraph& graph);
+    void re_render(IRGraph& graph);
 
 private:
     EvalContext& m_ctx;


### PR DESCRIPTION
## Summary
- Add `Interpreter::re_render()` that only runs phase 3 (GPU/render nodes), skipping mesh loading and shader compilation
- Add `Evaluator::re_render()` that updates the camera and calls the fast path
- `apply_camera()` now uses `re_render()` instead of full `evaluate()`

## Test plan
- [ ] Build in VS2022 (Release)
- [ ] Load Sponza, move camera with W/R — verify FPS is significantly higher than before
- [ ] Switch graphs — verify full evaluate still works correctly
- [ ] Verify no visual regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)