### PR TITLE
fix(rp): context cliff, hallucination, and summary improvements

### DIFF
--- a/projects/rp/context.py
+++ b/projects/rp/context.py
@@ -42,11 +42,14 @@ class SummaryBuffer(ContextStrategy):
 
     When a summary is available (via ctx["_summary"]), it is injected as a
     system message after the greeting. Messages already covered by the summary
-    are excluded. The summary gets a soft 25% budget cap; unused budget flows
-    to the recent message window.
+    are excluded, except for a style window of the most recent pre-summary
+    messages to maintain voice/style continuity. The summary gets a soft 25%
+    budget cap; unused budget flows to the recent message window.
 
     Falls back to SlidingWindow behavior when no summary exists.
     """
+
+    STYLE_WINDOW = 4
 
     def fit(self, messages: list[dict], max_tokens: int,
             token_counter=None, ctx: dict | None = None) -> list[dict]:
@@ -77,8 +80,15 @@ class SummaryBuffer(ContextStrategy):
                     "content": f"[Story so far]\n{summary}",
                 }
                 budget -= summary_tokens
-                rest = [m for m in rest
-                        if m.get("_sequence", 0) > summary_through]
+                post_summary = [m for m in rest
+                                if m.get("_sequence", 0) > summary_through]
+                if len(post_summary) < self.STYLE_WINDOW:
+                    pre_summary = [m for m in rest
+                                   if m.get("_sequence", 0) <= summary_through]
+                    need = self.STYLE_WINDOW - len(post_summary)
+                    rest = pre_summary[-need:] + post_summary
+                else:
+                    rest = post_summary
 
         # Fill recent messages newest-first (same as SlidingWindow)
         kept = []

--- a/projects/rp/context.py
+++ b/projects/rp/context.py
@@ -73,8 +73,7 @@ class SummaryBuffer(ContextStrategy):
             max_seq = max((m.get("_sequence", 0) for m in messages), default=0)
             stale = summary_through > 0 and summary_through >= max_seq
             summary_tokens = count(summary)
-            cap = int(max_tokens * 0.25)
-            if not stale and summary_tokens <= cap:
+            if not stale and summary_tokens < budget:
                 summary_msg = {
                     "role": "system",
                     "content": f"[Story so far]\n{summary}",

--- a/projects/rp/routes.py
+++ b/projects/rp/routes.py
@@ -448,7 +448,7 @@ def setup(app: FastAPI, ollama, resolve_model=None):
             resolve_model=_resolve_model,
         )
         if result is None:
-            return {"ok": False, "reason": "not enough unsummarized messages"}
+            return {"ok": False, "reason": "no overflow — messages fit within budget"}
         return {"ok": True, "summary": result}
 
     # -- Chat --
@@ -463,14 +463,16 @@ def setup(app: FastAPI, ollama, resolve_model=None):
         return await budget_ctx(ctx, model, ollama_options, ollama=_ollama)
 
     async def _maybe_summarize(conv_id: int, model: str,
-                               ai_name: str, user_name: str, ai_personality: str):
-        """Fire-and-forget summary generation if enough messages accumulated."""
+                               ai_name: str, user_name: str, ai_personality: str,
+                               messages_budget: int = 0):
+        """Fire-and-forget summary generation when messages exceed budget."""
         try:
             await maybe_generate_summary(
                 conv_id, _ollama, model,
                 char_name=ai_name, user_name=user_name,
                 ai_personality=ai_personality,
                 resolve_model=_resolve_model,
+                messages_budget=messages_budget,
             )
         except Exception as e:
             _log.warning("Summary generation failed for conv %d: %s", conv_id, e)
@@ -682,10 +684,13 @@ def setup(app: FastAPI, ollama, resolve_model=None):
                     prompt_json=chat_messages,
                 )
             conv_log.log_response(conv_id, save_role, post_ctx["response"], raw)
+            budget_report = ctx.get("_budget_report")
+            msg_budget = budget_report.messages_budget if budget_report else 0
             asyncio.create_task(_auto_update_scene_state(conv_id, model,
                                             get_ai_name(ctx), get_user_name(ctx), get_ai_personality(ctx)))
             asyncio.create_task(_maybe_summarize(conv_id, model,
-                                            get_ai_name(ctx), get_user_name(ctx), get_ai_personality(ctx)))
+                                            get_ai_name(ctx), get_user_name(ctx), get_ai_personality(ctx),
+                                            messages_budget=msg_budget))
         except Exception as e:
             yield json.dumps({"error": f"Failed to save response: {e}", "done": True}) + "\n"
 
@@ -833,10 +838,13 @@ def setup(app: FastAPI, ollama, resolve_model=None):
                 )
                 conv_log.log_response(conv_id, "assistant", post_ctx["response"], raw)
                 # Update scene state and maybe generate summary in background
+                budget_report = ctx.get("_budget_report")
+                msg_budget = budget_report.messages_budget if budget_report else 0
                 asyncio.create_task(_auto_update_scene_state(conv_id, model,
                                                 get_ai_name(ctx), get_user_name(ctx), get_ai_personality(ctx)))
                 asyncio.create_task(_maybe_summarize(conv_id, model,
-                                                get_ai_name(ctx), get_user_name(ctx), get_ai_personality(ctx)))
+                                                get_ai_name(ctx), get_user_name(ctx), get_ai_personality(ctx),
+                                                messages_budget=msg_budget))
             except Exception as e:
                 yield json.dumps({"error": f"Failed to save response: {e}", "done": True}) + "\n"
 

--- a/projects/rp/scene_state.py
+++ b/projects/rp/scene_state.py
@@ -23,6 +23,8 @@ _STOPWORDS = frozenset({
 
 _SKIP_VALIDATION = frozenset({"mood", "voice"})
 
+_STRIP_CATEGORIES = frozenset({"personality", "character", "background", "description"})
+
 _PLACEHOLDER_PATTERNS = frozenset({
     "not described", "not mentioned", "not specified", "not stated",
     "unknown", "unclear", "n/a", "none",
@@ -88,13 +90,18 @@ def build_scene_state_prompt(messages: list[dict], previous_state: str = "",
 
 
 def clean_scene_state_response(raw: str) -> str:
-    """Clean up LLM scene state output: strip think tags, remove empty/none lines."""
+    """Clean up LLM scene state output: strip think tags, remove empty/none lines,
+    and remove non-scene categories the LLM may parrot from the prompt."""
     clean = raw.strip()
     if "<think>" in clean:
         clean = clean.split("</think>")[-1].strip()
     lines = []
     for line in clean.splitlines():
         if ":" in line:
+            cat = line.split(":", 1)[0].strip()
+            cat_key = cat.lower().split("'s ")[-1] if "'s " in cat.lower() else cat.lower()
+            if cat_key in _STRIP_CATEGORIES:
+                continue
             value = line.split(":", 1)[1].strip().lower()
             if value and value != "none" and value != "n/a":
                 lines.append(line)

--- a/projects/rp/scene_state.py
+++ b/projects/rp/scene_state.py
@@ -217,4 +217,44 @@ def validate_scene_state(
             if old_val:
                 validated[cat] = old_val
 
+    _fix_discarded_clothing(validated)
     return "\n".join(f"{cat}: {val}" for cat, val in validated.items())
+
+
+def _fix_discarded_clothing(state: dict[str, str]) -> None:
+    """Remove items from clothing lines if they appear as 'discarded' in props."""
+    props_val = ""
+    for cat, val in state.items():
+        if cat.lower() == "props":
+            props_val = val.lower()
+            break
+    if not props_val:
+        return
+
+    discarded = set()
+    for part in re.findall(r"discarded\s+([a-z][a-z\s]*?)(?:,|$)", props_val):
+        discarded.update(w for w in part.strip().split() if len(w) >= 3)
+
+    if not discarded:
+        return
+
+    for cat in list(state.keys()):
+        if "clothing" not in cat.lower():
+            continue
+        val = state[cat]
+        val_lower = val.lower()
+        if any(d in val_lower for d in discarded):
+            cleaned_parts = []
+            for item in re.split(r",\s*|;\s*|\s+and\s+", val):
+                item_lower = item.strip().lower()
+                if not any(d in item_lower for d in discarded):
+                    cleaned_parts.append(item.strip())
+            if cleaned_parts:
+                state[cat] = ", ".join(cleaned_parts)
+            else:
+                state[cat] = "naked"
+            if state[cat].lower() != val_lower:
+                _log.info(
+                    "Fixed clothing [%s]: %r -> %r (items listed as discarded in props)",
+                    cat, val, state[cat],
+                )

--- a/projects/rp/summarize.py
+++ b/projects/rp/summarize.py
@@ -1,7 +1,10 @@
-"""Conversation summary generation, prompt building, and response cleaning.
+"""Hierarchical conversation summary generation.
 
-Generates rolling summaries of conversation history so the SummaryBuffer
-context strategy can inject them instead of losing older messages entirely.
+Generates rolling summaries that fill available budget space. Instead of
+fixed-size 600-token summaries every 10 messages, summaries scale to fill
+the space that dropped messages would have occupied. On each overflow,
+the previous summary + newly-overflowing messages are re-summarized into
+a new summary of the same target size.
 """
 
 import logging
@@ -12,12 +15,19 @@ from .tokenizer import count_tokens
 _log = logging.getLogger("rp.summarize")
 
 SUMMARY_MODEL = "q8"
-SUMMARY_THRESHOLD = 10  # unsummarized messages before triggering
+RECENT_WINDOW = 8
+MIN_UNSUMMARIZED = 4
+
+
+def _target_words(target_tokens: int) -> int:
+    """Rough token→word conversion for the prompt instruction."""
+    return max(200, int(target_tokens * 0.7))
 
 
 def build_summary_prompt(messages: list[dict], previous_summary: str = "",
                          char_name: str = "Character", user_name: str = "User",
-                         ai_personality: str = "") -> str:
+                         ai_personality: str = "",
+                         target_tokens: int = 600) -> str:
     """Build the prompt sent to the LLM to generate/update a rolling conversation summary."""
     history = "\n".join(f"{m['role']}: {m['content']}" for m in messages)
     prev_section = ""
@@ -31,6 +41,7 @@ def build_summary_prompt(messages: list[dict], previous_summary: str = "",
     if ai_personality:
         short = ai_personality[:200].rsplit(" ", 1)[0]
         personality_hint = f"{char_name}'s personality: {short}\n\n"
+    word_limit = _target_words(target_tokens)
     return (
         f"{prev_section}"
         f"{personality_hint}"
@@ -46,7 +57,7 @@ def build_summary_prompt(messages: list[dict], previous_summary: str = "",
         "- Present tense\n"
         "- Be specific — quote distinctive phrases when they matter\n"
         "- Track the emotional arc, not just events\n"
-        "- Keep under 400 words\n"
+        f"- Target approximately {word_limit} words\n"
         "- Do NOT narrate or continue the story — just summarize what happened\n\n"
         f"New messages:\n{history}"
     )
@@ -68,13 +79,15 @@ async def maybe_generate_summary(
     user_name: str = "User",
     ai_personality: str = "",
     resolve_model=None,
+    messages_budget: int = 0,
 ) -> dict | None:
-    """Generate a summary if enough unsummarized messages have accumulated.
+    """Generate a summary when conversation messages exceed available budget.
 
-    Uses SUMMARY_MODEL (a lighter model) for generation, falling back to
-    the conversation model if resolve_model is not provided.
+    Trigger: when unsummarized messages outside the recent window exceed
+    the space remaining after the recent window is accounted for.
 
-    Returns the saved summary row, or None if no summary was needed.
+    The summary targets filling the available space so the model always
+    operates with a full context window.
     """
     messages = await db.get_messages(conv_id)
     if not messages:
@@ -89,39 +102,69 @@ async def maybe_generate_summary(
         prev_through_seq = existing["through_sequence"]
 
     new_msgs = [m for m in messages if m["sequence"] > prev_through_seq]
-    if len(new_msgs) < SUMMARY_THRESHOLD:
+    if len(new_msgs) < MIN_UNSUMMARIZED:
         return None
 
+    recent = messages[-RECENT_WINDOW:] if len(messages) > RECENT_WINDOW else messages
+    recent_tokens = sum(count_tokens(m["content"]) for m in recent)
+
+    if messages_budget <= 0:
+        messages_budget = 13000
+
+    available_for_summary = messages_budget - recent_tokens
+    if available_for_summary < 400:
+        return None
+
+    older = messages[:-RECENT_WINDOW] if len(messages) > RECENT_WINDOW else []
+    unsummarized_older = [m for m in older if m["sequence"] > prev_through_seq]
+
+    if not unsummarized_older and not prev_summary:
+        return None
+
+    unsummarized_tokens = sum(count_tokens(m["content"]) for m in unsummarized_older)
+    prev_summary_tokens = count_tokens(prev_summary) if prev_summary else 0
+    total_older_content = unsummarized_tokens + prev_summary_tokens
+
+    if total_older_content <= available_for_summary:
+        return None
+
+    target_tokens = min(available_for_summary, 8000)
+    target_tokens = max(target_tokens, 400)
+
     prompt = build_summary_prompt(
-        [{"role": m["role"], "content": m["content"]} for m in new_msgs],
+        [{"role": m["role"], "content": m["content"]} for m in unsummarized_older],
         previous_summary=prev_summary,
         char_name=char_name,
         user_name=user_name,
         ai_personality=ai_personality,
+        target_tokens=target_tokens,
     )
 
     summary_model = resolve_model(SUMMARY_MODEL) if resolve_model else model
     raw = await ollama.generate(
         model=summary_model, prompt=prompt,
         system="Output only the summary. No thinking, no preamble.",
-        options={"temperature": 0.3, "num_predict": 600, "think": False},
+        options={"temperature": 0.3, "num_predict": target_tokens, "think": False},
     )
     summary = clean_summary_response(raw)
     if not summary:
         _log.warning("Empty summary generated for conv %d", conv_id)
         return None
 
-    last_msg = new_msgs[-1]
+    last_summarized = unsummarized_older[-1] if unsummarized_older else messages[-RECENT_WINDOW - 1]
     token_estimate = count_tokens(summary)
 
     saved = await db.save_summary(
         conv_id,
         summary=summary,
-        through_msg_id=last_msg["id"],
-        through_sequence=last_msg["sequence"],
-        msg_count=len(new_msgs),
+        through_msg_id=last_summarized["id"],
+        through_sequence=last_summarized["sequence"],
+        msg_count=len(unsummarized_older),
         token_estimate=token_estimate,
     )
-    _log.info("Generated summary for conv %d (through seq %d, %d msgs, ~%d tokens, model=%s)",
-              conv_id, last_msg["sequence"], len(new_msgs), token_estimate, summary_model)
+    _log.info(
+        "Generated summary for conv %d (through seq %d, %d msgs, ~%d tokens, target=%d, model=%s)",
+        conv_id, last_summarized["sequence"], len(unsummarized_older),
+        token_estimate, target_tokens, summary_model,
+    )
     return saved

--- a/projects/rp/tests/test_context.py
+++ b/projects/rp/tests/test_context.py
@@ -104,13 +104,16 @@ class TestSummaryBuffer:
         assert result[1] == msgs[0]  # greeting
 
     def test_summary_filters_covered_messages(self):
-        """Messages with sequence <= summary_through_sequence are excluded."""
+        """Messages with sequence <= summary_through are excluded
+        when enough post-summary messages exist for the style window."""
         msgs = [
             _seq_msg("assistant", "greeting", 1),
             _seq_msg("user", "old1", 2),
             _seq_msg("assistant", "old2", 3),
             _seq_msg("user", "new1", 4),
             _seq_msg("assistant", "new2", 5),
+            _seq_msg("user", "new3", 6),
+            _seq_msg("assistant", "new4", 7),
         ]
         ctx = {"_summary": "Previous events.", "_summary_through_sequence": 3}
         result = SummaryBuffer().fit(msgs, 10000, ctx=ctx)
@@ -169,16 +172,70 @@ class TestSummaryBuffer:
         assert len(result) == 2
 
     def test_messages_without_sequence_not_filtered(self):
-        """Messages without _sequence field default to 0, not filtered if through=0."""
+        """Messages without _sequence default to 0; the style window pulls them in."""
         msgs = [
             _msg("assistant", "greeting"),
             _msg("user", "msg1"),
         ]
         ctx = {"_summary": "Summary.", "_summary_through_sequence": 0}
         result = SummaryBuffer().fit(msgs, 10000, ctx=ctx)
-        # _sequence defaults to 0, 0 > 0 is False, so messages are filtered
-        # greeting is kept separately, msg1 should be filtered
-        assert len(result) == 2  # summary + greeting
+        assert len(result) == 3  # summary + greeting + msg1 (style window)
+
+    def test_style_window_pulls_pre_summary_messages(self):
+        """When < STYLE_WINDOW post-summary messages exist, pre-summary messages
+        are pulled in so the model has recent style examples."""
+        msgs = [
+            _seq_msg("assistant", "greeting", 1),
+            _seq_msg("user", "old1", 2),
+            _seq_msg("assistant", "old2", 3),
+            _seq_msg("user", "old3", 4),
+            _seq_msg("assistant", "old4", 5),
+            _seq_msg("user", "new_only", 6),
+        ]
+        ctx = {"_summary": "Previous events.", "_summary_through_sequence": 5}
+        result = SummaryBuffer().fit(msgs, 10000, ctx=ctx)
+        contents = [m["content"] for m in result]
+        # 1 post-summary message, STYLE_WINDOW=4 → pull 3 from pre-summary
+        assert "new_only" in contents
+        assert "old4" in contents  # most recent pre-summary
+        assert "old3" in contents
+        assert "old2" in contents
+        assert "old1" not in contents  # too old, beyond style window
+
+    def test_style_window_not_needed_when_enough_post_summary(self):
+        """No pre-summary messages pulled in when post-summary count >= STYLE_WINDOW."""
+        msgs = [
+            _seq_msg("assistant", "greeting", 1),
+            _seq_msg("user", "old1", 2),
+            _seq_msg("assistant", "old2", 3),
+            _seq_msg("user", "new1", 4),
+            _seq_msg("assistant", "new2", 5),
+            _seq_msg("user", "new3", 6),
+            _seq_msg("assistant", "new4", 7),
+        ]
+        ctx = {"_summary": "Previous events.", "_summary_through_sequence": 3}
+        result = SummaryBuffer().fit(msgs, 10000, ctx=ctx)
+        contents = [m["content"] for m in result]
+        assert "old1" not in contents
+        assert "old2" not in contents
+        assert "new1" in contents
+
+    def test_style_window_respects_budget(self):
+        """Style window messages are still subject to token budget."""
+        msgs = [
+            _seq_msg("assistant", "greeting", 1),
+            _seq_msg("user", "A" * 400, 2),
+            _seq_msg("assistant", "B" * 400, 3),
+            _seq_msg("user", "C" * 400, 4),
+            _seq_msg("assistant", "D" * 400, 5),
+            _seq_msg("user", "recent", 6),
+        ]
+        ctx = {"_summary": "Short.", "_summary_through_sequence": 5}
+        # Tight budget: greeting + summary + recent + maybe one style msg
+        result = SummaryBuffer().fit(msgs, 30, token_counter=_char4, ctx=ctx)
+        assert result[-1]["content"] == "recent"
+        # Can't fit all 4 style window messages, budget limits it
+        assert len(result) < 7
 
     def test_stale_summary_ignored(self):
         """Summary covering sequences beyond current messages is ignored."""

--- a/projects/rp/tests/test_context.py
+++ b/projects/rp/tests/test_context.py
@@ -124,20 +124,32 @@ class TestSummaryBuffer:
         assert "new2" in contents
         assert "greeting" in contents
 
-    def test_summary_budget_cap(self):
-        """Summary should not exceed 25% of budget."""
+    def test_summary_exceeding_budget_rejected(self):
+        """Summary larger than remaining budget after greeting is not injected."""
         huge_summary = "X" * 2000
         msgs = [
             _seq_msg("assistant", "greeting", 1),
             _seq_msg("user", "recent", 10),
         ]
         ctx = {"_summary": huge_summary, "_summary_through_sequence": 5}
+        # Budget of 100 tokens, greeting ~2 tokens, summary ~500 tokens → exceeds budget
         result = SummaryBuffer().fit(msgs, 100, token_counter=_char4, ctx=ctx)
         for m in result:
             assert "[Story so far]" not in m.get("content", "")
 
-    def test_summary_within_budget_cap(self):
-        """Small summary within 25% cap is injected."""
+    def test_large_summary_within_budget_injected(self):
+        """Large summary that fits within budget is injected (no fixed cap)."""
+        large_summary = "X" * 4000  # ~1000 tokens with _char4
+        msgs = [
+            _seq_msg("assistant", "greeting", 1),
+            _seq_msg("user", "recent", 10),
+        ]
+        ctx = {"_summary": large_summary, "_summary_through_sequence": 5}
+        result = SummaryBuffer().fit(msgs, 2000, token_counter=_char4, ctx=ctx)
+        assert any("[Story so far]" in m.get("content", "") for m in result)
+
+    def test_summary_within_budget_injected(self):
+        """Small summary is injected normally."""
         small_summary = "Short summary."
         msgs = [
             _seq_msg("assistant", "greeting", 1),

--- a/projects/rp/tests/test_scene_state.py
+++ b/projects/rp/tests/test_scene_state.py
@@ -172,6 +172,25 @@ class TestCleanSceneStateResponse:
         result = clean_scene_state_response(raw)
         assert "wrists behind back" in result
 
+    def test_strips_personality_line(self):
+        raw = "Location: park\nAmber's personality: warm and caring\nMood: calm"
+        result = clean_scene_state_response(raw)
+        assert "Location: park" in result
+        assert "Mood: calm" in result
+        assert "personality" not in result.lower()
+
+    def test_strips_character_and_description_lines(self):
+        raw = "Location: park\nCharacter: tall and strong\nDescription: blue eyes"
+        result = clean_scene_state_response(raw)
+        assert "Location: park" in result
+        assert "Character" not in result
+        assert "Description" not in result
+
+    def test_strips_background_line(self):
+        raw = "Location: park\nBackground: grew up in Italy"
+        result = clean_scene_state_response(raw)
+        assert "Background" not in result
+
 
 class TestParseSceneState:
     def test_basic_parsing(self):

--- a/projects/rp/tests/test_scene_state.py
+++ b/projects/rp/tests/test_scene_state.py
@@ -4,6 +4,7 @@ from projects.rp.scene_state import (
     parse_scene_state,
     validate_scene_state,
     _extract_content_words,
+    _fix_discarded_clothing,
     _has_evidence,
 )
 
@@ -401,3 +402,42 @@ class TestValidateSceneState:
         msgs = _msgs(("user", "hello"))
         result = validate_scene_state(narrative, "", msgs)
         assert result == ""
+
+    def test_discarded_items_removed_from_clothing(self):
+        old = "Amber's clothing: tank top\nProps: discarded tank top"
+        new = "Amber's clothing: tank top and jeans\nProps: discarded tank top, discarded jeans"
+        msgs = _msgs(("user", "she took off her jeans"))
+        result = validate_scene_state(new, old, msgs)
+        assert "jeans" not in result.split("clothing")[1].split("\n")[0]
+        assert "Props" in result
+
+    def test_all_items_discarded_becomes_naked(self):
+        state = {
+            "Amber's clothing": "tank top and jeans",
+            "Props": "discarded tank top, discarded jeans",
+        }
+        _fix_discarded_clothing(state)
+        assert state["Amber's clothing"] == "naked"
+
+    def test_partial_discard_keeps_remaining(self):
+        state = {
+            "Amber's clothing": "tank top, jeans, boots",
+            "Props": "discarded jeans",
+        }
+        _fix_discarded_clothing(state)
+        assert "jeans" not in state["Amber's clothing"]
+        assert "tank top" in state["Amber's clothing"]
+        assert "boots" in state["Amber's clothing"]
+
+    def test_no_props_no_change(self):
+        state = {"Amber's clothing": "tank top and jeans"}
+        _fix_discarded_clothing(state)
+        assert state["Amber's clothing"] == "tank top and jeans"
+
+    def test_no_discarded_no_change(self):
+        state = {
+            "Amber's clothing": "tank top",
+            "Props": "candles, rope",
+        }
+        _fix_discarded_clothing(state)
+        assert state["Amber's clothing"] == "tank top"

--- a/projects/rp/tests/test_summarize.py
+++ b/projects/rp/tests/test_summarize.py
@@ -54,7 +54,6 @@ class TestBuildSummaryPrompt:
             char_name="Sol",
         )
         assert "Sol's personality:" in prompt
-        # Truncated to ~200 chars
         hint_line = [line for line in prompt.split("\n") if "Sol's personality:" in line][0]
         assert len(hint_line) < 250
 
@@ -70,7 +69,15 @@ class TestBuildSummaryPrompt:
         assert "Emotional trajectory" in prompt
         assert "Relationship dynamics" in prompt
         assert "Character voice notes" in prompt
-        assert "under 400 words" in prompt
+
+    def test_target_tokens_scales_word_limit(self):
+        prompt_small = build_summary_prompt(
+            messages=_msgs(("user", "test")), target_tokens=600)
+        prompt_large = build_summary_prompt(
+            messages=_msgs(("user", "test")), target_tokens=4000)
+        # Extract the word targets
+        assert "420 words" in prompt_small
+        assert "2800 words" in prompt_large
 
     def test_present_tense_instruction(self):
         prompt = build_summary_prompt(messages=_msgs(("user", "test")))
@@ -118,26 +125,53 @@ def _make_messages(n):
     return msgs
 
 
+def _make_long_messages(n):
+    """Generate messages with varied content that tokenizes realistically."""
+    base = "The character walked through the scene and spoke with feeling about what happened. "
+    msgs = []
+    for i in range(n):
+        content = f"Turn {i}: " + base * 5 + f" End of turn {i}."
+        msgs.append(_db_msg("user", content, i * 2 + 1, i * 2 + 1))
+        msgs.append(_db_msg("assistant", content, i * 2 + 2, i * 2 + 2))
+    return msgs
+
+
 class TestMaybeGenerateSummary:
-    def test_skips_when_below_threshold(self):
-        """No summary generated when fewer than SUMMARY_THRESHOLD messages."""
+    def test_skips_when_below_min_unsummarized(self):
+        """No summary when fewer than MIN_UNSUMMARIZED new messages."""
         async def run():
-            few_msgs = _make_messages(3)  # 6 messages, below threshold of 10
+            few_msgs = _make_messages(1)  # 2 messages, below MIN_UNSUMMARIZED
             with patch("projects.rp.summarize.db") as mock_db:
                 mock_db.get_messages = AsyncMock(return_value=few_msgs)
                 mock_db.get_latest_summary = AsyncMock(return_value=None)
 
                 ollama = AsyncMock()
-                result = await maybe_generate_summary(1, ollama, "test-model")
-
+                result = await maybe_generate_summary(1, ollama, "test-model",
+                                                      messages_budget=100)
                 assert result is None
                 ollama.generate.assert_not_called()
         asyncio.run(run())
 
-    def test_generates_when_above_threshold(self):
-        """Summary generated when enough unsummarized messages exist."""
+    def test_skips_when_older_messages_fit(self):
+        """No summary when older messages fit within available budget."""
         async def run():
-            msgs = _make_messages(6)  # 12 messages, above threshold
+            msgs = _make_messages(8)  # 16 messages, recent_window=8 leaves 8 older
+            with patch("projects.rp.summarize.db") as mock_db:
+                mock_db.get_messages = AsyncMock(return_value=msgs)
+                mock_db.get_latest_summary = AsyncMock(return_value=None)
+
+                ollama = AsyncMock()
+                # Large budget — everything fits
+                result = await maybe_generate_summary(1, ollama, "test-model",
+                                                      messages_budget=120000)
+                assert result is None
+                ollama.generate.assert_not_called()
+        asyncio.run(run())
+
+    def test_generates_when_older_messages_overflow(self):
+        """Summary generated when older messages exceed available budget."""
+        async def run():
+            msgs = _make_long_messages(10)  # 20 long messages
             with patch("projects.rp.summarize.db") as mock_db:
                 mock_db.get_messages = AsyncMock(return_value=msgs)
                 mock_db.get_latest_summary = AsyncMock(return_value=None)
@@ -150,46 +184,45 @@ class TestMaybeGenerateSummary:
                 ollama = AsyncMock()
                 ollama.generate = AsyncMock(return_value="Test summary of conversation.")
 
+                # Small budget forces overflow
                 result = await maybe_generate_summary(1, ollama, "test-model",
-                                                      char_name="Amber", user_name="Val")
+                                                      char_name="Amber", user_name="Val",
+                                                      messages_budget=1200)
 
                 assert result is not None
                 ollama.generate.assert_called_once()
                 mock_db.save_summary.assert_called_once()
-                call_args = mock_db.save_summary.call_args
-                assert call_args[1]["through_msg_id"] == 12
-                assert call_args[1]["through_sequence"] == 12
-                assert call_args[1]["msg_count"] == 12
         asyncio.run(run())
 
-    def test_only_counts_unsummarized_messages(self):
-        """Only messages after the last summary count toward the threshold."""
+    def test_summarizes_only_older_messages(self):
+        """Summary covers messages before the recent window, not all messages."""
         async def run():
-            msgs = _make_messages(8)  # 16 messages total
-            existing_summary = {
-                "summary": "Previous summary text.",
-                "through_sequence": 10,  # summary covers through sequence 10
-                "through_msg_id": 10,
-            }
+            msgs = _make_long_messages(10)  # 20 messages
             with patch("projects.rp.summarize.db") as mock_db:
                 mock_db.get_messages = AsyncMock(return_value=msgs)
-                mock_db.get_latest_summary = AsyncMock(return_value=existing_summary)
+                mock_db.get_latest_summary = AsyncMock(return_value=None)
+                mock_db.save_summary = AsyncMock(return_value={"id": 1})
 
                 ollama = AsyncMock()
-                # 6 messages after sequence 10 (seqs 11-16), below threshold of 10
-                result = await maybe_generate_summary(1, ollama, "test-model")
+                ollama.generate = AsyncMock(return_value="Summary.")
 
-                assert result is None
-                ollama.generate.assert_not_called()
+                await maybe_generate_summary(1, ollama, "test-model",
+                                              messages_budget=1200)
+
+                call_args = mock_db.save_summary.call_args[1]
+                # 20 messages total, RECENT_WINDOW=8, older=12
+                # through_sequence should be the last older message
+                assert call_args["through_sequence"] == 12
+                assert call_args["msg_count"] == 12
         asyncio.run(run())
 
     def test_includes_previous_summary_in_prompt(self):
-        """When extending a summary, the previous summary text is passed to the prompt."""
+        """When extending a summary, the previous summary text is passed."""
         async def run():
-            msgs = _make_messages(10)  # 20 messages
+            msgs = _make_long_messages(10)
             existing_summary = {
                 "summary": "They met at the park.",
-                "through_sequence": 4,  # only covers first 4
+                "through_sequence": 4,
                 "through_msg_id": 4,
             }
             with patch("projects.rp.summarize.db") as mock_db:
@@ -200,17 +233,39 @@ class TestMaybeGenerateSummary:
                 ollama = AsyncMock()
                 ollama.generate = AsyncMock(return_value="Extended summary.")
 
-                await maybe_generate_summary(1, ollama, "test-model")
+                await maybe_generate_summary(1, ollama, "test-model",
+                                              messages_budget=1200)
 
-                # Check that the prompt included the previous summary
                 call_args = ollama.generate.call_args
                 assert "They met at the park" in call_args[1]["prompt"]
+        asyncio.run(run())
+
+    def test_target_tokens_scales_with_budget(self):
+        """num_predict scales to fill available budget space."""
+        async def run():
+            msgs = _make_long_messages(10)
+            with patch("projects.rp.summarize.db") as mock_db:
+                mock_db.get_messages = AsyncMock(return_value=msgs)
+                mock_db.get_latest_summary = AsyncMock(return_value=None)
+                mock_db.save_summary = AsyncMock(return_value={"id": 1})
+
+                ollama = AsyncMock()
+                ollama.generate = AsyncMock(return_value="Summary.")
+
+                # Budget 1500: available ~852, older ~972 → triggers
+                # target = min(852, 8000) = 852 > default 600
+                await maybe_generate_summary(1, ollama, "test-model",
+                                              messages_budget=1500)
+
+                call_args = ollama.generate.call_args
+                num_predict = call_args[1]["options"]["num_predict"]
+                assert num_predict > 600
         asyncio.run(run())
 
     def test_skips_on_empty_llm_response(self):
         """Don't save if the LLM returns empty."""
         async def run():
-            msgs = _make_messages(6)
+            msgs = _make_long_messages(10)
             with patch("projects.rp.summarize.db") as mock_db:
                 mock_db.get_messages = AsyncMock(return_value=msgs)
                 mock_db.get_latest_summary = AsyncMock(return_value=None)
@@ -218,7 +273,8 @@ class TestMaybeGenerateSummary:
                 ollama = AsyncMock()
                 ollama.generate = AsyncMock(return_value="<think>reasoning</think>")
 
-                result = await maybe_generate_summary(1, ollama, "test-model")
+                result = await maybe_generate_summary(1, ollama, "test-model",
+                                                      messages_budget=1200)
 
                 assert result is None
                 mock_db.save_summary.assert_not_called()
@@ -235,9 +291,9 @@ class TestMaybeGenerateSummary:
         asyncio.run(run())
 
     def test_uses_dedicated_model_when_resolve_model_provided(self):
-        """When resolve_model is given, uses SUMMARY_MODEL instead of conv model."""
+        """When resolve_model is given, uses SUMMARY_MODEL."""
         async def run():
-            msgs = _make_messages(6)
+            msgs = _make_long_messages(10)
             with patch("projects.rp.summarize.db") as mock_db:
                 mock_db.get_messages = AsyncMock(return_value=msgs)
                 mock_db.get_latest_summary = AsyncMock(return_value=None)
@@ -252,6 +308,7 @@ class TestMaybeGenerateSummary:
                 await maybe_generate_summary(
                     1, ollama, "conv-model",
                     resolve_model=fake_resolve,
+                    messages_budget=1200,
                 )
 
                 call_args = ollama.generate.call_args
@@ -261,7 +318,7 @@ class TestMaybeGenerateSummary:
     def test_falls_back_to_conv_model_without_resolve(self):
         """Without resolve_model, uses the conversation model directly."""
         async def run():
-            msgs = _make_messages(6)
+            msgs = _make_long_messages(10)
             with patch("projects.rp.summarize.db") as mock_db:
                 mock_db.get_messages = AsyncMock(return_value=msgs)
                 mock_db.get_latest_summary = AsyncMock(return_value=None)
@@ -270,7 +327,8 @@ class TestMaybeGenerateSummary:
                 ollama = AsyncMock()
                 ollama.generate = AsyncMock(return_value="Summary text.")
 
-                await maybe_generate_summary(1, ollama, "conv-model")
+                await maybe_generate_summary(1, ollama, "conv-model",
+                                              messages_budget=1200)
 
                 call_args = ollama.generate.call_args
                 assert call_args[1]["model"] == "conv-model"


### PR DESCRIPTION
## Summary

- **Style window** (`context.py`): Keep 4 recent pre-summary messages so the model retains voice/style continuity when summary covers nearly all history. Fixes POV drift observed in conv 109 and narrative breaks in conv 110.
- **Hierarchical summaries** (`summarize.py`): Summaries now fill available budget space (up to 8K tokens) instead of a fixed 600. Triggered by overflow rather than message count. Eliminates wasted context budget.
- **Personality stripping** (`scene_state.py`): Strip non-scene categories (personality, character, background, description) that the LLM parrots from the scene state prompt.
- **Discarded clothing cross-reference** (`scene_state.py`): When props list items as "discarded X", automatically remove those items from clothing lines. Fixes magically reappearing clothes (conv 113).

## Test plan

```bash
cd /mnt/d/prg/plum-rp-cleanup
# Run all rp tests
python3 -m pytest projects/rp/tests/ -v

# Specific test files for each fix
python3 -m pytest projects/rp/tests/test_context.py -v      # style window + budget
python3 -m pytest projects/rp/tests/test_summarize.py -v    # hierarchical summaries
python3 -m pytest projects/rp/tests/test_scene_state.py -v  # personality strip + clothing
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)