### PR TITLE
fix(rp): dynamic response length scaling

### DIFF
--- a/projects/rp/pipeline.py
+++ b/projects/rp/pipeline.py
@@ -102,6 +102,7 @@ Write only {{char}}'s next response. Stay in character. Do not narrate {{user}}'
 Each character has distinct physical traits — use the correct details for the correct person. Do not blend or swap attributes between {{char}} and {{user}}.
 Vary response length to match the beat — a gut-punch moment can be two lines; a vulnerable confession can breathe longer. Don't default to the same length every time.
 Match {{user}}'s tone and energy. If {{user}} is being casual or caring, respond in kind — do not escalate to sexual tension unless {{user}} is clearly initiating it. Nudity and physical proximity are not inherently sexual. Read the scene, not the setup.
+Don't spend the entire response inside {{char}}'s head. Anchor inner thought to physical action — if they're thinking, they're also doing something: shifting weight, fidgeting, avoiding eye contact, moving. Pure stream-of-consciousness with no dialogue or action is not a response.
 
 ## style
 Describe bodies naturally when clothing state calls for it — anatomy is not inherently sexual. If a character is undressed, describe what is visible: shape, skin, scars, weight, muscle, breasts, everything. Avoidance is more conspicuous than honesty.

--- a/projects/rp/prompt_builder.py
+++ b/projects/rp/prompt_builder.py
@@ -95,8 +95,9 @@ def build_ollama_options(settings: dict) -> dict:
 
 
 def scale_num_predict(opts: dict, user_message: str) -> dict:
+    base = opts.get("num_predict", CHAT_DEFAULTS["num_predict"])
     user_tokens = count_tokens(user_message)
-    scaled = max(1024, min(2048, user_tokens * 2))
+    scaled = max(384, min(base, user_tokens * 3))
     return {**opts, "num_predict": scaled}
 
 

--- a/projects/rp/tests/test_prompt_builder.py
+++ b/projects/rp/tests/test_prompt_builder.py
@@ -135,14 +135,23 @@ class TestBuildOllamaOptions:
 
 
 class TestScaleNumPredict:
-    def test_short_message(self):
+    def test_short_message_hits_floor(self):
         opts = scale_num_predict({"num_predict": 768}, "hi")
-        assert opts["num_predict"] == 1024
+        assert opts["num_predict"] == 384
 
-    def test_long_message(self):
+    def test_medium_message_scales(self):
+        msg = "word " * 200
+        opts = scale_num_predict({"num_predict": 768}, msg)
+        assert 384 < opts["num_predict"] <= 768
+
+    def test_long_message_hits_base(self):
         long_msg = "word " * 5000
         opts = scale_num_predict({"num_predict": 768}, long_msg)
-        assert opts["num_predict"] == 2048
+        assert opts["num_predict"] == 768
+
+    def test_uses_base_from_opts(self):
+        opts = scale_num_predict({"num_predict": 1024}, "word " * 5000)
+        assert opts["num_predict"] == 1024
 
     def test_preserves_other_keys(self):
         opts = scale_num_predict({"num_predict": 768, "temperature": 0.8}, "hello")


### PR DESCRIPTION
## Summary
- **scale_num_predict** formula changed from `max(1024, min(2048, tokens*2))` to `max(384, min(base, tokens*3))` — short user messages (typical in RP) now get 384 tokens instead of 1024, preventing 6-paragraph inner monologue responses to a 25-token input
- **Anti-monologue directive** added to `## post` section: "Don't spend the entire response inside char's head. Anchor inner thought to physical action."
- Uses opts `num_predict` as ceiling (default 768 from CHAT_DEFAULTS), so scenario overrides are respected

## Motivation
Conv 143 msg 5006: user writes 103 chars ("Amber, focus. Go into the bathroom..."), model responds with 2,775 chars of pure stream-of-consciousness inner monologue, zero dialogue. Root cause: `scale_num_predict` floor of 1024 tokens regardless of input length.

## Test plan
```bash
cd /mnt/d/prg/plum-rp-dynamic-response-length
source /mnt/d/prg/plum/projects/aiserver/.venv/bin/activate
PYTHONPATH="$PWD" pytest projects/rp/tests/ -x -v
# 482 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)