### PR TITLE
fix(rp): bump chat temperature to 1.1

### DIFF
--- a/projects/rp/prompt_builder.py
+++ b/projects/rp/prompt_builder.py
@@ -20,7 +20,7 @@ _log = logging.getLogger("rp.prompt_builder")
 CHAT_DEFAULTS = {
     "num_predict": 768,
     "num_ctx": 16384,
-    "temperature": 1.05,
+    "temperature": 1.1,
     "repeat_penalty": 1.08,
     "repeat_last_n": 512,
     "frequency_penalty": 0.1,


### PR DESCRIPTION
## Summary
- Bumps `CHAT_DEFAULTS["temperature"]` from 1.05 to 1.1
- Paired with local prompt.md style rewrite (prohibitions → positive directives) — slightly higher temp encourages bolder, more varied output

## Test plan
- [x] All 467 rp tests pass
- [ ] Start new conversation with Mag-Mell, verify output is less flat/safe than conv 142

🤖 Generated with [Claude Code](https://claude.com/claude-code)