### PR TITLE
feat(rp): Anthropic API routing + arc tracking + scene state fixes

### DIFF
--- a/projects/aiserver/anthropic_client.py
+++ b/projects/aiserver/anthropic_client.py
@@ -1,0 +1,160 @@
+"""Anthropic API client matching the OllamaClient interface for drop-in routing."""
+
+import os
+import logging
+from typing import AsyncGenerator
+
+import anthropic
+
+from ollama import OllamaError
+
+_log = logging.getLogger("aiserver.anthropic")
+
+ANTHROPIC_MODELS = frozenset({
+    "claude-opus-4-7",
+    "claude-sonnet-4-6",
+    "claude-haiku-4-5-20251001",
+})
+
+DEFAULT_MAX_TOKENS = 1024
+
+
+def is_anthropic_model(model: str) -> bool:
+    return model in ANTHROPIC_MODELS
+
+
+def _map_options(options: dict | None) -> dict:
+    """Map Ollama-style options to Anthropic API params."""
+    if not options:
+        return {"max_tokens": DEFAULT_MAX_TOKENS}
+    params: dict = {}
+    params["max_tokens"] = options.get("num_predict", DEFAULT_MAX_TOKENS)
+    if "temperature" in options:
+        params["temperature"] = options["temperature"]
+    if "top_p" in options:
+        params["top_p"] = options["top_p"]
+    if "top_k" in options:
+        params["top_k"] = options["top_k"]
+    if stop := options.get("stop"):
+        params["stop_sequences"] = stop if isinstance(stop, list) else [stop]
+    return params
+
+
+def _split_system_and_messages(messages: list[dict]) -> tuple[str, list[dict]]:
+    """Extract system message from message list, return (system, remaining)."""
+    system_parts = []
+    chat_messages = []
+    for msg in messages:
+        if msg["role"] == "system":
+            system_parts.append(msg["content"])
+        else:
+            chat_messages.append({"role": msg["role"], "content": msg["content"]})
+    return "\n\n".join(system_parts), chat_messages
+
+
+class AnthropicClient:
+    """Async Anthropic client with the same interface as OllamaClient."""
+
+    def __init__(self):
+        api_key = os.environ.get("ANTHROPIC_API_KEY")
+        if not api_key:
+            raise OllamaError("ANTHROPIC_API_KEY not set")
+        self._client = anthropic.AsyncAnthropic(api_key=api_key)
+
+    async def chat_stream(
+        self,
+        model: str,
+        messages: list[dict],
+        options: dict | None = None,
+        stop: list[str] | None = None,
+    ) -> AsyncGenerator[dict, None]:
+        """Stream tokens from Anthropic. Yields same format as OllamaClient.chat_stream."""
+        system, chat_messages = _split_system_and_messages(messages)
+        params = _map_options(options)
+        if stop:
+            params["stop_sequences"] = stop
+
+        max_tokens = params.pop("max_tokens", DEFAULT_MAX_TOKENS)
+        total_tokens = 0
+
+        try:
+            async with self._client.messages.stream(
+                model=model,
+                messages=chat_messages,
+                system=system or anthropic.NOT_GIVEN,
+                max_tokens=max_tokens,
+                **params,
+            ) as stream:
+                async for event in stream:
+                    if event.type == "content_block_delta":
+                        if event.delta.type == "text_delta":
+                            total_tokens += 1
+                            yield {"token": event.delta.text, "thinking": False, "done": False}
+                        elif event.delta.type == "thinking_delta":
+                            total_tokens += 1
+                            yield {"token": event.delta.thinking, "thinking": True, "done": False}
+
+                final = await stream.get_final_message()
+                input_tokens = final.usage.input_tokens
+                output_tokens = final.usage.output_tokens
+                yield {
+                    "token": "",
+                    "done": True,
+                    "total_tokens": output_tokens,
+                    "tokens_per_second": 0,
+                    "input_tokens": input_tokens,
+                    "output_tokens": output_tokens,
+                }
+        except anthropic.APIError as e:
+            raise OllamaError(f"Anthropic API error: {e}") from e
+
+    async def generate(
+        self,
+        model: str,
+        prompt: str,
+        system: str | None = None,
+        options: dict | None = None,
+    ) -> str:
+        """Non-streaming generation. Maps prompt to a single user message."""
+        messages = [{"role": "user", "content": prompt}]
+        if system:
+            messages.insert(0, {"role": "system", "content": system})
+        tokens = []
+        async for chunk in self.chat_stream(model=model, messages=messages, options=options):
+            if not chunk.get("thinking") and not chunk.get("done"):
+                tokens.append(chunk["token"])
+        return "".join(tokens)
+
+    async def chat(
+        self,
+        model: str,
+        messages: list[dict],
+        tools: list[dict] | None = None,
+        think: bool | None = None,
+        options: dict | None = None,
+    ) -> dict:
+        """Non-streaming chat. Returns dict compatible with OllamaClient.chat."""
+        system, chat_messages = _split_system_and_messages(messages)
+        params = _map_options(options)
+        max_tokens = params.pop("max_tokens", DEFAULT_MAX_TOKENS)
+
+        try:
+            response = await self._client.messages.create(
+                model=model,
+                messages=chat_messages,
+                system=system or anthropic.NOT_GIVEN,
+                max_tokens=max_tokens,
+                **params,
+            )
+            content = "".join(
+                block.text for block in response.content if block.type == "text"
+            )
+            return {
+                "message": {"role": "assistant", "content": content},
+                "done": True,
+                "total_duration": 0,
+                "eval_count": response.usage.output_tokens,
+                "prompt_eval_count": response.usage.input_tokens,
+            }
+        except anthropic.APIError as e:
+            raise OllamaError(f"Anthropic API error: {e}") from e

--- a/projects/aiserver/config.json
+++ b/projects/aiserver/config.json
@@ -10,7 +10,9 @@
     "q8": "qwen3:8b",
     "q25": "qwen2.5:7b-instruct-q3_K_M",
     "q36": "qwen3.6:35b",
-    "nemo": "mistral-nemo"
+    "nemo": "mistral-nemo",
+    "opus": "claude-opus-4-7",
+    "sonnet": "claude-sonnet-4-6"
   },
   "default_options": {
     "temperature": 0.7,

--- a/projects/aiserver/main.py
+++ b/projects/aiserver/main.py
@@ -27,10 +27,12 @@ from models import (  # noqa: E402
     StatsResponse,
 )
 from ollama import OllamaClient, OllamaError  # noqa: E402
+from multi_client import MultiClient  # noqa: E402
 
 
 config = Config()
-ollama = OllamaClient(base_url=config.ollama_url)
+_raw_ollama = OllamaClient(base_url=config.ollama_url)
+ollama = MultiClient(_raw_ollama)
 
 # Server identity
 _started_at = datetime.now(timezone.utc).isoformat()
@@ -161,13 +163,23 @@ async def health():
     available = await ollama.is_available()
     models = []
     if available:
-        # Build reverse alias map: full_name -> alias
         reverse_aliases = {v: k for k, v in config.aliases.items()}
         for m in await ollama.list_models_detail():
             models.append(ModelInfo(
                 alias=reverse_aliases.get(m["name"]),
                 **m,
             ))
+    from anthropic_client import ANTHROPIC_MODELS
+    reverse_aliases = {v: k for k, v in config.aliases.items()}
+    for name in sorted(ANTHROPIC_MODELS):
+        models.append(ModelInfo(
+            name=name,
+            alias=reverse_aliases.get(name),
+            parameter_size="",
+            quantization_level="api",
+            size_bytes=0,
+            supports_think=True,
+        ))
     return HealthResponse(
         status="ok" if available else "ollama_unavailable",
         ollama_connected=available,

--- a/projects/aiserver/multi_client.py
+++ b/projects/aiserver/multi_client.py
@@ -1,0 +1,104 @@
+"""Routing layer that dispatches to Ollama or Anthropic based on model name."""
+
+import logging
+from typing import AsyncGenerator
+
+from ollama import OllamaClient
+from anthropic_client import AnthropicClient, is_anthropic_model, ANTHROPIC_MODELS
+
+_log = logging.getLogger("aiserver.multi")
+
+
+class MultiClient:
+    """Drop-in replacement for OllamaClient that routes Anthropic models to their API."""
+
+    def __init__(self, ollama: OllamaClient):
+        self._ollama = ollama
+        self._anthropic: AnthropicClient | None = None
+
+    def _get_anthropic(self) -> AnthropicClient:
+        if self._anthropic is None:
+            self._anthropic = AnthropicClient()
+            _log.info("Anthropic client initialized")
+        return self._anthropic
+
+    def _backend(self, model: str):
+        if is_anthropic_model(model):
+            return self._get_anthropic()
+        return self._ollama
+
+    @property
+    def base_url(self) -> str:
+        return self._ollama.base_url
+
+    async def chat_stream(
+        self,
+        model: str,
+        messages: list[dict],
+        options: dict | None = None,
+        stop: list[str] | None = None,
+    ) -> AsyncGenerator[dict, None]:
+        backend = self._backend(model)
+        async for chunk in backend.chat_stream(model=model, messages=messages,
+                                               options=options, stop=stop):
+            yield chunk
+
+    async def generate_stream(self, model: str, prompt: str, **kwargs) -> AsyncGenerator[dict, None]:
+        if is_anthropic_model(model):
+            backend = self._get_anthropic()
+            messages = [{"role": "user", "content": prompt}]
+            system = kwargs.get("system")
+            if system:
+                messages.insert(0, {"role": "system", "content": system})
+            options = kwargs.get("options")
+            async for chunk in backend.chat_stream(model=model, messages=messages, options=options):
+                yield chunk
+        else:
+            async for chunk in self._ollama.generate_stream(model, prompt, **kwargs):
+                yield chunk
+
+    async def generate(
+        self,
+        model: str,
+        prompt: str,
+        system: str | None = None,
+        options: dict | None = None,
+    ) -> str:
+        return await self._backend(model).generate(model=model, prompt=prompt,
+                                                   system=system, options=options)
+
+    async def chat(
+        self,
+        model: str,
+        messages: list[dict],
+        tools: list[dict] | None = None,
+        think: bool | None = None,
+        options: dict | None = None,
+    ) -> dict:
+        if is_anthropic_model(model) and options and options.get("num_predict", 0) <= 1:
+            total_chars = sum(len(m.get("content", "")) for m in messages)
+            return {"prompt_eval_count": total_chars // 4, "message": {"content": ""}, "done": True}
+        return await self._backend(model).chat(model=model, messages=messages,
+                                               tools=tools, think=think, options=options)
+
+    async def count_generate_prompt(self, model: str, prompt: str,
+                                    system: str | None = None) -> int:
+        if is_anthropic_model(model):
+            return len(prompt) // 4
+        return await self._ollama.count_generate_prompt(model, prompt, system=system)
+
+    async def list_models(self) -> list[str]:
+        models = await self._ollama.list_models()
+        models.extend(ANTHROPIC_MODELS)
+        return models
+
+    async def list_models_detail(self) -> list[dict]:
+        return await self._ollama.list_models_detail()
+
+    async def is_available(self) -> bool:
+        return await self._ollama.is_available()
+
+    async def get_num_ctx(self, model: str) -> int:
+        if is_anthropic_model(model):
+            return 200000
+        return await self._ollama.get_num_ctx(model)

--- a/projects/aiserver/requirements.txt
+++ b/projects/aiserver/requirements.txt
@@ -2,3 +2,4 @@ fastapi>=0.115.0
 uvicorn>=0.34.0
 httpx>=0.28.0
 websockets>=14.0
+anthropic>=0.100.0

--- a/projects/rp/pipeline.py
+++ b/projects/rp/pipeline.py
@@ -496,7 +496,6 @@ def create_default_pipeline() -> Pipeline:
     p.add_pre(expand_variables)
     p.add_pre(select_style)
     p.add_pre(detect_pov)
-    p.add_pre(inject_tools)
     p.add_post(clean_response)
     p.add_post(enforce_pronouns)
     p.add_post(check_stock_phrases)

--- a/projects/rp/routes.py
+++ b/projects/rp/routes.py
@@ -599,7 +599,7 @@ def setup(app: FastAPI, ollama, resolve_model=None):
             clean = clean[len(char_name) + 1:].strip()
         return clean
 
-    _scene_state_model = "q36"
+    _scene_state_model = "qwen3:14b"
 
     async def _generate_scene_state(model: str, messages: list[dict], previous_state: str = "",
                                      ai_name: str = "Character", user_name: str = "User",

--- a/projects/rp/scene_state.py
+++ b/projects/rp/scene_state.py
@@ -21,7 +21,7 @@ _STOPWORDS = frozenset({
     "now", "still", "also", "about", "up", "down",
 })
 
-_SKIP_VALIDATION = frozenset({"mood", "voice"})
+_SKIP_VALIDATION = frozenset({"mood", "voice", "arc"})
 
 _STRIP_CATEGORIES = frozenset({"personality", "character", "background", "description"})
 
@@ -99,6 +99,8 @@ def build_scene_state_prompt(messages: list[dict], previous_state: str = "",
         "Position: (posture, who is where, physical contact)\n"
         "Props: (objects currently in play)\n"
         "Mood: (what characters feel right now — use neutral terms; avoid sexually-charged words like 'charged' or 'electric' unless characters are explicitly intimate)\n"
+        "Arc: (where the emotional/romantic dynamic currently stands between the characters — what feelings are present, "
+        "what's unspoken, and what would feel like a natural next beat. Describe state, not rules.)\n"
         "ONLY state facts explicitly shown or described in the messages. Do NOT invent or assume details not present.\n"
         f"{clothing_instruction}"
         "No narration, no story, no explanation. Just the current facts.\n\n"


### PR DESCRIPTION
## Summary
- **Anthropic API routing**: `MultiClient` wraps `OllamaClient` and routes `claude-*` model names to the Anthropic streaming API. Token counting uses char/4 estimate to avoid wasteful API calls. Aliases: `opus` → `claude-opus-4-7`, `sonnet` → `claude-sonnet-4-6`
- **Arc tracking in scene state**: New `Arc` field describes where the emotional/romantic dynamic stands between characters — descriptive, not prescriptive, so the RP model can advance the arc organically without hard gates
- **Removed tools injection**: `inject_tools` removed from pipeline (was adding wiki tool descriptions to every prompt)
- **Scene state model**: Changed from `q36` (unavailable, causing silent failures) to `qwen3:14b`

## Test plan
```bash
cd /mnt/d/prg/plum-rp-anthropic-client
source /mnt/d/prg/plum/projects/aiserver/.venv/bin/activate

# Install new dependency
pip install anthropic>=0.100.0

# Run all tests
python -m pytest projects/rp/tests/ -x -q
python -m pytest projects/aiserver/tests/ -x -q

# Verify Anthropic routing (needs ANTHROPIC_API_KEY in .env)
# Start server, then:
curl http://127.0.0.1:8080/health | python3 -m json.tool
# Should show claude-opus-4-7 and claude-sonnet-4-6 in available_models

# Test with RP: create a conversation with model "opus" or "claude-opus-4-7"
# Verify scene state populates after each message (check DB: SELECT scene_state FROM rp_conversations WHERE id=N)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)