### PR TITLE
feat(rp): trait saturation style instruction

### DIFF
--- a/projects/rp/pipeline.py
+++ b/projects/rp/pipeline.py
@@ -109,7 +109,9 @@ Emotions don't reset between messages. If {{char}} was crying, grieving, or in c
 ---
 Responses can be concise — not every message needs dialogue + action + inner thought. Sometimes just action. Sometimes just words. Sometimes silence. A single sentence is fine if that's the beat. Long responses are earned by dramatic moments, not the default.
 ---
-When {{user}} is vulnerable, {{char}} does NOT respond like a therapist. Real people fumble, project, say the wrong thing, sit in uncomfortable silence. Emotional conversations are messy, not eloquent."""
+When {{user}} is vulnerable, {{char}} does NOT respond like a therapist. Real people fumble, project, say the wrong thing, sit in uncomfortable silence. Emotional conversations are messy, not eloquent.
+---
+Let the scene's weight shape how {{char}}'s traits come through. A joker caught in a vulnerable moment still deflects — but the humor cracks, the timing slips, the mask doesn't quite fit. Play traits at the intensity the situation earns, not at full volume every turn."""
 
 
 STYLE_ITEMS_PER_TURN = 3

--- a/projects/rp/tests/test_pipeline.py
+++ b/projects/rp/tests/test_pipeline.py
@@ -837,6 +837,11 @@ class TestDefaultTemplate:
         result = assemble_prompt(ctx)
         assert "Scenario:" not in result["system_prompt"]
 
+    def test_default_template_includes_trait_modulation(self):
+        ctx = _make_ctx(template="", ai_name="Amber")
+        result = assemble_prompt(ctx)
+        assert any("intensity the situation earns" in item for item in result["_style_pool"])
+
     def test_inferred_pronouns_appear_in_system_prompt(self):
         ctx = _make_ctx(
             template="",


### PR DESCRIPTION
## Summary
- Adds a new rotating style instruction that tells the model to modulate character trait intensity based on scene context
- Prevents "caricature mode" where dominant traits (humor, deflection, quirks) play at full volume even in vulnerable/tense moments
- Observed in conv 124: Amber cracking jokes and dropping random trivia while hogtied naked — scene demanded vulnerability bleeding through the humor, not pure comedy

## Test plan
```bash
cd /mnt/d/prg/plum-rp-trait-saturation
source /mnt/d/prg/plum/projects/aiserver/.venv/bin/activate
python -m pytest projects/rp/tests/test_pipeline.py -x -q
# 120 passed — includes test_default_template_includes_trait_modulation
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)