### PR TITLE
fix(rp): pronoun inference + user character pronoun fixing

### DIFF
--- a/projects/rp/pipeline.py
+++ b/projects/rp/pipeline.py
@@ -3,6 +3,7 @@ import logging
 import re
 from typing import Callable
 from .mcp_client import get_router
+from .prompt_builder import infer_pronouns
 
 _log = logging.getLogger(__name__)
 
@@ -210,8 +211,8 @@ def assemble_prompt(ctx: dict) -> dict:
         "char": ai_data.get("name", "Character"),
         "user": user_data.get("name", "User"),
         "user_description": user_data.get("description", ""),
-        "user_pronouns": user_data.get("pronouns", ""),
-        "char_pronouns": ai_data.get("pronouns", ""),
+        "user_pronouns": user_data.get("pronouns", "") or infer_pronouns(user_data.get("description", "")),
+        "char_pronouns": ai_data.get("pronouns", "") or infer_pronouns(ai_data.get("description", "")),
     }
 
     system_part, post_part, style_part, scene_style_part = _split_template(template)
@@ -291,27 +292,18 @@ def _fix_pronouns_in_sentence(sentence: str, mapping: dict) -> str:
     return result
 
 
-def enforce_pronouns(ctx: dict) -> dict:
-    """Fix they/them → she/her or he/him when the character has explicit pronouns."""
-    pronouns = ctx.get("_char_pronouns", "")
-    if not pronouns:
-        return ctx
-
+def _fix_character_pronouns(response: str, char_name: str, pronouns: str) -> tuple[str, int]:
+    """Fix they/them → correct pronouns for a named character in the response."""
     mapping = _PRONOUN_MAP.get(pronouns.lower().strip())
-    if not mapping:
-        return ctx
-
-    ai_name = ctx.get("ai_name", "")
-    response = ctx.get("response", "")
-    if not ai_name or not response:
-        return ctx
+    if not mapping or not char_name:
+        return response, 0
 
     sentences = re.split(r'(?<=[.!?…"])\s+', response)
     fixed = []
     name_recent = False
     corrections = 0
     for sent in sentences:
-        has_name = ai_name.lower() in sent.lower()
+        has_name = char_name.lower() in sent.lower()
         has_plural = bool(_PLURAL_SIGNALS.search(sent))
         has_they = bool(re.search(r'\b[Tt]he(?:y|m|ir|msel(?:f|ves))\b', sent))
 
@@ -328,10 +320,36 @@ def enforce_pronouns(ctx: dict) -> dict:
         elif re.search(r'\b[A-Z][a-z]+\b', sent) and not has_name:
             name_recent = False
 
-    if corrections:
-        ctx["response"] = " ".join(fixed)
-        ctx["_pronoun_corrections"] = corrections
-        _log.info("Fixed %d pronoun(s) for %s (%s)", corrections, ai_name, pronouns)
+    return " ".join(fixed), corrections
+
+
+def enforce_pronouns(ctx: dict) -> dict:
+    """Fix they/them → she/her or he/him for both AI and user characters."""
+    response = ctx.get("response", "")
+    if not response:
+        return ctx
+
+    total = 0
+
+    ai_pronouns = ctx.get("_char_pronouns", "")
+    ai_name = ctx.get("ai_name", "")
+    if ai_pronouns and ai_name:
+        response, n = _fix_character_pronouns(response, ai_name, ai_pronouns)
+        if n:
+            _log.info("Fixed %d pronoun(s) for AI %s (%s)", n, ai_name, ai_pronouns)
+        total += n
+
+    user_pronouns = ctx.get("_user_pronouns", "")
+    user_name = ctx.get("_user_name", "")
+    if user_pronouns and user_name:
+        response, n = _fix_character_pronouns(response, user_name, user_pronouns)
+        if n:
+            _log.info("Fixed %d pronoun(s) for user %s (%s)", n, user_name, user_pronouns)
+        total += n
+
+    if total:
+        ctx["response"] = response
+        ctx["_pronoun_corrections"] = total
     return ctx
 
 

--- a/projects/rp/prompt_builder.py
+++ b/projects/rp/prompt_builder.py
@@ -6,6 +6,7 @@ preparing the pipeline context. Functions that need external services
 """
 
 import logging
+import re
 from dataclasses import asdict
 from pathlib import Path
 
@@ -37,10 +38,38 @@ def get_user_name(ctx: dict) -> str:
     return user_data.get("name", "User")
 
 
+_FEMALE_SIGNALS = re.compile(
+    r'\b(woman|female|girl|lady|she|daughter|mother|wife|girlfriend|sister)\b',
+    re.IGNORECASE,
+)
+_MALE_SIGNALS = re.compile(
+    r'\b(man|male|boy|guy|he|son|father|husband|boyfriend|brother)\b',
+    re.IGNORECASE,
+)
+
+
+def infer_pronouns(description: str) -> str:
+    """Infer she/her or he/him from the first 200 chars of a card description."""
+    text = description[:200]
+    female = len(_FEMALE_SIGNALS.findall(text))
+    male = len(_MALE_SIGNALS.findall(text))
+    if female > male:
+        return "she/her"
+    if male > female:
+        return "he/him"
+    return ""
+
+
 def get_ai_pronouns(ctx: dict) -> str:
     ai_data = ctx.get("ai_card", {}).get("card_data", {}).get(
         "data", ctx.get("ai_card", {}).get("card_data", {}))
-    return ai_data.get("pronouns", "")
+    return ai_data.get("pronouns", "") or infer_pronouns(ai_data.get("description", ""))
+
+
+def get_user_pronouns(ctx: dict) -> str:
+    user_data = ctx.get("user_card", {}).get("card_data", {}).get(
+        "data", ctx.get("user_card", {}).get("card_data", {}))
+    return user_data.get("pronouns", "") or infer_pronouns(user_data.get("description", ""))
 
 
 def get_ai_personality(ctx: dict) -> str:

--- a/projects/rp/routes.py
+++ b/projects/rp/routes.py
@@ -22,8 +22,9 @@ from .fewshot import get_fewshot_messages
 from .summarize import maybe_generate_summary
 from .prompt_builder import (
     get_ai_name, get_user_name, get_ai_personality, get_ai_pronouns,
-    get_user_description, build_chat_messages, build_ollama_options,
-    scale_num_predict, budget_to_json, build_pipeline_ctx, budget_ctx,
+    get_user_pronouns, get_user_description, build_chat_messages,
+    build_ollama_options, scale_num_predict, budget_to_json,
+    build_pipeline_ctx, budget_ctx,
 )
 from . import conv_log
 
@@ -682,7 +683,12 @@ def setup(app: FastAPI, ollama, resolve_model=None):
 
         try:
             response_text = "".join(tokens)
-            post_ctx = {"response": response_text, "ai_name": get_ai_name(ctx), "_char_pronouns": get_ai_pronouns(ctx)}
+            post_ctx = {
+                "response": response_text, "ai_name": get_ai_name(ctx),
+                "_char_pronouns": get_ai_pronouns(ctx),
+                "_user_name": get_user_name(ctx),
+                "_user_pronouns": get_user_pronouns(ctx),
+            }
             post_ctx = await _pipeline.run_post(post_ctx)
             full_text = prefix_text + post_ctx["response"] if prefix_text else post_ctx["response"]
             if continue_msg_id:
@@ -841,7 +847,12 @@ def setup(app: FastAPI, ollama, resolve_model=None):
                 cur_messages.append({"role": "user", "content": "\n".join(tool_results) + "\n\nContinue your response naturally, incorporating the information above. Do not use [TOOL:] again for the same query."})
 
             try:
-                post_ctx = {"response": final_text, "ai_name": get_ai_name(ctx), "_char_pronouns": get_ai_pronouns(ctx)}
+                post_ctx = {
+                    "response": final_text, "ai_name": get_ai_name(ctx),
+                    "_char_pronouns": get_ai_pronouns(ctx),
+                    "_user_name": get_user_name(ctx),
+                    "_user_pronouns": get_user_pronouns(ctx),
+                }
                 post_ctx = await _pipeline.run_post(post_ctx)
                 await db.add_message(
                     conv_id, "assistant", post_ctx["response"], raw_response=raw,

--- a/projects/rp/scene_state.py
+++ b/projects/rp/scene_state.py
@@ -98,7 +98,7 @@ def build_scene_state_prompt(messages: list[dict], previous_state: str = "",
         "Restraints: (describe the specific tie/pattern AND what it practically limits — e.g. 'wrists behind back — no free hand use' — or 'none')\n"
         "Position: (posture, who is where, physical contact)\n"
         "Props: (objects currently in play)\n"
-        "Mood: (emotional atmosphere right now)\n"
+        "Mood: (what characters feel right now — use neutral terms; avoid sexually-charged words like 'charged' or 'electric' unless characters are explicitly intimate)\n"
         "ONLY state facts explicitly shown or described in the messages. Do NOT invent or assume details not present.\n"
         f"{clothing_instruction}"
         "No narration, no story, no explanation. Just the current facts.\n\n"

--- a/projects/rp/tests/test_pipeline.py
+++ b/projects/rp/tests/test_pipeline.py
@@ -2,9 +2,10 @@ import pytest  # noqa: F401
 from projects.rp.pipeline import assemble_prompt, expand_variables, render_template
 
 
-def _make_ctx(template="", scenario_desc="", ai_desc="", ai_personality="", ai_name="Char", user_name="User", messages=None):
+def _make_ctx(template="", scenario_desc="", ai_desc="", ai_personality="",
+              ai_name="Char", user_name="User", user_desc="", messages=None):
     return {
-        "user_card": {"card_data": {"data": {"name": user_name}}},
+        "user_card": {"card_data": {"data": {"name": user_name, "description": user_desc}}},
         "ai_card": {"card_data": {"data": {
             "name": ai_name,
             "description": ai_desc,
@@ -83,6 +84,7 @@ from projects.rp.pipeline import (  # noqa: E402
     _match_scene_condition, select_style, clean_response,
     check_stock_phrases, enforce_pronouns, Pipeline, STYLE_ITEMS_PER_TURN,
 )
+from projects.rp.prompt_builder import infer_pronouns  # noqa: E402
 import asyncio  # noqa: E402
 
 
@@ -627,6 +629,91 @@ class TestEnforcePronouns:
         assert "_pronoun_corrections" not in result
 
 
+class TestInferPronouns:
+    def test_woman_infers_she_her(self):
+        assert infer_pronouns("Valentina is a short woman in her early thirties.") == "she/her"
+
+    def test_man_infers_he_him(self):
+        assert infer_pronouns("Marcus is a tall man with broad shoulders.") == "he/him"
+
+    def test_female_signals(self):
+        assert infer_pronouns("A girl from the countryside, she grew up on a farm.") == "she/her"
+
+    def test_male_signals(self):
+        assert infer_pronouns("The boy had always dreamed of adventure. He left home at 16.") == "he/him"
+
+    def test_no_signal_returns_empty(self):
+        assert infer_pronouns("A mysterious figure cloaked in shadow.") == ""
+
+    def test_empty_description(self):
+        assert infer_pronouns("") == ""
+
+    def test_only_first_200_chars(self):
+        desc = "A mysterious figure. " * 20 + "She is actually a woman."
+        assert infer_pronouns(desc) == ""
+
+    def test_mixed_signals_majority_wins(self):
+        assert infer_pronouns("She is a woman, daughter of a king and wife of a prince.") == "she/her"
+
+
+class TestEnforcePronounsUserCharacter:
+    def test_fixes_user_character_they_to_she(self):
+        ctx = {
+            "response": "I looked up at Valentina. Their eyes were red from crying.",
+            "ai_name": "Amber",
+            "_char_pronouns": "she/her",
+            "_user_name": "Valentina",
+            "_user_pronouns": "she/her",
+        }
+        result = enforce_pronouns(ctx)
+        assert "Her eyes were red" in result["response"]
+
+    def test_fixes_user_character_them_to_her(self):
+        ctx = {
+            "response": "Valentina pulled me close. I leaned into them gratefully.",
+            "ai_name": "Amber",
+            "_char_pronouns": "she/her",
+            "_user_name": "Valentina",
+            "_user_pronouns": "she/her",
+        }
+        result = enforce_pronouns(ctx)
+        assert "leaned into her" in result["response"]
+
+    def test_no_fix_without_user_pronouns(self):
+        ctx = {
+            "response": "Valentina smiled. They waved.",
+            "ai_name": "Amber",
+            "_char_pronouns": "she/her",
+            "_user_name": "Valentina",
+            "_user_pronouns": "",
+        }
+        result = enforce_pronouns(ctx)
+        assert "They waved" in result["response"]
+
+    def test_both_characters_fixed(self):
+        ctx = {
+            "response": "Amber sighed. They looked at Valentina. They smiled back.",
+            "ai_name": "Amber",
+            "_char_pronouns": "she/her",
+            "_user_name": "Valentina",
+            "_user_pronouns": "she/her",
+        }
+        result = enforce_pronouns(ctx)
+        assert "She looked at Valentina" in result["response"]
+        assert "She smiled back" in result["response"]
+
+    def test_skips_plural_for_user_character(self):
+        ctx = {
+            "response": "Valentina and I looked at each other. They both laughed.",
+            "ai_name": "Amber",
+            "_char_pronouns": "she/her",
+            "_user_name": "Valentina",
+            "_user_pronouns": "she/her",
+        }
+        result = enforce_pronouns(ctx)
+        assert "They both" in result["response"]
+
+
 class TestDefaultTemplate:
     def test_default_template_renders_with_full_card(self):
         ctx = _make_ctx(
@@ -649,6 +736,17 @@ class TestDefaultTemplate:
         ctx = _make_ctx(template="", ai_name="Sol", ai_desc="", scenario_desc="")
         result = assemble_prompt(ctx)
         assert "Scenario:" not in result["system_prompt"]
+
+    def test_inferred_pronouns_appear_in_system_prompt(self):
+        ctx = _make_ctx(
+            template="",
+            ai_name="Amber",
+            ai_desc="Amber is a tall woman with red hair.",
+            user_name="Val",
+            user_desc="Val is a short woman with dark curly hair.",
+        )
+        result = assemble_prompt(ctx)
+        assert "she/her" in result["system_prompt"]
 
 
 class TestPipelineClass:

--- a/projects/rp/tests/test_scene_state.py
+++ b/projects/rp/tests/test_scene_state.py
@@ -141,6 +141,12 @@ class TestBuildSceneStatePrompt:
         for cat in ["Location:", "'s clothing:", "Restraints:", "Position:", "Props:", "Mood:"]:
             assert cat in prompt
 
+    def test_mood_line_warns_against_sexual_terms(self):
+        prompt = build_scene_state_prompt(messages=_msgs(("user", "test")))
+        mood_line = [ln for ln in prompt.splitlines() if ln.startswith("Mood:")][0]
+        assert "neutral" in mood_line.lower()
+        assert "charged" in mood_line.lower()
+
     def test_per_character_clothing_lines(self):
         prompt = build_scene_state_prompt(
             messages=_msgs(("user", "test")),


### PR DESCRIPTION
## Summary
- Auto-infer she/her or he/him from card descriptions when no explicit `pronouns` field exists (scans first 200 chars for gender signals)
- Extend `enforce_pronouns` post-hook to fix they/them for the **user character** too — in first-person narration, they/them almost always refers to the other character
- Scene state mood prompt now discourages sexually-charged mood terms unless characters are explicitly intimate
- Inferred pronouns now appear in the system prompt template (`{{char_pronouns}}`, `{{user_pronouns}}`)

## Test plan
- [x] All 449 rp tests pass (15 new tests)
- [x] `infer_pronouns("Valentina is a short woman")` → `"she/her"`
- [x] `enforce_pronouns` fixes "Valentina... Their eyes" → "Her eyes"
- [x] Template renders inferred pronouns in system prompt
- [x] Scene state mood line includes neutral-term guidance
- [ ] Regenerate conv 116 and verify Valentina gets she/her pronouns

🤖 Generated with [Claude Code](https://claude.com/claude-code)