### PR TITLE
fix(rp): move fewshot from message history to system prompt

### DIFF
--- a/projects/rp/routes.py
+++ b/projects/rp/routes.py
@@ -759,9 +759,19 @@ def setup(app: FastAPI, ollama, resolve_model=None):
             )
 
         if fewshot_msgs and ctx["messages"] and alloc.keep_fewshot:
-            _log.info("Injecting %d fewshot examples (vector-matched)", len(fewshot_msgs) // 2)
-            conv_log.log_fewshot(conv_id, len(fewshot_msgs) // 2, fewshot_msgs)
-            ctx["messages"] = [ctx["messages"][0]] + fewshot_msgs + ctx["messages"][1:]
+            n_examples = len(fewshot_msgs) // 2
+            _log.info("Injecting %d fewshot examples (vector-matched, system prompt)", n_examples)
+            conv_log.log_fewshot(conv_id, n_examples, fewshot_msgs)
+            ref_parts = []
+            for i in range(0, len(fewshot_msgs), 2):
+                user_msg = fewshot_msgs[i]["content"]
+                asst_msg = fewshot_msgs[i + 1]["content"]
+                ref_parts.append(f"User: {user_msg}\n{get_ai_name(ctx)}: {asst_msg}")
+            ctx["system_prompt"] += (
+                "\n\nVoice reference (match this tone and style, NOT the scene content"
+                " — these are from different scenes):\n"
+                + "\n---\n".join(ref_parts)
+            )
 
         ctx["_injection_alloc"] = alloc
 


### PR DESCRIPTION
## Summary
- Fewshot examples were spliced into `ctx["messages"]` as fake conversation history — the model treated them as "what happened earlier," importing scene details (rain, towels, shivering) from other scenarios
- Root cause of conv 131 contamination: vector-matched examples from conv 128-130 (rain crisis scenario) injected into a first-date scenario, making the model write about Amber being wet/cold
- Now formats fewshot as labeled voice references in the system prompt with "match this tone and style, NOT the scene content — these are from different scenes"
- Preserves dynamic voice matching while eliminating cross-scenario contamination

## Test plan
```bash
cd /mnt/d/prg/plum-rp-fewshot-system
source /mnt/d/prg/plum/projects/aiserver/.venv/bin/activate
python -m pytest projects/rp/tests/ -x -q
# 463 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)