### PR TITLE
fix(rp): widen repeat penalty window to cover previous turns

### DIFF
--- a/projects/rp/prompt_builder.py
+++ b/projects/rp/prompt_builder.py
@@ -22,6 +22,7 @@ CHAT_DEFAULTS = {
     "num_ctx": 16384,
     "temperature": 1.05,
     "repeat_penalty": 1.08,
+    "repeat_last_n": 512,
     "min_p": 0.1,
 }
 


### PR DESCRIPTION
## Summary
- Added `repeat_last_n: 512` to `CHAT_DEFAULTS` — Ollama's default of 64 only covers the current generation's tail, so cross-turn phrase repetition goes unpenalized
- Observed in conv 130 (Magnum v4 27B): "clinging to every curve", "hysterical laugh bubbled up", "walked here in the rain" each appeared 3x across turns
- Mag-Mell didn't need this because RP finetune training data already models phrase variety; general creative models like Magnum don't
- 512 tokens covers ~2-3 prior assistant messages, enough to catch recycled phrases without over-penalizing common words

## Test plan
```bash
cd /mnt/d/prg/plum-rp-repeat-window
source /mnt/d/prg/plum/projects/aiserver/.venv/bin/activate
python -m pytest projects/rp/tests/ -x -q
# 463 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)