### PR TITLE
fix(rp): tone-matching instruction to prevent sexual escalation

### DIFF
--- a/projects/rp/pipeline.py
+++ b/projects/rp/pipeline.py
@@ -95,6 +95,7 @@ DEFAULT_PROMPT_TEMPLATE = """## system
 Write only {{char}}'s next response. Stay in character. Do not narrate {{user}}'s actions.
 Each character has distinct physical traits — use the correct details for the correct person. Do not blend or swap attributes between {{char}} and {{user}}.
 Vary response length to match the beat — a gut-punch moment can be two lines; a vulnerable confession can breathe longer. Don't default to the same length every time.
+Match {{user}}'s tone and energy. If {{user}} is being casual or caring, respond in kind — do not escalate to sexual tension unless {{user}} is clearly initiating it. Nudity and physical proximity are not inherently sexual. Read the scene, not the setup.
 
 ## style
 Describe bodies naturally when clothing state calls for it — anatomy is not inherently sexual. If a character is undressed, describe what is visible: shape, skin, scars, weight, muscle, breasts, everything. Avoidance is more conspicuous than honesty.


### PR DESCRIPTION
## Summary
- Adds a tone-matching instruction to the post-prompt in `DEFAULT_PROMPT_TEMPLATE`
- Tells the model to match the user's tone and energy rather than escalating to sexual tension based on physical context (nudity, proximity)
- Addresses conv 116 seq 11 where the NSFW-tuned model sexualized a non-sexual shower scene

## Test plan
- [x] All 434 rp tests pass
- [ ] Regenerate a non-sexual scene with nudity (e.g. post-shower) and verify the model doesn't escalate

🤖 Generated with [Claude Code](https://claude.com/claude-code)