### PR TITLE
fix(rp): strip card system prompt from greeting generation

### DIFF
--- a/projects/rp/routes.py
+++ b/projects/rp/routes.py
@@ -532,10 +532,8 @@ def setup(app: FastAPI, ollama, resolve_model=None):
         char_name = ai_data.get("name", "Character")
         user_name = user_data.get("name", "User")
 
-        # Build the generation prompt
         scenario_desc = (scenario or {}).get("description", "")
         style_reference = ai_data.get("first_mes", "")
-        system_prompt = ai_data.get("system_prompt", "")
         description = ai_data.get("description", "")
         personality = ai_data.get("personality", "")
 
@@ -548,33 +546,38 @@ def setup(app: FastAPI, ollama, resolve_model=None):
                     .replace("${char}", char_name))
 
         prompt_parts = []
-        if system_prompt:
-            prompt_parts.append(_expand_vars(system_prompt))
         if description:
             prompt_parts.append(f"Character: {_expand_vars(description)}")
         if personality:
             prompt_parts.append(f"Personality: {_expand_vars(personality)}")
 
-        prompt_parts.append(
-            f"\nWrite the opening scene for a roleplay conversation. "
-            f"Write as {char_name} in third person (e.g. \"{char_name} stepped forward\", not \"I stepped forward\"). "
-            f"Match the voice and style demonstrated below."
-        )
         if scenario_desc:
-            prompt_parts.append(f"\nScenario to set up:\n{_expand_vars(scenario_desc)}")
-        else:
-            prompt_parts.append(f"\nSet up a natural opening scene where {char_name} and {user_name} encounter each other.")
-
-        if style_reference:
             prompt_parts.append(
-                f"\nStyle reference (match this prose register, voice, and level of detail — "
-                f"do NOT copy the content, write a NEW scene for the scenario above):\n{_expand_vars(style_reference)}"
+                f"Scenario (follow this EXACTLY — who is where, who arrives, "
+                f"who is already present):\n{_expand_vars(scenario_desc)}"
+            )
+            prompt_parts.append(
+                f"Write the opening scene that sets up this scenario. "
+                f"Write as {char_name} in third person (e.g. \"{char_name} stepped forward\", "
+                f"not \"I stepped forward\")."
+            )
+        else:
+            prompt_parts.append(
+                f"Write a natural opening scene where {char_name} and {user_name} encounter each other. "
+                f"Write as {char_name} in third person (e.g. \"{char_name} stepped forward\", "
+                f"not \"I stepped forward\")."
             )
 
         prompt_parts.append(
-            f"\nWrite ONLY {char_name}'s opening. Do not write {user_name}'s actions or dialogue. "
-            f"300-500 words."
+            f"Write ONLY {char_name}'s actions, thoughts, and dialogue. "
+            f"Do not write {user_name}'s actions or dialogue. 300-500 words."
         )
+
+        if style_reference:
+            prompt_parts.append(
+                f"Style reference (match this prose register, voice, and level of detail — "
+                f"do NOT copy the content, write a NEW scene for the scenario above):\n{_expand_vars(style_reference)}"
+            )
 
         full_prompt = "\n\n".join(prompt_parts)
         model = _resolve_model(conv["model"])

--- a/projects/rp/tests/test_routes.py
+++ b/projects/rp/tests/test_routes.py
@@ -326,6 +326,7 @@ class IntegrationStubOllama:
         }
 
     async def generate(self, model, prompt, system=None, options=None):
+        self.last_generate_prompt = prompt
         return self.generate_response
 
     async def count_generate_prompt(self, model, prompt, system=None):
@@ -612,6 +613,40 @@ class TestConversations:
         resp = await client.get("/rp/conversations")
         assert resp.status_code == 200
         assert len(resp.json()) >= 1
+
+    @pytest.mark.asyncio
+    async def test_greeting_prompt_excludes_card_system_prompt(
+        self, client, fake_db, stub_ollama,
+    ):
+        card_system = "You are writing a roleplay where you are Alice. SYSTEM_SENTINEL"
+        scenario_text = "Alice visits Bob's apartment. Alice rings the doorbell."
+        user = await fake_db.create_card("Bob", {"data": {"name": "Bob"}})
+        ai = await fake_db.create_card("Alice", {
+            "data": {
+                "name": "Alice",
+                "description": "A test character",
+                "personality": "Friendly",
+                "system_prompt": card_system,
+                "first_mes": "",
+                "mes_example": "",
+            }
+        })
+        scenario = await fake_db.create_scenario(
+            "Test", scenario_text, {}, first_message="",
+        )
+        stub_ollama.generate_response = "Alice stood at the door."
+
+        await client.post("/rp/conversations", json={
+            "user_card_id": user["id"],
+            "ai_card_id": ai["id"],
+            "scenario_id": scenario["id"],
+            "model": "test-model",
+        })
+
+        prompt = stub_ollama.last_generate_prompt
+        assert "SYSTEM_SENTINEL" not in prompt
+        assert scenario_text in prompt
+        assert "EXACTLY" in prompt
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Removed the full card `system_prompt` from `_generate_first_message()` — it's a conversation-mode instruction block (example dialogues, tool defs, genre/tone) that drowns the scenario instruction
- The greeting prompt now uses only `description`, `personality`, and `scenario_desc` with an explicit "follow this EXACTLY" directive for spatial/role setup
- Style reference moved after format requirements so it doesn't override the scenario

Fixes the role inversion in conv 131 where the model generated Amber as the host instead of the visitor, despite the scenario clearly stating "Amber rings the bell to Valentina's apartment."

## Test plan
```bash
cd /mnt/d/prg/plum-rp-greeting-prompt
# Run tests (464 pass, 1 new)
PYTHONPATH=projects projects/aiserver/.venv/bin/python -m pytest projects/rp/tests/ -x -q

# New test verifies:
# - Card system_prompt is NOT in the generate() prompt
# - Scenario text IS in the prompt
# - "EXACTLY" directive is present
PYTHONPATH=projects projects/aiserver/.venv/bin/python -m pytest projects/rp/tests/test_routes.py::TestConversations::test_greeting_prompt_excludes_card_system_prompt -xvs

# Manual: restart server, create new conv with Amber/Valentina scenario
# Verify greeting has Amber as VISITOR (ringing bell), not host (opening door)
# Clear cached greeting first if needed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)