### PR TITLE
feat(joon): per-material textures for Sponza

### DIFF
--- a/projects/joon/gui/app.cpp
+++ b/projects/joon/gui/app.cpp
@@ -38,12 +38,8 @@ void App::init() {
         {"Constant", R"(; Constant output
 (output 0.5)
 )"},
-        {"Sponza", R"(; Sponza atrium
-(def mat (shader
-  :fragment (fn [normal uv] -> [albedo vec4]
-    (set albedo [0.5 0.45 0.4 1]))))
-
-(def sponza (mesh "assets/scenes/sponza/sponza.obj" :material mat))
+        {"Sponza", R"(; Sponza atrium with textures
+(def sponza (mesh "assets/scenes/sponza/sponza.obj"))
 (def cam (camera :fov 75 :position [-500 400 0] :target [500 400 0] :near 1 :far 5000))
 (def sun (light :direction [-0.5 -1 -0.3] :intensity 0.7))
 (def gbuf (pass))

--- a/projects/joon/include/joon/scene.h
+++ b/projects/joon/include/joon/scene.h
@@ -16,15 +16,16 @@ struct Mesh {
     std::vector<uint32_t> indices;
 };
 
+struct GpuImage;
+
 struct SceneObject {
     Mesh mesh;
     vec3 position{0, 0, 0};
     vec3 rotation{0, 0, 0};   // Euler XYZ, radians
     vec3 scale{1, 1, 1};
-    // Material wired by node id when fragment shading is per-object.
-    // Sub-project 2 uses a single hardcoded fragment, so this is unused for now.
-    // UINT32_MAX = unset; matches ResolvedKwarg::source_node convention in ir/node.h.
     uint32_t material_node_id = UINT32_MAX;
+    GpuImage* albedo_texture = nullptr;
+    GpuImage* normal_texture = nullptr;
 };
 
 enum class LightType { Directional, Point, Spot };

--- a/projects/joon/shaders/scene_textured.frag.hlsl
+++ b/projects/joon/shaders/scene_textured.frag.hlsl
@@ -1,0 +1,38 @@
+[[vk::binding(1, 0)]] Texture2D albedo_tex;
+[[vk::binding(2, 0)]] SamplerState samp;
+[[vk::binding(3, 0)]] Texture2D normal_tex;
+
+struct PSIn {
+    float4 sv        : SV_POSITION;
+    float3 normal    : NORMAL;
+    float2 uv        : TEXCOORD0;
+    float3 world_pos : TEXCOORD1;
+};
+
+struct PSOut {
+    float4 albedo     : SV_TARGET0;
+    float4 normal_out : SV_TARGET1;
+};
+
+PSOut main(PSIn i) {
+    PSOut o;
+    o.albedo = albedo_tex.Sample(samp, i.uv);
+
+    float3 N = normalize(i.normal);
+
+    // Cotangent-frame TBN from screen-space derivatives
+    float3 dp1 = ddx(i.world_pos);
+    float3 dp2 = ddy(i.world_pos);
+    float2 duv1 = ddx(i.uv);
+    float2 duv2 = ddy(i.uv);
+
+    float det = duv1.x * duv2.y - duv1.y * duv2.x;
+    float3 T = normalize((dp1 * duv2.y - dp2 * duv1.y) * sign(det));
+    float3 B = normalize(cross(N, T)) * sign(det);
+
+    float3 ts = normal_tex.Sample(samp, i.uv).xyz * 2.0 - 1.0;
+    float3 mapped = normalize(T * ts.x + B * ts.y + N * ts.z);
+
+    o.normal_out = float4(mapped * 0.5 + 0.5, 1.0);
+    return o;
+}

--- a/projects/joon/shaders/scene_textured.vert.hlsl
+++ b/projects/joon/shaders/scene_textured.vert.hlsl
@@ -1,0 +1,28 @@
+struct UBO {
+    float4x4 mvp;
+    float4x4 model;
+};
+
+[[vk::binding(0, 0)]] ConstantBuffer<UBO> ubo;
+
+struct VSIn {
+    [[vk::location(0)]] float3 pos    : POSITION;
+    [[vk::location(1)]] float3 normal : NORMAL;
+    [[vk::location(2)]] float2 uv     : TEXCOORD0;
+};
+
+struct VSOut {
+    float4 sv        : SV_POSITION;
+    float3 normal    : NORMAL;
+    float2 uv        : TEXCOORD0;
+    float3 world_pos : TEXCOORD1;
+};
+
+VSOut main(VSIn v) {
+    VSOut o;
+    o.sv = mul(ubo.mvp, float4(v.pos, 1.0));
+    o.normal = normalize(mul((float3x3)ubo.model, v.normal));
+    o.uv = v.uv;
+    o.world_pos = mul(ubo.model, float4(v.pos, 1.0)).xyz;
+    return o;
+}

--- a/projects/joon/src/evaluator.cpp
+++ b/projects/joon/src/evaluator.cpp
@@ -5,6 +5,7 @@
 #include "ir/ir_graph.h"
 #include "interpreter/interpreter.h"
 #include "nodes/node_registry.h"
+#include "scene/texture_cache.h"
 #include "vulkan/device.h"
 #include "vulkan/resource_pool.h"
 #include "vulkan/pipeline_cache.h"
@@ -99,9 +100,10 @@ static std::string resolve_shader_dir() {
 
 struct Evaluator::Impl {
     Context& ctx;
-    Graph graph; // mutable copy for param updates
+    Graph graph;
     NodeRegistry registry;
     std::unique_ptr<PipelineCache> pipelines;
+    std::unique_ptr<TextureCache> textures;
     VkDescriptorPool desc_pool = VK_NULL_HANDLE;
     SceneCollection scene;
     Camera camera_override_storage;
@@ -110,25 +112,25 @@ struct Evaluator::Impl {
     Impl(Context& ctx, const Graph& source_graph)
         : ctx(ctx),
           registry(NodeRegistry::create_default()),
-          pipelines(std::make_unique<PipelineCache>(ctx.device(), resolve_shader_dir())) {
+          pipelines(std::make_unique<PipelineCache>(ctx.device(), resolve_shader_dir())),
+          textures(std::make_unique<TextureCache>(ctx.device())) {
 
-        // Copy the graph so we can mutate params
-        graph = ctx.parse_string(""); // placeholder
-        graph.ir() = source_graph.ir(); // copy IR
+        graph = ctx.parse_string("");
+        graph.ir() = source_graph.ir();
 
         VkDescriptorPoolSize pool_sizes[4]{};
         pool_sizes[0].type = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
         pool_sizes[0].descriptorCount = 256;
         pool_sizes[1].type = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
-        pool_sizes[1].descriptorCount = 256;
+        pool_sizes[1].descriptorCount = 512;
         pool_sizes[2].type = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
-        pool_sizes[2].descriptorCount = 64;
+        pool_sizes[2].descriptorCount = 512;
         pool_sizes[3].type = VK_DESCRIPTOR_TYPE_SAMPLER;
-        pool_sizes[3].descriptorCount = 64;
+        pool_sizes[3].descriptorCount = 512;
 
         VkDescriptorPoolCreateInfo pool_info{};
         pool_info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
-        pool_info.maxSets = 256;
+        pool_info.maxSets = 512;
         pool_info.poolSizeCount = 4;
         pool_info.pPoolSizes = pool_sizes;
         pool_info.flags = VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT;
@@ -150,7 +152,6 @@ Evaluator::~Evaluator() = default;
 void Evaluator::evaluate() {
     vkResetDescriptorPool(m_impl->ctx.device().device, m_impl->desc_pool, 0);
 
-    // Drop any scene state from a previous evaluate so re-runs don't accumulate.
     m_impl->scene.clear();
 
     EvalContext eval_ctx{
@@ -163,7 +164,8 @@ void Evaluator::evaluate() {
         &m_impl->graph.ir().shader_defs,
         {},
         {},
-        m_impl->has_camera_override ? &m_impl->camera_override_storage : nullptr
+        m_impl->has_camera_override ? &m_impl->camera_override_storage : nullptr,
+        m_impl->textures.get()
     };
 
     Interpreter interp(eval_ctx, m_impl->registry);
@@ -186,7 +188,8 @@ void Evaluator::re_render() {
         &m_impl->graph.ir().shader_defs,
         {},
         {},
-        nullptr
+        nullptr,
+        m_impl->textures.get()
     };
 
     Interpreter interp(eval_ctx, m_impl->registry);

--- a/projects/joon/src/nodes/node_registry.h
+++ b/projects/joon/src/nodes/node_registry.h
@@ -14,6 +14,7 @@
 namespace joon {
 
 struct SceneCollection;
+class TextureCache;
 
 struct EvalContext {
     Device& device;
@@ -27,6 +28,7 @@ struct EvalContext {
     std::unordered_map<uint32_t, const GraphicsPipeline*> material_pipelines;
     std::unordered_map<uint32_t, ShaderFnIR> material_brdfs;
     const Camera* camera_override = nullptr;
+    TextureCache* texture_cache = nullptr;
 };
 
 using NodeExecutor = std::function<void(const Node& node, EvalContext& ctx)>;

--- a/projects/joon/src/scene/geometry_pass.cpp
+++ b/projects/joon/src/scene/geometry_pass.cpp
@@ -1,5 +1,6 @@
 #include "scene/geometry_pass.h"
 #include "scene/lighting_pass.h"
+#include "scene/texture_cache.h"
 #include "nodes/node_registry.h"
 #include "ir/node.h"
 #include "vulkan/buffer.h"
@@ -27,11 +28,18 @@ struct PushLight {
     float pad1;
 };
 
+bool has_textured_objects(const SceneCollection& scene) {
+    for (const auto& obj : scene.objects)
+        if (obj.albedo_texture) return true;
+    return false;
+}
+
 void exec_pass(const Node& n, EvalContext& ctx) {
     bool has_materials = !ctx.material_pipelines.empty();
-    // When materials are active, G-buffer goes to an intermediate slot and
-    // the lighting pass writes the final lit output to n.id.
-    uint32_t color_id = has_materials ? (n.id ^ 0x40000000u) : n.id;
+    bool has_textures = has_textured_objects(ctx.scene);
+    bool has_deferred = has_materials || has_textures;
+
+    uint32_t color_id = has_deferred ? (n.id ^ 0x40000000u) : n.id;
     uint32_t normal_id = n.id ^ 0x20000000u;
     uint32_t depth_id = n.id ^ 0x80000000u;
 
@@ -41,13 +49,12 @@ void exec_pass(const Node& n, EvalContext& ctx) {
     GpuImage* normal_buf = nullptr;
     std::vector<VkFormat> color_formats = { albedo->format };
     std::vector<VkImageView> color_views = { albedo->view };
-    if (has_materials) {
+    if (has_deferred) {
         normal_buf = ctx.pool.alloc_render_target(normal_id, ctx.default_width, ctx.default_height);
         color_formats.push_back(normal_buf->format);
         color_views.push_back(normal_buf->view);
     }
 
-    // Render pass + framebuffer — created per-evaluate (caching is a follow-up).
     RenderPass rp = create_color_depth_renderpass(ctx.device, color_formats);
     VkFramebuffer fb = create_framebuffer(ctx.device, rp, color_views, depth->view,
                                            ctx.default_width, ctx.default_height);
@@ -55,7 +62,10 @@ void exec_pass(const Node& n, EvalContext& ctx) {
     uint32_t num_color = static_cast<uint32_t>(color_formats.size());
     const auto& gp = ctx.pipelines.get_graphics("scene_basic", rp.pass, sizeof(PushLight), num_color);
 
-    // Camera matrices — fall back to defaults if no camera was set.
+    const GraphicsPipeline* tex_gp = nullptr;
+    if (has_textures)
+        tex_gp = &ctx.pipelines.get_graphics_textured("scene_textured", rp.pass, num_color);
+
     const auto& cam = ctx.scene.camera;
     mat4 view = look_at(cam.position, cam.target, cam.up);
     mat4 proj = perspective_vk(cam.fov_deg,
@@ -63,7 +73,6 @@ void exec_pass(const Node& n, EvalContext& ctx) {
                                     / static_cast<float>(ctx.default_height),
                                 cam.near_z, cam.far_z);
 
-    // Light push constant — first directional light or default.
     PushLight pc{};
     if (!ctx.scene.lights.empty()) {
         const auto& l = ctx.scene.lights[0];
@@ -84,8 +93,8 @@ void exec_pass(const Node& n, EvalContext& ctx) {
     clears[0].color = {{ 0.0f, 0.0f, 0.0f, 1.0f }};
     clears[1].color = {{ 0.0f, 0.0f, 0.0f, 0.0f }};
     clears[2].depthStencil = { 1.0f, 0 };
-    uint32_t clear_count = has_materials ? 3u : 2u;
-    if (!has_materials) {
+    uint32_t clear_count = has_deferred ? 3u : 2u;
+    if (!has_deferred) {
         clears[1].depthStencil = { 1.0f, 0 };
     }
 
@@ -111,7 +120,6 @@ void exec_pass(const Node& n, EvalContext& ctx) {
     scissor.extent = { ctx.default_width, ctx.default_height };
     vkCmdSetScissor(cmd, 0, 1, &scissor);
 
-    // Per-frame buffers — freed after submit.
     std::vector<GpuBuffer> per_frame_bufs;
     per_frame_bufs.reserve(ctx.scene.objects.size() * 3);
 
@@ -120,9 +128,12 @@ void exec_pass(const Node& n, EvalContext& ctx) {
     for (const auto& obj : ctx.scene.objects) {
         if (obj.mesh.vertices.empty() || obj.mesh.indices.empty()) continue;
 
-        // Select pipeline: per-material if available, else default.
+        bool use_textured = obj.albedo_texture && tex_gp;
+
         const GraphicsPipeline* cur_gp = &gp;
-        if (obj.material_node_id != UINT32_MAX) {
+        if (use_textured) {
+            cur_gp = tex_gp;
+        } else if (obj.material_node_id != UINT32_MAX) {
             auto mat_it = ctx.material_pipelines.find(obj.material_node_id);
             if (mat_it != ctx.material_pipelines.end())
                 cur_gp = mat_it->second;
@@ -161,14 +172,58 @@ void exec_pass(const Node& n, EvalContext& ctx) {
         dbi.offset = 0;
         dbi.range = sizeof(UBO);
 
-        VkWriteDescriptorSet wds{};
-        wds.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
-        wds.dstSet = ds;
-        wds.dstBinding = 0;
-        wds.descriptorCount = 1;
-        wds.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
-        wds.pBufferInfo = &dbi;
-        vkUpdateDescriptorSets(ctx.device.device, 1, &wds, 0, nullptr);
+        if (use_textured) {
+            VkDescriptorImageInfo albedo_info{};
+            albedo_info.imageView = obj.albedo_texture->view;
+            albedo_info.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+
+            VkDescriptorImageInfo samp_info{};
+            samp_info.sampler = ctx.texture_cache->sampler();
+
+            VkDescriptorImageInfo normal_info{};
+            normal_info.imageView = obj.normal_texture->view;
+            normal_info.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+
+            VkWriteDescriptorSet writes[4]{};
+            writes[0].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+            writes[0].dstSet = ds;
+            writes[0].dstBinding = 0;
+            writes[0].descriptorCount = 1;
+            writes[0].descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+            writes[0].pBufferInfo = &dbi;
+
+            writes[1].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+            writes[1].dstSet = ds;
+            writes[1].dstBinding = 1;
+            writes[1].descriptorCount = 1;
+            writes[1].descriptorType = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
+            writes[1].pImageInfo = &albedo_info;
+
+            writes[2].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+            writes[2].dstSet = ds;
+            writes[2].dstBinding = 2;
+            writes[2].descriptorCount = 1;
+            writes[2].descriptorType = VK_DESCRIPTOR_TYPE_SAMPLER;
+            writes[2].pImageInfo = &samp_info;
+
+            writes[3].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+            writes[3].dstSet = ds;
+            writes[3].dstBinding = 3;
+            writes[3].descriptorCount = 1;
+            writes[3].descriptorType = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
+            writes[3].pImageInfo = &normal_info;
+
+            vkUpdateDescriptorSets(ctx.device.device, 4, writes, 0, nullptr);
+        } else {
+            VkWriteDescriptorSet wds{};
+            wds.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+            wds.dstSet = ds;
+            wds.dstBinding = 0;
+            wds.descriptorCount = 1;
+            wds.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+            wds.pBufferInfo = &dbi;
+            vkUpdateDescriptorSets(ctx.device.device, 1, &wds, 0, nullptr);
+        }
 
         vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, cur_gp->layout,
                                  0, 1, &ds, 0, nullptr);
@@ -186,8 +241,6 @@ void exec_pass(const Node& n, EvalContext& ctx) {
 
     vkCmdEndRenderPass(cmd);
 
-    // Transition color attachment from COLOR_ATTACHMENT_OPTIMAL → GENERAL so
-    // downstream compute and the GUI viewport can read it.
     VkImageMemoryBarrier barriers[2]{};
     uint32_t barrier_count = 1;
     barriers[0].sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
@@ -218,7 +271,7 @@ void exec_pass(const Node& n, EvalContext& ctx) {
     vkDestroyFramebuffer(ctx.device.device, fb, nullptr);
     destroy_renderpass(ctx.device, rp);
 
-    if (!ctx.material_pipelines.empty()) {
+    if (has_deferred) {
         const ShaderFnIR* brdf = nullptr;
         for (auto& [mat_id, fn_ir] : ctx.material_brdfs) {
             brdf = &fn_ir;

--- a/projects/joon/src/scene/obj_loader.cpp
+++ b/projects/joon/src/scene/obj_loader.cpp
@@ -3,8 +3,10 @@
 
 #include "scene/obj_loader.h"
 
+#include <filesystem>
 #include <sstream>
 #include <stdexcept>
+#include <unordered_map>
 
 namespace joon {
 
@@ -74,6 +76,91 @@ Mesh load_obj_file(const std::string& path) {
         throw std::runtime_error("OBJ load produced no shapes from: " + path);
     }
     return build_mesh(attrib, shapes);
+}
+
+static Vertex build_vertex(const tinyobj::attrib_t& attrib,
+                           const tinyobj::index_t& idx) {
+    Vertex v{};
+    if (idx.vertex_index >= 0 &&
+        static_cast<size_t>(3 * idx.vertex_index + 2) < attrib.vertices.size()) {
+        v.position = {
+            attrib.vertices[3 * idx.vertex_index + 0],
+            attrib.vertices[3 * idx.vertex_index + 1],
+            attrib.vertices[3 * idx.vertex_index + 2],
+        };
+    }
+    if (idx.normal_index >= 0 &&
+        static_cast<size_t>(3 * idx.normal_index + 2) < attrib.normals.size()) {
+        v.normal = {
+            attrib.normals[3 * idx.normal_index + 0],
+            attrib.normals[3 * idx.normal_index + 1],
+            attrib.normals[3 * idx.normal_index + 2],
+        };
+    }
+    if (idx.texcoord_index >= 0 &&
+        static_cast<size_t>(2 * idx.texcoord_index + 1) < attrib.texcoords.size()) {
+        v.uv = {
+            attrib.texcoords[2 * idx.texcoord_index + 0],
+            attrib.texcoords[2 * idx.texcoord_index + 1],
+        };
+    }
+    return v;
+}
+
+std::vector<SubMesh> load_obj_with_materials(const std::string& path) {
+    namespace fs = std::filesystem;
+    std::string mtl_dir = fs::path(path).parent_path().string();
+    if (!mtl_dir.empty()) mtl_dir += "/";
+
+    tinyobj::attrib_t attrib;
+    std::vector<tinyobj::shape_t> shapes;
+    std::vector<tinyobj::material_t> materials;
+    std::string warn, err;
+    if (!tinyobj::LoadObj(&attrib, &shapes, &materials, &warn, &err,
+                          path.c_str(), mtl_dir.c_str()))
+        throw std::runtime_error("OBJ load failed: " + err);
+    if (shapes.empty())
+        throw std::runtime_error("OBJ load produced no shapes from: " + path);
+
+    // Group faces by material_id across all shapes.
+    std::unordered_map<int, Mesh> meshes_by_mat;
+
+    for (const auto& shape : shapes) {
+        size_t index_offset = 0;
+        for (size_t f = 0; f < shape.mesh.num_face_vertices.size(); f++) {
+            int mat_id = -1;
+            if (f < shape.mesh.material_ids.size())
+                mat_id = shape.mesh.material_ids[f];
+
+            int fv = shape.mesh.num_face_vertices[f];
+            auto& mesh = meshes_by_mat[mat_id];
+            for (int vi = 0; vi < fv; vi++) {
+                auto v = build_vertex(attrib, shape.mesh.indices[index_offset + vi]);
+                mesh.indices.push_back(
+                    static_cast<uint32_t>(mesh.vertices.size()));
+                mesh.vertices.push_back(v);
+            }
+            index_offset += fv;
+        }
+    }
+
+    std::vector<SubMesh> result;
+    result.reserve(meshes_by_mat.size());
+    for (auto& [mat_id, mesh] : meshes_by_mat) {
+        SubMesh sm;
+        sm.mesh = std::move(mesh);
+        if (mat_id >= 0 && mat_id < static_cast<int>(materials.size())) {
+            auto& m = materials[mat_id];
+            if (!m.diffuse_texname.empty())
+                sm.material.diffuse_tex = mtl_dir + m.diffuse_texname;
+            if (!m.displacement_texname.empty())
+                sm.material.normal_tex = mtl_dir + m.displacement_texname;
+            else if (!m.bump_texname.empty())
+                sm.material.normal_tex = mtl_dir + m.bump_texname;
+        }
+        result.push_back(std::move(sm));
+    }
+    return result;
 }
 
 } // namespace joon

--- a/projects/joon/src/scene/obj_loader.h
+++ b/projects/joon/src/scene/obj_loader.h
@@ -1,13 +1,23 @@
 #pragma once
 #include <joon/scene.h>
 #include <string>
+#include <vector>
 
 namespace joon {
 
-// Parse an OBJ from an in-memory string. Throws std::runtime_error on parse failure.
 Mesh load_obj_string(const std::string& obj_text);
-
-// Parse an OBJ from a file path. Throws std::runtime_error on read or parse failure.
 Mesh load_obj_file(const std::string& path);
+
+struct MaterialInfo {
+    std::string diffuse_tex;
+    std::string normal_tex;
+};
+
+struct SubMesh {
+    Mesh mesh;
+    MaterialInfo material;
+};
+
+std::vector<SubMesh> load_obj_with_materials(const std::string& path);
 
 } // namespace joon

--- a/projects/joon/src/scene/scene_executors.cpp
+++ b/projects/joon/src/scene/scene_executors.cpp
@@ -1,6 +1,7 @@
 #include "scene/scene_executors.h"
 #include "scene/primitives.h"
 #include "scene/obj_loader.h"
+#include "scene/texture_cache.h"
 #include "nodes/node_registry.h"
 #include "ir/node.h"
 #include <joon/scene.h>
@@ -72,12 +73,41 @@ void exec_cylinder(const Node& n, EvalContext& ctx) {
 }
 
 void exec_mesh(const Node& n, EvalContext& ctx) {
-    SceneObject o;
-    if (!n.string_arg.empty()) o.mesh = load_obj_file(n.string_arg);
-    o.position = kwarg_vec3(n, "position", {0, 0, 0});
-    o.rotation = kwarg_vec3(n, "rotation", {0, 0, 0});
-    o.material_node_id = kwarg_source_node(n, "material");
-    ctx.scene.add_object(std::move(o));
+    if (n.string_arg.empty()) {
+        ctx.scene.add_object(SceneObject{});
+        return;
+    }
+
+    vec3 pos = kwarg_vec3(n, "position", {0, 0, 0});
+    vec3 rot = kwarg_vec3(n, "rotation", {0, 0, 0});
+    uint32_t mat_id = kwarg_source_node(n, "material");
+
+    if (ctx.texture_cache) {
+        auto submeshes = load_obj_with_materials(n.string_arg);
+        for (auto& sm : submeshes) {
+            SceneObject o;
+            o.mesh = std::move(sm.mesh);
+            o.position = pos;
+            o.rotation = rot;
+            o.material_node_id = mat_id;
+            if (!sm.material.diffuse_tex.empty())
+                o.albedo_texture = ctx.texture_cache->load(sm.material.diffuse_tex);
+            if (!sm.material.normal_tex.empty())
+                o.normal_texture = ctx.texture_cache->load(sm.material.normal_tex);
+            if (!o.albedo_texture)
+                o.albedo_texture = ctx.texture_cache->default_albedo();
+            if (!o.normal_texture)
+                o.normal_texture = ctx.texture_cache->default_normal();
+            ctx.scene.add_object(std::move(o));
+        }
+    } else {
+        SceneObject o;
+        o.mesh = load_obj_file(n.string_arg);
+        o.position = pos;
+        o.rotation = rot;
+        o.material_node_id = mat_id;
+        ctx.scene.add_object(std::move(o));
+    }
 }
 
 void exec_light(const Node& n, EvalContext& ctx) {

--- a/projects/joon/src/scene/texture_cache.cpp
+++ b/projects/joon/src/scene/texture_cache.cpp
@@ -1,0 +1,171 @@
+#include "scene/texture_cache.h"
+#include <stb/stb_image.h>
+#include <cstring>
+#include <stdexcept>
+
+namespace joon {
+
+TextureCache::TextureCache(Device& device) : m_device(device) {
+    VkSamplerCreateInfo si{};
+    si.sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
+    si.magFilter = VK_FILTER_LINEAR;
+    si.minFilter = VK_FILTER_LINEAR;
+    si.mipmapMode = VK_SAMPLER_MIPMAP_MODE_LINEAR;
+    si.addressModeU = VK_SAMPLER_ADDRESS_MODE_REPEAT;
+    si.addressModeV = VK_SAMPLER_ADDRESS_MODE_REPEAT;
+    si.addressModeW = VK_SAMPLER_ADDRESS_MODE_REPEAT;
+    si.maxAnisotropy = 1.0f;
+    vkCreateSampler(device.device, &si, nullptr, &m_sampler);
+}
+
+TextureCache::~TextureCache() {
+    for (auto& [path, img] : m_textures) {
+        vkDestroyImageView(m_device.device, img->view, nullptr);
+        vmaDestroyImage(m_device.allocator, img->image, img->allocation);
+    }
+    if (m_defaults_created) {
+        vkDestroyImageView(m_device.device, m_default_albedo.view, nullptr);
+        vmaDestroyImage(m_device.allocator, m_default_albedo.image,
+                        m_default_albedo.allocation);
+        vkDestroyImageView(m_device.device, m_default_normal.view, nullptr);
+        vmaDestroyImage(m_device.allocator, m_default_normal.image,
+                        m_default_normal.allocation);
+    }
+    if (m_sampler)
+        vkDestroySampler(m_device.device, m_sampler, nullptr);
+}
+
+GpuImage TextureCache::upload_rgba8(const uint8_t* data, uint32_t w, uint32_t h,
+                                    VkFormat format) {
+    GpuImage img{};
+    img.width = w;
+    img.height = h;
+    img.format = format;
+
+    VkImageCreateInfo img_info{};
+    img_info.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
+    img_info.imageType = VK_IMAGE_TYPE_2D;
+    img_info.format = format;
+    img_info.extent = {w, h, 1};
+    img_info.mipLevels = 1;
+    img_info.arrayLayers = 1;
+    img_info.samples = VK_SAMPLE_COUNT_1_BIT;
+    img_info.tiling = VK_IMAGE_TILING_OPTIMAL;
+    img_info.usage = VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
+
+    VmaAllocationCreateInfo alloc_info{};
+    alloc_info.usage = VMA_MEMORY_USAGE_GPU_ONLY;
+
+    if (vmaCreateImage(m_device.allocator, &img_info, &alloc_info,
+                       &img.image, &img.allocation, nullptr) != VK_SUCCESS)
+        throw std::runtime_error("TextureCache: failed to allocate image");
+
+    VkImageViewCreateInfo view_info{};
+    view_info.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
+    view_info.image = img.image;
+    view_info.viewType = VK_IMAGE_VIEW_TYPE_2D;
+    view_info.format = format;
+    view_info.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    view_info.subresourceRange.levelCount = 1;
+    view_info.subresourceRange.layerCount = 1;
+    if (vkCreateImageView(m_device.device, &view_info, nullptr, &img.view) !=
+        VK_SUCCESS)
+        throw std::runtime_error("TextureCache: failed to create image view");
+
+    size_t byte_size = w * h * 4;
+
+    VkBufferCreateInfo buf_info{};
+    buf_info.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
+    buf_info.size = byte_size;
+    buf_info.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
+
+    VmaAllocationCreateInfo staging_alloc{};
+    staging_alloc.usage = VMA_MEMORY_USAGE_CPU_ONLY;
+
+    VkBuffer staging;
+    VmaAllocation staging_mem;
+    vmaCreateBuffer(m_device.allocator, &buf_info, &staging_alloc, &staging,
+                    &staging_mem, nullptr);
+
+    void* mapped;
+    vmaMapMemory(m_device.allocator, staging_mem, &mapped);
+    memcpy(mapped, data, byte_size);
+    vmaUnmapMemory(m_device.allocator, staging_mem);
+
+    auto cmd = m_device.begin_single_command();
+
+    VkImageMemoryBarrier barrier{};
+    barrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+    barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    barrier.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    barrier.newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+    barrier.image = img.image;
+    barrier.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+    barrier.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+    vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+                         VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, nullptr, 0,
+                         nullptr, 1, &barrier);
+
+    VkBufferImageCopy region{};
+    region.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    region.imageSubresource.layerCount = 1;
+    region.imageExtent = {w, h, 1};
+    vkCmdCopyBufferToImage(cmd, staging, img.image,
+                           VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &region);
+
+    barrier.oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+    barrier.newLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+    barrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+    barrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+    vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TRANSFER_BIT,
+                         VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, 0, 0, nullptr,
+                         0, nullptr, 1, &barrier);
+
+    m_device.end_single_command(cmd);
+    vmaDestroyBuffer(m_device.allocator, staging, staging_mem);
+
+    return img;
+}
+
+void TextureCache::create_defaults() {
+    if (m_defaults_created) return;
+    uint8_t white[4] = {255, 255, 255, 255};
+    m_default_albedo = upload_rgba8(white, 1, 1, VK_FORMAT_R8G8B8A8_UNORM);
+
+    // Tangent-space "flat" normal: (0.5, 0.5, 1.0) encoded as 8-bit
+    uint8_t flat_normal[4] = {128, 128, 255, 255};
+    m_default_normal = upload_rgba8(flat_normal, 1, 1, VK_FORMAT_R8G8B8A8_UNORM);
+
+    m_defaults_created = true;
+}
+
+GpuImage* TextureCache::load(const std::string& path) {
+    auto it = m_textures.find(path);
+    if (it != m_textures.end()) return it->second.get();
+
+    int w, h, channels;
+    uint8_t* data = stbi_load(path.c_str(), &w, &h, &channels, 4);
+    if (!data) return nullptr;
+
+    auto img = upload_rgba8(data, static_cast<uint32_t>(w),
+                            static_cast<uint32_t>(h), VK_FORMAT_R8G8B8A8_UNORM);
+    stbi_image_free(data);
+
+    auto ptr = std::make_unique<GpuImage>(img);
+    GpuImage* raw = ptr.get();
+    m_textures[path] = std::move(ptr);
+    return raw;
+}
+
+GpuImage* TextureCache::default_albedo() {
+    create_defaults();
+    return &m_default_albedo;
+}
+
+GpuImage* TextureCache::default_normal() {
+    create_defaults();
+    return &m_default_normal;
+}
+
+} // namespace joon

--- a/projects/joon/src/scene/texture_cache.h
+++ b/projects/joon/src/scene/texture_cache.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "vulkan/device.h"
+#include "vulkan/resource_pool.h"
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+namespace joon {
+
+class TextureCache {
+public:
+    explicit TextureCache(Device& device);
+    ~TextureCache();
+
+    GpuImage* load(const std::string& path);
+    GpuImage* default_albedo();
+    GpuImage* default_normal();
+    VkSampler sampler() const { return m_sampler; }
+
+private:
+    Device& m_device;
+    VkSampler m_sampler = VK_NULL_HANDLE;
+    std::unordered_map<std::string, std::unique_ptr<GpuImage>> m_textures;
+
+    GpuImage upload_rgba8(const uint8_t* data, uint32_t w, uint32_t h,
+                          VkFormat format);
+    void create_defaults();
+    bool m_defaults_created = false;
+    GpuImage m_default_albedo{};
+    GpuImage m_default_normal{};
+};
+
+} // namespace joon

--- a/projects/joon/src/vulkan/pipeline_cache.cpp
+++ b/projects/joon/src/vulkan/pipeline_cache.cpp
@@ -327,6 +327,81 @@ const GraphicsPipeline& PipelineCache::get_graphics_from_source(
     return m_graphics_pipelines[key];
 }
 
+const GraphicsPipeline& PipelineCache::get_graphics_textured(
+    const std::string& name, VkRenderPass render_pass,
+    uint32_t num_color_attachments) {
+    std::string key = "tex_" + name + ":" +
+                      std::to_string(reinterpret_cast<uintptr_t>(render_pass)) +
+                      ":" + std::to_string(num_color_attachments);
+    auto it = m_graphics_pipelines.find(key);
+    if (it != m_graphics_pipelines.end()) return it->second;
+
+    GraphicsPipeline p{};
+
+    auto vs_spirv = load_or_compile_stage(name, "vert", "vs_6_0");
+    auto fs_spirv = load_or_compile_stage(name, "frag", "ps_6_0");
+
+    auto make_module = [&](const std::vector<uint8_t>& spirv, const char* what) {
+        if (spirv.size() % 4 != 0)
+            throw std::runtime_error(
+                std::string("SPIR-V size not multiple of 4: ") + what);
+        VkShaderModuleCreateInfo info{};
+        info.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
+        info.codeSize = spirv.size();
+        info.pCode = reinterpret_cast<const uint32_t*>(spirv.data());
+        VkShaderModule mod = VK_NULL_HANDLE;
+        if (vkCreateShaderModule(m_device.device, &info, nullptr, &mod) !=
+            VK_SUCCESS)
+            throw std::runtime_error(
+                std::string("vkCreateShaderModule failed: ") + what);
+        return mod;
+    };
+    p.vert_module = make_module(vs_spirv, (name + ".vert").c_str());
+    p.frag_module = make_module(fs_spirv, (name + ".frag").c_str());
+
+    VkDescriptorSetLayoutBinding bindings[4]{};
+    bindings[0].binding = 0;
+    bindings[0].descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+    bindings[0].descriptorCount = 1;
+    bindings[0].stageFlags = VK_SHADER_STAGE_VERTEX_BIT;
+    bindings[1].binding = 1;
+    bindings[1].descriptorType = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
+    bindings[1].descriptorCount = 1;
+    bindings[1].stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
+    bindings[2].binding = 2;
+    bindings[2].descriptorType = VK_DESCRIPTOR_TYPE_SAMPLER;
+    bindings[2].descriptorCount = 1;
+    bindings[2].stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
+    bindings[3].binding = 3;
+    bindings[3].descriptorType = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
+    bindings[3].descriptorCount = 1;
+    bindings[3].stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
+
+    VkDescriptorSetLayoutCreateInfo desc_info{};
+    desc_info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
+    desc_info.bindingCount = 4;
+    desc_info.pBindings = bindings;
+    if (vkCreateDescriptorSetLayout(m_device.device, &desc_info, nullptr,
+                                    &p.desc_layout) != VK_SUCCESS)
+        throw std::runtime_error(
+            "graphics_textured: vkCreateDescriptorSetLayout failed");
+
+    VkPipelineLayoutCreateInfo layout_info{};
+    layout_info.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
+    layout_info.setLayoutCount = 1;
+    layout_info.pSetLayouts = &p.desc_layout;
+    if (vkCreatePipelineLayout(m_device.device, &layout_info, nullptr,
+                               &p.layout) != VK_SUCCESS)
+        throw std::runtime_error(
+            "graphics_textured: vkCreatePipelineLayout failed");
+
+    p.pipeline = build_graphics_pipeline(p.vert_module, p.frag_module, p.layout,
+                                         render_pass, num_color_attachments);
+
+    m_graphics_pipelines[key] = p;
+    return m_graphics_pipelines[key];
+}
+
 VkPipeline PipelineCache::build_graphics_pipeline(VkShaderModule vert_module,
                                                     VkShaderModule frag_module,
                                                     VkPipelineLayout layout,

--- a/projects/joon/src/vulkan/pipeline_cache.h
+++ b/projects/joon/src/vulkan/pipeline_cache.h
@@ -56,7 +56,13 @@ public:
     const GraphicsPipeline& get_fullscreen(const std::string& frag_name,
                                             VkRenderPass render_pass);
 
-    // Like get_fullscreen but compiles frag from source string instead of file.
+    // Graphics pipeline with per-object texture bindings for textured meshes.
+    // Descriptor layout: binding 0 = UBO (vertex), binding 1 = SAMPLED_IMAGE (frag),
+    //   binding 2 = SAMPLER (frag), binding 3 = SAMPLED_IMAGE (frag).
+    const GraphicsPipeline& get_graphics_textured(const std::string& name,
+                                                   VkRenderPass render_pass,
+                                                   uint32_t num_color_attachments = 2);
+
     const GraphicsPipeline& get_fullscreen_from_source(
         const std::string& key,
         const std::string& frag_hlsl_source,


### PR DESCRIPTION
## Summary
- Splits OBJ meshes by material group and loads albedo/normal textures from MTL references
- New `TextureCache` loads TGA files via stb_image, caches on GPU with VK_FORMAT_R8G8B8A8_UNORM
- New `scene_textured` vertex/fragment shaders with screen-space cotangent-frame normal mapping
- Geometry pass selects textured pipeline when objects have textures, enabling deferred lighting
- Sponza DSL simplified — no longer needs a flat-color shader node

## Test plan
- [ ] Build with `VULKAN_SDK="C:/VulkanSDK/1.4.341.1" premake5 vs2022` then MSBuild
- [ ] Run GUI, select Sponza scene — verify textured rendering with proper lighting
- [ ] Verify normal mapping produces visible surface detail (not flat shading)
- [ ] Verify other scenes (3D Scene, Noise, etc.) still work correctly
- [ ] Check no Vulkan validation errors in log.txt

🤖 Generated with [Claude Code](https://claude.com/claude-code)