### PR TITLE
fix(rp): budget token counting times out on large models

### DIFF
--- a/projects/aiserver/ollama.py
+++ b/projects/aiserver/ollama.py
@@ -211,6 +211,7 @@ class OllamaClient:
         messages: list[dict],
         tools: list[dict] | None = None,
         think: bool | None = None,
+        options: dict | None = None,
     ) -> dict:
         """Non-streaming chat call. Returns the full Ollama response dict.
 
@@ -225,6 +226,8 @@ class OllamaClient:
             body["tools"] = tools
         if think is not None:
             body["think"] = think
+        if options:
+            body["options"] = options
         try:
             async with httpx.AsyncClient(timeout=120.0) as client:
                 resp = await client.post(f"{self.base_url}/api/chat", json=body)

--- a/projects/rp/budget.py
+++ b/projects/rp/budget.py
@@ -161,7 +161,8 @@ async def _ollama_count_messages(
     Returns 0 if Ollama doesn't surface the field — caller decides
     how to handle a missing value.
     """
-    result = await ollama.chat(model=model, messages=messages)
+    result = await ollama.chat(model=model, messages=messages,
+                               options={"num_predict": 1})
     return int(result.get("prompt_eval_count", 0) or 0)
 
 

--- a/projects/rp/tests/conftest.py
+++ b/projects/rp/tests/conftest.py
@@ -37,7 +37,7 @@ class StubOllama:
             raise OllamaError(f"stub has no num_ctx for model {model!r}")
         return self.num_ctx_map[model]
 
-    async def chat(self, model: str, messages, tools=None, think=False):
+    async def chat(self, model: str, messages, tools=None, think=False, options=None):
         """Stub /api/chat that returns a prompt_eval_count.
 
         Ground-truth counting calls this with num_predict=0 in options;

--- a/projects/rp/tests/test_budget.py
+++ b/projects/rp/tests/test_budget.py
@@ -405,7 +405,7 @@ class TestFitPromptGroundTruth:
                 self.counts = [2000, 400]  # decreasing per call
                 self.call_idx = 0
 
-            async def chat(self, model, messages, tools=None, think=False):
+            async def chat(self, model, messages, tools=None, think=False, options=None):
                 self.chat_calls += 1
                 idx = min(self.call_idx, len(self.counts) - 1)
                 self.call_idx += 1
@@ -436,7 +436,7 @@ class TestFitPromptGroundTruth:
                     default_count=1000,  # always over
                 )
 
-            async def chat(self, model, messages, tools=None, think=False):
+            async def chat(self, model, messages, tools=None, think=False, options=None):
                 self.chat_calls += 1
                 return {"done": True, "prompt_eval_count": 1000}
 

--- a/projects/rp/tests/test_routes.py
+++ b/projects/rp/tests/test_routes.py
@@ -309,7 +309,7 @@ class IntegrationStubOllama:
     async def get_num_ctx(self, model: str) -> int:
         return self._num_ctx
 
-    async def chat(self, model, messages, tools=None, think=False):
+    async def chat(self, model, messages, tools=None, think=False, options=None):
         return {
             "message": {"role": "assistant", "content": ""},
             "done": True,


### PR DESCRIPTION
## Summary
- Budget ground-truth counter called `ollama.chat()` without `num_predict`, forcing full generation before returning `prompt_eval_count`
- On cydonia-22b (Q8, ~24GB), this exceeded the 120s httpx timeout, causing all message sends to fail silently
- Now passes `options: {"num_predict": 1}` — Ollama tokenizes the full prompt but generates only 1 token
- Added `options` param to `OllamaClient.chat()` and updated all test stubs

## Test plan
```bash
cd /mnt/d/prg/plum-rp-budget-timeout
source /mnt/d/prg/plum/projects/aiserver/.venv/bin/activate
python -m pytest projects/aiserver/tests/ projects/rp/tests/ -x -q
# 485 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)