### PR TITLE
fix(rp): include all style items every turn

### DIFF
--- a/projects/rp/pipeline.py
+++ b/projects/rp/pipeline.py
@@ -114,7 +114,7 @@ When {{user}} is vulnerable, {{char}} does NOT respond like a therapist. Real pe
 Let the scene's weight shape how {{char}}'s traits come through. A joker caught in a vulnerable moment still deflects — but the humor cracks, the timing slips, the mask doesn't quite fit. Play traits at the intensity the situation earns, not at full volume every turn."""
 
 
-STYLE_ITEMS_PER_TURN = 3
+STYLE_ITEMS_PER_TURN = 32
 
 
 def _split_template(template: str) -> tuple[str, str, str, str]:

--- a/projects/rp/tests/test_pipeline.py
+++ b/projects/rp/tests/test_pipeline.py
@@ -225,10 +225,10 @@ class TestSelectStyle:
         ctx = {"post_prompt": "", "_style_pool": pool, "messages": []}
         select_style(ctx)
         selected = [item for item in pool if item in ctx["post_prompt"]]
-        assert len(selected) == STYLE_ITEMS_PER_TURN
+        assert len(selected) == min(STYLE_ITEMS_PER_TURN, len(pool))
 
     def test_rotates_with_message_count(self):
-        pool = [f"Item {i}" for i in range(6)]
+        pool = [f"Item {i}" for i in range(60)]
         results = []
         for n_msgs in range(6):
             ctx = {"post_prompt": "", "_style_pool": list(pool),
@@ -381,7 +381,7 @@ class TestSelectStyleWithSceneState:
         assert "Restraint rule" in ctx["post_prompt"]
         general_count = sum(1 for g in ["Gen A", "Gen B", "Gen C", "Gen D"]
                            if g in ctx["post_prompt"])
-        assert general_count == STYLE_ITEMS_PER_TURN
+        assert general_count == min(STYLE_ITEMS_PER_TURN, 4)
 
     def test_no_scene_pool_works_like_before(self):
         ctx = {


### PR DESCRIPTION
## Summary
- Bump `STYLE_ITEMS_PER_TURN` from 3 to 32, effectively including all style items every turn
- Update tests to handle pool sizes smaller than the limit

## Root cause
The style rotation (introduced with scene-style conditionals) reduced style items from all 12 to 3 per turn. Critical anti-verbosity guidelines ("never explain what a moment means", "keep dialogue natural and brief", "not a romance novel narrator") were absent most turns, causing Mag-Mell to default to verbose inner monologue. Pre-rotation conversations had all items and produced significantly better output.

## Test plan
```bash
cd /mnt/d/prg/plum-fix-style-items
python3 -m pytest projects/rp/tests/ -x -q
# 467 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)