### PR TITLE
refactor(joon): rename re_render() to render()

### DIFF
--- a/projects/joon/gui/app.cpp
+++ b/projects/joon/gui/app.cpp
@@ -172,7 +172,7 @@ void App::apply_camera() {
     cam.far_z = cam_far;
 
     eval->set_camera(cam);
-    eval->re_render();
+    eval->render();
     viewport_dirty = true;
 }
 

--- a/projects/joon/include/joon/evaluator.h
+++ b/projects/joon/include/joon/evaluator.h
@@ -49,7 +49,7 @@ public:
     ~Evaluator();
 
     void evaluate();
-    void re_render();
+    void render();
 
     template<typename T>
     Param<T> param(const std::string& name);

--- a/projects/joon/src/evaluator.cpp
+++ b/projects/joon/src/evaluator.cpp
@@ -170,7 +170,7 @@ void Evaluator::evaluate() {
     interp.evaluate(m_impl->graph.ir());
 }
 
-void Evaluator::re_render() {
+void Evaluator::render() {
     vkResetDescriptorPool(m_impl->ctx.device().device, m_impl->desc_pool, 0);
 
     if (m_impl->has_camera_override)
@@ -190,7 +190,7 @@ void Evaluator::re_render() {
     };
 
     Interpreter interp(eval_ctx, m_impl->registry);
-    interp.re_render(m_impl->graph.ir());
+    interp.render(m_impl->graph.ir());
 }
 
 template<>

--- a/projects/joon/src/interpreter/interpreter.cpp
+++ b/projects/joon/src/interpreter/interpreter.cpp
@@ -72,7 +72,7 @@ void Interpreter::evaluate(IRGraph& graph) {
     }
 }
 
-void Interpreter::re_render(IRGraph& graph) {
+void Interpreter::render(IRGraph& graph) {
     auto order = graph.topological_order();
 
     for (uint32_t id : order) {

--- a/projects/joon/src/interpreter/interpreter.h
+++ b/projects/joon/src/interpreter/interpreter.h
@@ -10,7 +10,7 @@ public:
     Interpreter(EvalContext& ctx, const NodeRegistry& registry);
 
     void evaluate(IRGraph& graph);
-    void re_render(IRGraph& graph);
+    void render(IRGraph& graph);
 
 private:
     EvalContext& m_ctx;


### PR DESCRIPTION
## Summary
- Renames `re_render()` to `render()` across Evaluator and Interpreter APIs and the single call site in `apply_camera()`

## Test plan
- [ ] Build the project and verify no compile errors
- [ ] Run the GUI — camera controls should still work at full framerate

🤖 Generated with [Claude Code](https://claude.com/claude-code)