### PR TITLE
fix(rp): prevent Arc field from amplifying hallucinations

### DIFF
--- a/projects/rp/routes.py
+++ b/projects/rp/routes.py
@@ -621,7 +621,8 @@ def setup(app: FastAPI, ollama, resolve_model=None):
             _log.error("Scene state generation failed: %s", e)
             return previous_state
         clean = clean_scene_state_response(result)
-        return validate_scene_state(clean, previous_state, messages)
+        return validate_scene_state(clean, previous_state, messages,
+                                    character_names=[ai_name, user_name])
 
     async def _auto_update_scene_state(conv_id: int, model: str,
                                         ai_name: str = "Character", user_name: str = "User",

--- a/projects/rp/scene_state.py
+++ b/projects/rp/scene_state.py
@@ -21,7 +21,7 @@ _STOPWORDS = frozenset({
     "now", "still", "also", "about", "up", "down",
 })
 
-_SKIP_VALIDATION = frozenset({"mood", "voice", "arc"})
+_SKIP_VALIDATION = frozenset({"mood", "voice"})
 
 _STRIP_CATEGORIES = frozenset({"personality", "character", "background", "description"})
 
@@ -99,8 +99,7 @@ def build_scene_state_prompt(messages: list[dict], previous_state: str = "",
         "Position: (posture, who is where, physical contact)\n"
         "Props: (objects currently in play)\n"
         "Mood: (what characters feel right now — use neutral terms; avoid sexually-charged words like 'charged' or 'electric' unless characters are explicitly intimate)\n"
-        "Arc: (where the emotional/romantic dynamic currently stands between the characters — what feelings are present, "
-        "what's unspoken, and what would feel like a natural next beat. Describe state, not rules.)\n"
+        "Arc: (what each character explicitly said or did that reveals their feelings toward the other — quote or paraphrase actual actions/dialogue only, never infer hidden emotions)\n"
         "ONLY state facts explicitly shown or described in the messages. Do NOT invent or assume details not present.\n"
         f"{clothing_instruction}"
         "No narration, no story, no explanation. Just the current facts.\n\n"
@@ -173,6 +172,7 @@ def validate_scene_state(
     new_state: str,
     previous_state: str,
     messages: list[dict],
+    character_names: list[str] | None = None,
 ) -> str:
     """Revert scene state categories that changed without evidence in messages."""
     if not previous_state.strip():
@@ -192,8 +192,12 @@ def validate_scene_state(
 
     old = parse_scene_state(previous_state)
 
+    name_words = set()
+    for name in (character_names or []):
+        name_words.update(w.lower() for w in name.split() if len(w) >= 3)
+
     msg_text = " ".join(m.get("content", "") for m in messages)
-    msg_words = _extract_content_words(msg_text)
+    msg_words = _extract_content_words(msg_text) - name_words
 
     validated: dict[str, str] = {}
 
@@ -222,8 +226,8 @@ def validate_scene_state(
             validated[cat] = old_val
             continue
 
-        new_words = _extract_content_words(new_val)
-        old_words = _extract_content_words(old_val) if old_val else set()
+        new_words = _extract_content_words(new_val) - name_words
+        old_words = (_extract_content_words(old_val) - name_words) if old_val else set()
         added_words = new_words - old_words
 
         if not added_words or _has_evidence(added_words, msg_words):


### PR DESCRIPTION
## Summary
- Remove Arc from `_SKIP_VALIDATION` so hallucinated content gets evidence-checked
- Rewrite Arc prompt to require explicit actions/dialogue only, forbidding inferred emotions
- Exclude character names from evidence word matching (they create false positives since names appear in both scene state and messages)

## Root cause
The scene state generator (qwen3:14b) was inventing interpretive subtext in the Arc field (e.g. "the past she thought was buried") not supported by actual message content. This was then injected as `[Current Scene State — do NOT contradict this]`, forcing the RP model to confabulate backstory to satisfy it. The feedback loop amplified across turns, producing 400-word run-on monologues of hallucinated inner monologue.

## Test plan
```bash
cd /mnt/d/prg/plum-fix-arc-hallucination-loop
python3 -m pytest projects/rp/tests/ -x -q
# 467 passed

# Manual verification:
python3 -c "
import sys; sys.path.insert(0, 'projects/rp')
from scene_state import validate_scene_state

# Hallucinated Arc should be blocked
prev = 'Location: apt\nMood: tense'
new = prev + '\nArc: Unresolved history, facing the past she thought was buried'
msgs = [{'role':'assistant','content':'She stood there shivering.'}]
result = validate_scene_state(new, prev, msgs, character_names=['Amber','Valentina'])
assert 'Arc' not in result, 'Hallucinated Arc should be reverted'

# Evidenced Arc should pass
prev2 = 'Location: apt\nArc: friends'
new2 = 'Location: apt\nArc: Amber confessed love'
msgs2 = [{'role':'assistant','content':'I love you, Val. I always have.'}]
result2 = validate_scene_state(new2, prev2, msgs2, character_names=['Amber','Valentina'])
assert 'confessed' in result2, 'Evidenced Arc should be kept'
print('All assertions passed')
"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)