### PR TITLE
fix(rp): add character descriptions to prevent pronoun drift

### DIFF
--- a/projects/rp/prompt_builder.py
+++ b/projects/rp/prompt_builder.py
@@ -49,6 +49,12 @@ def get_ai_personality(ctx: dict) -> str:
     return ai_data.get("description", "")
 
 
+def get_user_description(ctx: dict) -> str:
+    user_data = ctx.get("user_card", {}).get("card_data", {}).get(
+        "data", ctx.get("user_card", {}).get("card_data", {}))
+    return user_data.get("description", "")
+
+
 def build_ollama_options(settings: dict) -> dict:
     opts = dict(CHAT_DEFAULTS)
     for k, v in settings.items():

--- a/projects/rp/routes.py
+++ b/projects/rp/routes.py
@@ -22,8 +22,8 @@ from .fewshot import get_fewshot_messages
 from .summarize import maybe_generate_summary
 from .prompt_builder import (
     get_ai_name, get_user_name, get_ai_personality, get_ai_pronouns,
-    build_chat_messages, build_ollama_options, scale_num_predict,
-    budget_to_json, build_pipeline_ctx, budget_ctx,
+    get_user_description, build_chat_messages, build_ollama_options,
+    scale_num_predict, budget_to_json, build_pipeline_ctx, budget_ctx,
 )
 from . import conv_log
 
@@ -328,7 +328,9 @@ def setup(app: FastAPI, ollama, resolve_model=None):
             asyncio.create_task(_auto_update_scene_state(
                 result["id"], model,
                 ai_data.get("name", "Character"), user_data.get("name", "User"),
-                ai_data.get("description", ""), scenario_desc))
+                ai_data.get("description", ""),
+                user_description=user_data.get("description", ""),
+                scenario_context=scenario_desc))
         return result
 
     @app.get("/rp/conversations/{conv_id}", response_model=ConversationDetailResponse)
@@ -377,7 +379,9 @@ def setup(app: FastAPI, ollama, resolve_model=None):
             asyncio.create_task(_auto_update_scene_state(
                 conv_id, model,
                 ai_data.get("name", "Character"), user_data.get("name", "User"),
-                ai_data.get("description", ""), scenario_desc))
+                ai_data.get("description", ""),
+                user_description=user_data.get("description", ""),
+                scenario_context=scenario_desc))
         return {"ok": True}
 
     @app.put("/rp/conversations/{conv_id}/scene-state")
@@ -445,6 +449,7 @@ def setup(app: FastAPI, ollama, resolve_model=None):
             char_name=ai_data.get("name", "Character"),
             user_name=user_data.get("name", "User"),
             ai_personality=ai_data.get("description", ""),
+            user_description=user_data.get("description", ""),
             resolve_model=_resolve_model,
         )
         if result is None:
@@ -464,6 +469,7 @@ def setup(app: FastAPI, ollama, resolve_model=None):
 
     async def _maybe_summarize(conv_id: int, model: str,
                                ai_name: str, user_name: str, ai_personality: str,
+                               user_description: str = "",
                                messages_budget: int = 0):
         """Fire-and-forget summary generation when messages exceed budget."""
         try:
@@ -471,6 +477,7 @@ def setup(app: FastAPI, ollama, resolve_model=None):
                 conv_id, _ollama, model,
                 char_name=ai_name, user_name=user_name,
                 ai_personality=ai_personality,
+                user_description=user_description,
                 resolve_model=_resolve_model,
                 messages_budget=messages_budget,
             )
@@ -587,9 +594,12 @@ def setup(app: FastAPI, ollama, resolve_model=None):
     async def _generate_scene_state(model: str, messages: list[dict], previous_state: str = "",
                                      ai_name: str = "Character", user_name: str = "User",
                                      ai_personality: str = "",
+                                     user_description: str = "",
                                      scenario_context: str = "") -> str:
         from .scene_state import build_scene_state_prompt, clean_scene_state_response, validate_scene_state
-        prompt = build_scene_state_prompt(messages, previous_state, ai_name, user_name, ai_personality, scenario_context)
+        prompt = build_scene_state_prompt(messages, previous_state, ai_name, user_name,
+                                          ai_personality, user_description=user_description,
+                                          scenario_context=scenario_context)
         summary_model = _resolve_model(_scene_state_model) if _resolve_model else model
         try:
             result = await _ollama.generate(
@@ -606,6 +616,7 @@ def setup(app: FastAPI, ollama, resolve_model=None):
     async def _auto_update_scene_state(conv_id: int, model: str,
                                         ai_name: str = "Character", user_name: str = "User",
                                         ai_personality: str = "",
+                                        user_description: str = "",
                                         scenario_context: str = ""):
         """Background task: generate scene state from previous state + new messages."""
         try:
@@ -629,7 +640,9 @@ def setup(app: FastAPI, ollama, resolve_model=None):
             latest_msg_id = new_msgs[-1]["id"]
             msg_list = [{"role": m["role"], "content": m["content"]} for m in new_msgs]
             clean = await _generate_scene_state(model, msg_list, previous_state,
-                                                ai_name, user_name, ai_personality, scenario_context)
+                                                ai_name, user_name, ai_personality,
+                                                user_description=user_description,
+                                                scenario_context=scenario_context)
             await db.update_scene_state(conv_id, clean, latest_msg_id)
             conv_log.log_scene_state(conv_id, previous_state, clean)
         except Exception as e:
@@ -687,9 +700,11 @@ def setup(app: FastAPI, ollama, resolve_model=None):
             budget_report = ctx.get("_budget_report")
             msg_budget = budget_report.messages_budget if budget_report else 0
             asyncio.create_task(_auto_update_scene_state(conv_id, model,
-                                            get_ai_name(ctx), get_user_name(ctx), get_ai_personality(ctx)))
+                                            get_ai_name(ctx), get_user_name(ctx), get_ai_personality(ctx),
+                                            user_description=get_user_description(ctx)))
             asyncio.create_task(_maybe_summarize(conv_id, model,
                                             get_ai_name(ctx), get_user_name(ctx), get_ai_personality(ctx),
+                                            user_description=get_user_description(ctx),
                                             messages_budget=msg_budget))
         except Exception as e:
             yield json.dumps({"error": f"Failed to save response: {e}", "done": True}) + "\n"
@@ -841,9 +856,11 @@ def setup(app: FastAPI, ollama, resolve_model=None):
                 budget_report = ctx.get("_budget_report")
                 msg_budget = budget_report.messages_budget if budget_report else 0
                 asyncio.create_task(_auto_update_scene_state(conv_id, model,
-                                                get_ai_name(ctx), get_user_name(ctx), get_ai_personality(ctx)))
+                                                get_ai_name(ctx), get_user_name(ctx), get_ai_personality(ctx),
+                                                user_description=get_user_description(ctx)))
                 asyncio.create_task(_maybe_summarize(conv_id, model,
                                                 get_ai_name(ctx), get_user_name(ctx), get_ai_personality(ctx),
+                                                user_description=get_user_description(ctx),
                                                 messages_budget=msg_budget))
             except Exception as e:
                 yield json.dumps({"error": f"Failed to save response: {e}", "done": True}) + "\n"

--- a/projects/rp/scene_state.py
+++ b/projects/rp/scene_state.py
@@ -31,9 +31,22 @@ _PLACEHOLDER_PATTERNS = frozenset({
 })
 
 
+def _first_sentence(text: str) -> str:
+    """Extract the first sentence from a description, capped at 120 chars."""
+    if not text:
+        return ""
+    end = text.find(". ")
+    if end == -1:
+        end = text.find(".\n")
+    if end == -1:
+        end = len(text)
+    return text[:min(end + 1, 120)].strip()
+
+
 def build_scene_state_prompt(messages: list[dict], previous_state: str = "",
                               ai_name: str = "Character", user_name: str = "User",
                               ai_personality: str = "",
+                              user_description: str = "",
                               scenario_context: str = "") -> str:
     """Build the prompt sent to the LLM to generate/update scene state."""
     history = "\n".join(f"{m['role']}: {m['content']}" for m in messages)
@@ -43,10 +56,14 @@ def build_scene_state_prompt(messages: list[dict], previous_state: str = "",
             "PREVIOUS SCENE STATE (carry forward anything not contradicted by new messages):\n"
             f"{previous_state.strip()}\n\n"
         )
-    personality_hint = ""
+    char_hints = []
     if ai_personality:
-        short = ai_personality[:200].rsplit(" ", 1)[0]
-        personality_hint = f"{ai_name}'s personality: {short}\n\n"
+        char_hints.append(f"{ai_name}: {_first_sentence(ai_personality)}")
+    if user_description:
+        char_hints.append(f"{user_name}: {_first_sentence(user_description)}")
+    char_section = ""
+    if char_hints:
+        char_section = "\n".join(char_hints) + "\n\n"
     scenario_section = ""
     if scenario_context.strip():
         scenario_section = f"Scenario context: {scenario_context.strip()}\n\n"
@@ -70,7 +87,7 @@ def build_scene_state_prompt(messages: list[dict], previous_state: str = "",
     )
     return (
         f"{prev_section}"
-        f"{personality_hint}"
+        f"{char_section}"
         f"{scenario_section}"
         f"{instruction}"
         f"Characters: {ai_name} (AI) and {user_name} (user).\n\n"

--- a/projects/rp/summarize.py
+++ b/projects/rp/summarize.py
@@ -24,9 +24,22 @@ def _target_words(target_tokens: int) -> int:
     return max(200, int(target_tokens * 0.7))
 
 
+def _first_sentence(text: str) -> str:
+    """Extract the first sentence (up to first period) from a description, capped at 120 chars."""
+    if not text:
+        return ""
+    end = text.find(". ")
+    if end == -1:
+        end = text.find(".\n")
+    if end == -1:
+        end = len(text)
+    return text[:min(end + 1, 120)].strip()
+
+
 def build_summary_prompt(messages: list[dict], previous_summary: str = "",
                          char_name: str = "Character", user_name: str = "User",
                          ai_personality: str = "",
+                         user_description: str = "",
                          target_tokens: int = 600) -> str:
     """Build the prompt sent to the LLM to generate/update a rolling conversation summary."""
     history = "\n".join(f"{m['role']}: {m['content']}" for m in messages)
@@ -37,14 +50,19 @@ def build_summary_prompt(messages: list[dict], previous_summary: str = "",
             "revise anything the new messages change):\n"
             f"{previous_summary.strip()}\n\n"
         )
-    personality_hint = ""
+    char_hints = []
     if ai_personality:
         short = ai_personality[:200].rsplit(" ", 1)[0]
-        personality_hint = f"{char_name}'s personality: {short}\n\n"
+        char_hints.append(f"{char_name}: {_first_sentence(short)}")
+    if user_description:
+        char_hints.append(f"{user_name}: {_first_sentence(user_description)}")
+    char_section = ""
+    if char_hints:
+        char_section = "Characters:\n" + "\n".join(char_hints) + "\n\n"
     word_limit = _target_words(target_tokens)
     return (
         f"{prev_section}"
-        f"{personality_hint}"
+        f"{char_section}"
         "Update the story summary based on the new messages below. Preserve:\n"
         "- Key plot events and decisions (what actually happened)\n"
         f"- Emotional trajectory (how {char_name}'s feelings evolved, not just current mood)\n"
@@ -57,6 +75,7 @@ def build_summary_prompt(messages: list[dict], previous_summary: str = "",
         "- Present tense\n"
         "- Be specific — quote distinctive phrases when they matter\n"
         "- Track the emotional arc, not just events\n"
+        "- Use each character's correct pronouns based on their description above\n"
         f"- Target approximately {word_limit} words\n"
         "- Do NOT narrate or continue the story — just summarize what happened\n\n"
         f"New messages:\n{history}"
@@ -78,6 +97,7 @@ async def maybe_generate_summary(
     char_name: str = "Character",
     user_name: str = "User",
     ai_personality: str = "",
+    user_description: str = "",
     resolve_model=None,
     messages_budget: int = 0,
 ) -> dict | None:
@@ -137,6 +157,7 @@ async def maybe_generate_summary(
         char_name=char_name,
         user_name=user_name,
         ai_personality=ai_personality,
+        user_description=user_description,
         target_tokens=target_tokens,
     )
 

--- a/projects/rp/tests/test_scene_state.py
+++ b/projects/rp/tests/test_scene_state.py
@@ -88,17 +88,37 @@ class TestBuildSceneStatePrompt:
             ai_personality=long_personality,
             ai_name="Sol",
         )
-        assert "Sol's personality:" in prompt
-        assert len(prompt.split("Sol's personality:")[1].split("\n")[0]) <= 210
+        assert "Sol:" in prompt
+        sol_line = [ln for ln in prompt.splitlines() if ln.startswith("Sol:")][0]
+        assert len(sol_line) <= 130
 
     def test_no_personality_no_hint(self):
         prompt = build_scene_state_prompt(
             messages=_msgs(("user", "test")),
             ai_personality="",
         )
-        # "personality" should not appear before the format section
         before_format = prompt.split("Format")[0]
-        assert "personality:" not in before_format.lower()
+        assert "Characters:" not in before_format or "AI" in before_format
+
+    def test_user_description_included(self):
+        prompt = build_scene_state_prompt(
+            messages=_msgs(("user", "test")),
+            user_name="Valentina",
+            user_description="Valentina is a short woman in her early thirties. She has dark skin.",
+        )
+        assert "Valentina:" in prompt
+        assert "short woman" in prompt
+
+    def test_both_descriptions_included(self):
+        prompt = build_scene_state_prompt(
+            messages=_msgs(("user", "test")),
+            ai_name="Amber",
+            ai_personality="Amber has long wavy chestnut hair. She is warm.",
+            user_name="Val",
+            user_description="Val is a short woman. She has piercings.",
+        )
+        assert "Amber:" in prompt
+        assert "Val:" in prompt
 
     def test_character_names_in_prompt(self):
         prompt = build_scene_state_prompt(

--- a/projects/rp/tests/test_summarize.py
+++ b/projects/rp/tests/test_summarize.py
@@ -53,16 +53,37 @@ class TestBuildSummaryPrompt:
             ai_personality=long_personality,
             char_name="Sol",
         )
-        assert "Sol's personality:" in prompt
-        hint_line = [line for line in prompt.split("\n") if "Sol's personality:" in line][0]
-        assert len(hint_line) < 250
+        assert "Sol:" in prompt
+        sol_line = [ln for ln in prompt.splitlines() if ln.startswith("Sol:")][0]
+        assert len(sol_line) <= 130
 
     def test_no_personality_no_hint(self):
         prompt = build_summary_prompt(
             messages=_msgs(("user", "test")),
             ai_personality="",
         )
-        assert "personality:" not in prompt.split("Update")[0].lower()
+        assert "Characters:" not in prompt.split("Update")[0]
+
+    def test_user_description_included(self):
+        prompt = build_summary_prompt(
+            messages=_msgs(("user", "test")),
+            user_name="Valentina",
+            user_description="Valentina is a short woman in her early thirties. She has dark skin.",
+        )
+        assert "Valentina:" in prompt
+        assert "short woman" in prompt
+
+    def test_both_descriptions_with_pronouns_rule(self):
+        prompt = build_summary_prompt(
+            messages=_msgs(("user", "test")),
+            char_name="Amber",
+            ai_personality="Amber has long chestnut hair. She is warm.",
+            user_name="Val",
+            user_description="Val is a short woman. She has piercings.",
+        )
+        assert "Amber:" in prompt
+        assert "Val:" in prompt
+        assert "correct pronouns" in prompt
 
     def test_preservation_rules_present(self):
         prompt = build_summary_prompt(messages=_msgs(("user", "test")))


### PR DESCRIPTION
## Summary

- Include first sentence of each character's description as a gender/identity anchor in both summary and scene state prompts
- Prevents pronoun drift where the summarizer defaults to they/them and the model reads female characters as male (stubble, "sir", lean muscle)
- Adds "use correct pronouns" rule to summary prompt

Cherry-picked from rp-cleanup branch — this commit was pushed after PR #158 was merged.

## Test plan

```bash
cd /mnt/d/prg/plum-rp-pronouns
python3 -m pytest projects/rp/tests/test_scene_state.py projects/rp/tests/test_summarize.py -v
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)