### PR TITLE
fix(rp): stop sequences and sentence truncation for clean endings

### DIFF
--- a/projects/rp/pipeline.py
+++ b/projects/rp/pipeline.py
@@ -257,16 +257,32 @@ def render_template(template: str, values: dict) -> str:
 
 # -- Built-in post-processing hooks --
 
+_SENTENCE_END = re.compile(r'[.!?…"\')’”]\s*$')
+
+
+def _truncate_to_sentence(text: str) -> str:
+    """Trim text back to the last complete sentence if it ends mid-sentence."""
+    if not text or _SENTENCE_END.search(text):
+        return text
+    for end_pat in (r'[.!?…]["\')’”]', r'[.!?…]'):
+        m = list(re.finditer(end_pat, text))
+        if m:
+            truncated = text[:m[-1].end()].rstrip()
+            if len(truncated) > len(text) * 0.3:
+                return truncated
+    return text
+
+
 def clean_response(ctx: dict) -> dict:
     """Strip common LLM artifacts from response."""
     response = ctx.get("response", "")
     response = response.strip()
-    # Strip AI name prefix if model echoes it (e.g. "Jessica: ..." or "Jessica Klein: ...")
     ai_name = ctx.get("ai_name", "")
     if ai_name and response.startswith(ai_name):
         after = response[len(ai_name):]
         if after.startswith(": "):
             response = after[2:]
+    response = _truncate_to_sentence(response)
     ctx["response"] = response
     return ctx
 

--- a/projects/rp/prompt_builder.py
+++ b/projects/rp/prompt_builder.py
@@ -97,7 +97,7 @@ def build_ollama_options(settings: dict) -> dict:
 def scale_num_predict(opts: dict, user_message: str) -> dict:
     base = opts.get("num_predict", CHAT_DEFAULTS["num_predict"])
     user_tokens = count_tokens(user_message)
-    scaled = max(384, min(base, user_tokens * 3))
+    scaled = max(512, min(base, user_tokens * 3))
     return {**opts, "num_predict": scaled}
 
 

--- a/projects/rp/routes.py
+++ b/projects/rp/routes.py
@@ -688,7 +688,7 @@ def setup(app: FastAPI, ollama, resolve_model=None):
         try:
             async for chunk in _ollama.chat_stream(
                 model=model, messages=chat_messages,
-                options=ollama_options, stop=[f"{user_name}:"],
+                options=ollama_options, stop=[f"{user_name}:", "\n\n\n"],
             ):
                 yield json.dumps(chunk) + "\n"
                 if chunk.get("done"):
@@ -840,7 +840,7 @@ def setup(app: FastAPI, ollama, resolve_model=None):
                 try:
                     async for chunk in _ollama.chat_stream(
                         model=model, messages=cur_messages,
-                        options=ollama_options, stop=[f"{user_name}:"],
+                        options=ollama_options, stop=[f"{user_name}:", "\n\n\n"],
                     ):
                         yield json.dumps(chunk) + "\n"
                         if chunk.get("done"):

--- a/projects/rp/tests/test_pipeline.py
+++ b/projects/rp/tests/test_pipeline.py
@@ -1,5 +1,7 @@
 import pytest  # noqa: F401
-from projects.rp.pipeline import assemble_prompt, expand_variables, render_template
+from projects.rp.pipeline import (
+    assemble_prompt, expand_variables, render_template, _truncate_to_sentence,
+)
 
 
 def _make_ctx(template="", scenario_desc="", ai_desc="", ai_personality="",
@@ -967,3 +969,32 @@ class TestPipelineClass:
         p.add_pre(async_hook)
         result = asyncio.run(p.run_pre({}))
         assert result["async_ran"] is True
+
+
+class TestTruncateToSentence:
+    def test_complete_sentence_unchanged(self):
+        assert _truncate_to_sentence("She walked away.") == "She walked away."
+
+    def test_ends_with_quote(self):
+        text = '"I know," she said.'
+        assert _truncate_to_sentence(text) == text
+
+    def test_trims_mid_sentence(self):
+        text = "She walked away. Then she turned and"
+        assert _truncate_to_sentence(text) == "She walked away."
+
+    def test_trims_to_closing_quote(self):
+        text = '"I told you already, I don\'t want to talk about it." She turned and'
+        assert _truncate_to_sentence(text) == '"I told you already, I don\'t want to talk about it."'
+
+    def test_empty_unchanged(self):
+        assert _truncate_to_sentence("") == ""
+
+    def test_ellipsis_counts_as_end(self):
+        text = "She paused... Then something"
+        assert _truncate_to_sentence(text) == "She paused..."
+
+    def test_no_truncation_if_too_short(self):
+        text = "Hi. Then she walked over to the counter and picked up the glass and started"
+        result = _truncate_to_sentence(text)
+        assert result == text

--- a/projects/rp/tests/test_prompt_builder.py
+++ b/projects/rp/tests/test_prompt_builder.py
@@ -137,12 +137,12 @@ class TestBuildOllamaOptions:
 class TestScaleNumPredict:
     def test_short_message_hits_floor(self):
         opts = scale_num_predict({"num_predict": 768}, "hi")
-        assert opts["num_predict"] == 384
+        assert opts["num_predict"] == 512
 
     def test_medium_message_scales(self):
         msg = "word " * 200
         opts = scale_num_predict({"num_predict": 768}, msg)
-        assert 384 < opts["num_predict"] <= 768
+        assert 512 < opts["num_predict"] <= 768
 
     def test_long_message_hits_base(self):
         long_msg = "word " * 5000


### PR DESCRIPTION
## Summary
- Raised `num_predict` floor from 384 → 512 (384 caused mid-sentence cutoffs in conv 144)
- Added `"\n\n\n"` stop sequence to both stream sites — model stops at paragraph boundaries instead of filling budget
- Added `_truncate_to_sentence()` in `clean_response` — if response still ends mid-sentence, trims back to last `.!?…` with closing quotes. Won't over-trim (30% minimum threshold)

## Test plan
```bash
cd /mnt/d/prg/plum-rp-response-truncation
source /mnt/d/prg/plum/projects/aiserver/.venv/bin/activate
PYTHONPATH="$PWD" pytest projects/rp/tests/ -x -v
# 489 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)