### PR TITLE
feat(rp): add lorebook (World Info) for keyword-triggered context injection

### DIFF
--- a/projects/rp/db.py
+++ b/projects/rp/db.py
@@ -615,3 +615,169 @@ async def get_latest_metrics(
         target_type, target_id, domain,
     )
     return dict(row) if row else None
+
+
+# -- Lorebook --
+
+_LOREBOOK_COLS = (
+    "id, card_id, name, scan_depth, token_budget, recursive_scan, enabled, "
+    "created_at::text, updated_at::text"
+)
+
+_ENTRY_COLS = (
+    "id, lorebook_id, name, keys, secondary_keys, content, enabled, constant, "
+    "selective, position, insertion_order, priority, comment, "
+    "created_at::text, updated_at::text"
+)
+
+
+async def get_lorebook_for_card(card_id: int) -> dict | None:
+    pool = await get_pool()
+    row = await pool.fetchrow(
+        f"SELECT {_LOREBOOK_COLS} FROM rp_lorebooks WHERE card_id = $1", card_id,
+    )
+    return dict(row) if row else None
+
+
+async def get_or_create_lorebook(card_id: int, name: str = "",
+                                  scan_depth: int = 10,
+                                  token_budget: int = 2048) -> dict:
+    pool = await get_pool()
+    row = await pool.fetchrow(
+        f"INSERT INTO rp_lorebooks (card_id, name, scan_depth, token_budget) "
+        f"VALUES ($1, $2, $3, $4) "
+        f"ON CONFLICT (card_id) DO UPDATE SET updated_at=NOW() "
+        f"RETURNING {_LOREBOOK_COLS}",
+        card_id, name, scan_depth, token_budget,
+    )
+    return dict(row)
+
+
+async def update_lorebook(lorebook_id: int, **kwargs) -> dict | None:
+    allowed = {"name", "scan_depth", "token_budget", "recursive_scan", "enabled"}
+    pool = await get_pool()
+    sets, params = [], [lorebook_id]
+    idx = 2
+    for col, val in kwargs.items():
+        if col in allowed and val is not None:
+            sets.append(f"{col}=${idx}")
+            params.append(val)
+            idx += 1
+    if not sets:
+        row = await pool.fetchrow(
+            f"SELECT {_LOREBOOK_COLS} FROM rp_lorebooks WHERE id = $1", lorebook_id)
+        return dict(row) if row else None
+    sets.append("updated_at=NOW()")
+    row = await pool.fetchrow(
+        f"UPDATE rp_lorebooks SET {', '.join(sets)} WHERE id = $1 "
+        f"RETURNING {_LOREBOOK_COLS}", *params,
+    )
+    return dict(row) if row else None
+
+
+async def get_lorebook_entries(lorebook_id: int) -> list[dict]:
+    pool = await get_pool()
+    rows = await pool.fetch(
+        f"SELECT {_ENTRY_COLS} FROM rp_lorebook_entries "
+        f"WHERE lorebook_id = $1 ORDER BY insertion_order, id",
+        lorebook_id,
+    )
+    return [dict(r) for r in rows]
+
+
+async def get_lorebook_entry(entry_id: int) -> dict | None:
+    pool = await get_pool()
+    row = await pool.fetchrow(
+        f"SELECT {_ENTRY_COLS} FROM rp_lorebook_entries WHERE id = $1", entry_id,
+    )
+    return dict(row) if row else None
+
+
+async def create_lorebook_entry(lorebook_id: int, **kwargs) -> dict:
+    pool = await get_pool()
+    row = await pool.fetchrow(
+        f"INSERT INTO rp_lorebook_entries "
+        f"(lorebook_id, name, keys, secondary_keys, content, enabled, constant, "
+        f"selective, position, insertion_order, priority, comment) "
+        f"VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12) "
+        f"RETURNING {_ENTRY_COLS}",
+        lorebook_id,
+        kwargs.get("name", ""),
+        kwargs.get("keys", []),
+        kwargs.get("secondary_keys", []),
+        kwargs.get("content", ""),
+        kwargs.get("enabled", True),
+        kwargs.get("constant", False),
+        kwargs.get("selective", False),
+        kwargs.get("position", "after_char"),
+        kwargs.get("insertion_order", 100),
+        kwargs.get("priority", 100),
+        kwargs.get("comment", ""),
+    )
+    return dict(row)
+
+
+async def update_lorebook_entry(entry_id: int, **kwargs) -> dict | None:
+    allowed = {"name", "keys", "secondary_keys", "content", "enabled", "constant",
+               "selective", "position", "insertion_order", "priority", "comment"}
+    pool = await get_pool()
+    sets, params = [], [entry_id]
+    idx = 2
+    for col, val in kwargs.items():
+        if col in allowed:
+            sets.append(f"{col}=${idx}")
+            params.append(val)
+            idx += 1
+    if not sets:
+        return await get_lorebook_entry(entry_id)
+    sets.append("updated_at=NOW()")
+    row = await pool.fetchrow(
+        f"UPDATE rp_lorebook_entries SET {', '.join(sets)} WHERE id = $1 "
+        f"RETURNING {_ENTRY_COLS}", *params,
+    )
+    return dict(row) if row else None
+
+
+async def delete_lorebook_entry(entry_id: int) -> bool:
+    pool = await get_pool()
+    result = await pool.execute(
+        "DELETE FROM rp_lorebook_entries WHERE id = $1", entry_id)
+    return result == "DELETE 1"
+
+
+async def delete_lorebook(lorebook_id: int) -> bool:
+    pool = await get_pool()
+    result = await pool.execute(
+        "DELETE FROM rp_lorebooks WHERE id = $1", lorebook_id)
+    return result == "DELETE 1"
+
+
+async def bulk_import_lorebook_entries(lorebook_id: int,
+                                        entries: list[dict]) -> int:
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        async with conn.transaction():
+            await conn.execute(
+                "DELETE FROM rp_lorebook_entries WHERE lorebook_id = $1",
+                lorebook_id,
+            )
+            for e in entries:
+                await conn.execute(
+                    "INSERT INTO rp_lorebook_entries "
+                    "(lorebook_id, name, keys, secondary_keys, content, enabled, "
+                    "constant, selective, position, insertion_order, priority, comment) "
+                    "VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)",
+                    lorebook_id,
+                    e.get("name", "") or "",
+                    e.get("keys", []) or [],
+                    e.get("secondary_keys", []) or [],
+                    e.get("content", "") or "",
+                    bool(e.get("enabled", True)),
+                    bool(e.get("constant", False)),
+                    bool(e.get("selective", False)),
+                    e.get("position", "after_char") or "after_char",
+                    int(e.get("insertion_order", 100)),
+                    int(e.get("priority", 100)),
+                    e.get("comment", "") or "",
+                )
+    return len(entries)

--- a/projects/rp/lorebook.py
+++ b/projects/rp/lorebook.py
@@ -1,0 +1,108 @@
+"""Lorebook (World Info) — keyword-triggered prompt injection.
+
+Entries stored in rp_lorebook_entries, matched against recent messages,
+injected into system_prompt based on position field.
+"""
+
+import logging
+from . import db
+from .tokenizer import count_tokens
+
+_log = logging.getLogger("rp.lorebook")
+
+
+def _keywords_match(text: str, keys: list[str]) -> bool:
+    haystack = text.lower()
+    return any(k and k.lower() in haystack for k in keys)
+
+
+def match_entries(entries: list[dict], messages: list[dict],
+                  scan_depth: int = 10) -> list[dict]:
+    """Return entries whose keywords appear in recent messages.
+
+    Constant entries always match. Selective entries require both primary
+    AND secondary key hits. Results sorted by insertion_order.
+    """
+    window = messages[-scan_depth:] if scan_depth > 0 else messages
+    combined = "\n".join(m.get("content", "") for m in window)
+
+    matched = []
+    for entry in entries:
+        if not entry.get("enabled", True):
+            continue
+        if not entry.get("content", "").strip():
+            continue
+
+        if entry.get("constant", False):
+            matched.append(entry)
+            continue
+
+        keys = entry.get("keys", [])
+        if not keys or not _keywords_match(combined, keys):
+            continue
+
+        if entry.get("selective", False):
+            secondary = entry.get("secondary_keys", [])
+            if secondary and not _keywords_match(combined, secondary):
+                continue
+
+        matched.append(entry)
+
+    matched.sort(key=lambda e: e.get("insertion_order", 100))
+    return matched
+
+
+def build_injection_text(matched_entries: list[dict]) -> tuple[str, str]:
+    """Split matched entries into (before_char, after_char) text blocks."""
+    before, after = [], []
+    for entry in matched_entries:
+        text = entry.get("content", "").strip()
+        if not text:
+            continue
+        if entry.get("position", "after_char") == "before_char":
+            before.append(text)
+        else:
+            after.append(text)
+    return "\n\n".join(before), "\n\n".join(after)
+
+
+async def inject_lorebook(ctx: dict) -> dict:
+    """Pipeline pre-hook: match lorebook entries and inject into system_prompt."""
+    ai_card = ctx.get("ai_card") or {}
+    card_id = ai_card.get("id")
+    if not card_id:
+        return ctx
+
+    lorebook = await db.get_lorebook_for_card(card_id)
+    if not lorebook or not lorebook.get("enabled", True):
+        return ctx
+
+    entries = await db.get_lorebook_entries(lorebook["id"])
+    if not entries:
+        return ctx
+
+    matched = match_entries(
+        entries, ctx.get("messages", []), lorebook.get("scan_depth", 10))
+    if not matched:
+        return ctx
+
+    before_text, after_text = build_injection_text(matched)
+
+    if before_text:
+        ctx["system_prompt"] = before_text + "\n\n" + ctx.get("system_prompt", "")
+    if after_text:
+        ctx["system_prompt"] = ctx.get("system_prompt", "") + "\n\n[World Info]\n" + after_text
+
+    names = [e.get("name") or (e.get("keys", ["?"])[0] if e.get("keys") else "?")
+             for e in matched]
+    ctx["_lorebook_injected"] = names
+    ctx["_lorebook_tokens"] = count_tokens(before_text + after_text)
+    _log.info("Lorebook: injected %d entries (%d tokens): %s",
+              len(matched), ctx["_lorebook_tokens"], names[:5])
+    return ctx
+
+
+def extract_character_book(card_data: dict) -> dict | None:
+    """Extract character_book from SillyTavern v2 card_data, or None."""
+    data = card_data.get("data", card_data)
+    return data.get("character_book") or None

--- a/projects/rp/models.py
+++ b/projects/rp/models.py
@@ -93,6 +93,48 @@ class AuthorsNoteRequest(BaseModel):
     depth: int = 4
 
 
+class LorebookEntryCreate(BaseModel):
+    name: str = ""
+    keys: list[str] = []
+    secondary_keys: list[str] = []
+    content: str = ""
+    enabled: bool = True
+    constant: bool = False
+    selective: bool = False
+    position: str = "after_char"
+    insertion_order: int = 100
+    priority: int = 100
+    comment: str = ""
+
+
+class LorebookEntryResponse(LorebookEntryCreate):
+    id: int
+    lorebook_id: int
+    created_at: str
+    updated_at: str
+
+
+class LorebookUpdate(BaseModel):
+    name: str | None = None
+    scan_depth: int | None = None
+    token_budget: int | None = None
+    recursive_scan: bool | None = None
+    enabled: bool | None = None
+
+
+class LorebookResponse(BaseModel):
+    id: int
+    card_id: int
+    name: str
+    scan_depth: int
+    token_budget: int
+    recursive_scan: bool
+    enabled: bool
+    entries: list[LorebookEntryResponse] = []
+    created_at: str
+    updated_at: str
+
+
 class CompareConfig(BaseModel):
     label: str = ""
     model: str | None = None

--- a/projects/rp/pipeline.py
+++ b/projects/rp/pipeline.py
@@ -554,8 +554,10 @@ def create_default_pipeline() -> Pipeline:
     needs access to the ollama client and resolved model name.
     """
     p = Pipeline()
+    from .lorebook import inject_lorebook
     p.add_pre(assemble_prompt)
     p.add_pre(expand_variables)
+    p.add_pre(inject_lorebook)
     p.add_pre(select_style)
     p.add_pre(detect_pov)
     p.add_post(clean_response)

--- a/projects/rp/routes.py
+++ b/projects/rp/routes.py
@@ -26,6 +26,7 @@ from .prompt_builder import (
     build_ollama_options, scale_num_predict, budget_to_json,
     build_pipeline_ctx, budget_ctx,
 )
+from .lorebook import extract_character_book
 from . import conv_log
 
 # Priority levels from aiserver's inference queue (lower = higher priority).
@@ -97,6 +98,17 @@ def setup(app: FastAPI, ollama, resolve_model=None):
             existing_scenario = await db.find_scenario_by_name(scenario_name)
             if not existing_scenario:
                 await db.create_scenario(scenario_name, scenario_text, {})
+        char_book = extract_character_book(card_data)
+        if char_book and char_book.get("entries"):
+            lorebook = await db.get_or_create_lorebook(
+                card["id"],
+                name=char_book.get("name", ""),
+                scan_depth=char_book.get("scan_depth", 10),
+                token_budget=char_book.get("token_budget", 2048),
+            )
+            await db.bulk_import_lorebook_entries(lorebook["id"], char_book["entries"])
+            _log.info("Imported %d lorebook entries for card %s",
+                      len(char_book["entries"]), name)
         return card
 
     @app.get("/rp/cards/{card_id}", response_model=CardResponse)
@@ -157,6 +169,75 @@ def setup(app: FastAPI, ollama, resolve_model=None):
         if not scenario_text.strip():
             raise HTTPException(400, "Card has no scenario text")
         return await db.create_scenario(card["name"] + " — Scenario", scenario_text, {})
+
+    # -- Lorebook --
+
+    from .models import (
+        LorebookEntryCreate, LorebookEntryResponse, LorebookUpdate, LorebookResponse,
+    )
+
+    @app.get("/rp/cards/{card_id}/lorebook", response_model=LorebookResponse)
+    async def get_lorebook(card_id: int):
+        card = await db.get_card(card_id)
+        if not card:
+            raise HTTPException(404, "Card not found")
+        lorebook = await db.get_lorebook_for_card(card_id)
+        if not lorebook:
+            lorebook = await db.get_or_create_lorebook(card_id)
+        entries = await db.get_lorebook_entries(lorebook["id"])
+        return {**lorebook, "entries": entries}
+
+    @app.put("/rp/cards/{card_id}/lorebook", response_model=LorebookResponse)
+    async def update_lorebook_settings(card_id: int, req: LorebookUpdate):
+        card = await db.get_card(card_id)
+        if not card:
+            raise HTTPException(404, "Card not found")
+        lorebook = await db.get_lorebook_for_card(card_id)
+        if not lorebook:
+            lorebook = await db.get_or_create_lorebook(card_id)
+        updated = await db.update_lorebook(lorebook["id"], **req.model_dump(exclude_none=True))
+        entries = await db.get_lorebook_entries(updated["id"])
+        return {**updated, "entries": entries}
+
+    @app.post("/rp/cards/{card_id}/lorebook/entries", response_model=LorebookEntryResponse)
+    async def create_entry(card_id: int, req: LorebookEntryCreate):
+        card = await db.get_card(card_id)
+        if not card:
+            raise HTTPException(404, "Card not found")
+        lorebook = await db.get_lorebook_for_card(card_id)
+        if not lorebook:
+            lorebook = await db.get_or_create_lorebook(card_id)
+        return await db.create_lorebook_entry(lorebook["id"], **req.model_dump())
+
+    @app.put("/rp/lorebook/entries/{entry_id}", response_model=LorebookEntryResponse)
+    async def update_entry(entry_id: int, req: LorebookEntryCreate):
+        result = await db.update_lorebook_entry(entry_id, **req.model_dump())
+        if not result:
+            raise HTTPException(404, "Entry not found")
+        return result
+
+    @app.delete("/rp/lorebook/entries/{entry_id}")
+    async def delete_entry(entry_id: int):
+        if not await db.delete_lorebook_entry(entry_id):
+            raise HTTPException(404, "Entry not found")
+        return {"ok": True}
+
+    @app.post("/rp/cards/{card_id}/lorebook/import")
+    async def reimport_lorebook(card_id: int):
+        card = await db.get_card(card_id)
+        if not card:
+            raise HTTPException(404, "Card not found")
+        char_book = extract_character_book(card["card_data"])
+        if not char_book or not char_book.get("entries"):
+            raise HTTPException(400, "No character_book in card data")
+        lorebook = await db.get_or_create_lorebook(
+            card_id,
+            name=char_book.get("name", ""),
+            scan_depth=char_book.get("scan_depth", 10),
+            token_budget=char_book.get("token_budget", 2048),
+        )
+        count = await db.bulk_import_lorebook_entries(lorebook["id"], char_book["entries"])
+        return {"ok": True, "imported": count}
 
     # -- Card Generation --
 
@@ -679,6 +760,9 @@ def setup(app: FastAPI, ollama, resolve_model=None):
         if ctx.get("_summary"):
             debug["debug_summary"] = ctx["_summary"]
             debug["debug_summary_through"] = ctx.get("_summary_through_sequence", 0)
+        if ctx.get("_lorebook_injected"):
+            debug["debug_lorebook"] = ctx["_lorebook_injected"]
+            debug["debug_lorebook_tokens"] = ctx.get("_lorebook_tokens", 0)
         if extra_debug:
             debug.update(extra_debug)
         yield json.dumps(debug) + "\n"

--- a/projects/rp/schema.sql
+++ b/projects/rp/schema.sql
@@ -215,3 +215,38 @@ CREATE TABLE IF NOT EXISTS rp_eval_metrics (
 
 CREATE INDEX IF NOT EXISTS idx_rp_eval_metrics_target
     ON rp_eval_metrics(target_type, target_id, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS rp_lorebooks (
+    id              SERIAL PRIMARY KEY,
+    card_id         INTEGER NOT NULL REFERENCES rp_character_cards(id) ON DELETE CASCADE,
+    name            TEXT NOT NULL DEFAULT '',
+    scan_depth      INTEGER NOT NULL DEFAULT 10,
+    token_budget    INTEGER NOT NULL DEFAULT 2048,
+    recursive_scan  BOOLEAN NOT NULL DEFAULT FALSE,
+    enabled         BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at      TIMESTAMPTZ DEFAULT NOW(),
+    updated_at      TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_rp_lorebooks_card ON rp_lorebooks(card_id);
+
+CREATE TABLE IF NOT EXISTS rp_lorebook_entries (
+    id              SERIAL PRIMARY KEY,
+    lorebook_id     INTEGER NOT NULL REFERENCES rp_lorebooks(id) ON DELETE CASCADE,
+    name            TEXT NOT NULL DEFAULT '',
+    keys            TEXT[] NOT NULL DEFAULT '{}',
+    secondary_keys  TEXT[] NOT NULL DEFAULT '{}',
+    content         TEXT NOT NULL DEFAULT '',
+    enabled         BOOLEAN NOT NULL DEFAULT TRUE,
+    constant        BOOLEAN NOT NULL DEFAULT FALSE,
+    selective       BOOLEAN NOT NULL DEFAULT FALSE,
+    position        TEXT NOT NULL DEFAULT 'after_char' CHECK (position IN ('before_char', 'after_char')),
+    insertion_order INTEGER NOT NULL DEFAULT 100,
+    priority        INTEGER NOT NULL DEFAULT 100,
+    comment         TEXT NOT NULL DEFAULT '',
+    created_at      TIMESTAMPTZ DEFAULT NOW(),
+    updated_at      TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_rp_lorebook_entries_book
+    ON rp_lorebook_entries(lorebook_id, insertion_order);

--- a/projects/rp/static/app.js
+++ b/projects/rp/static/app.js
@@ -639,6 +639,14 @@
             } else {
               $("underHoodSummaryContent").textContent = "No summary active.";
             }
+            if (chunk.debug_lorebook && chunk.debug_lorebook.length) {
+              $("underHoodLorebookContent").textContent =
+                "Injected " + chunk.debug_lorebook.length + " entries (" +
+                (chunk.debug_lorebook_tokens || 0) + " tokens):\n" +
+                chunk.debug_lorebook.join(", ");
+            } else {
+              $("underHoodLorebookContent").textContent = "No lorebook entries matched.";
+            }
             // Update bubble side if auto_role differs
             if (chunk.auto_role && chunk.auto_role !== streamRole) {
               streamRole = chunk.auto_role;
@@ -1222,7 +1230,12 @@
           });
         },
       });
+      const loreBtn = el("button", {
+        textContent: "Lorebook",
+        onClick: (e) => { e.stopPropagation(); openLorebook(card.id, card.name); },
+      });
       actions.appendChild(editBtn);
+      actions.appendChild(loreBtn);
       actions.appendChild(exportBtn);
       actions.appendChild(delBtn);
       tile.appendChild(actions);
@@ -1832,6 +1845,139 @@
   });
 
   // ---------------------------------------------------------------------------
+  // ---------------------------------------------------------------------------
+  // Lorebook
+  // ---------------------------------------------------------------------------
+  let lorebookCardId = null;
+  let lorebookData = null;
+  let editingEntryId = null;
+
+  async function openLorebook(cardId, cardName) {
+    lorebookCardId = cardId;
+    const panel = document.getElementById("lorebookPanel");
+    document.getElementById("lorebookTitle").textContent = (cardName || "Card") + " — Lorebook";
+    panel.style.display = "block";
+    lorebookData = await api("GET", "/rp/cards/" + cardId + "/lorebook");
+    document.getElementById("lorebookEnabled").checked = lorebookData.enabled;
+    document.getElementById("lorebookScanDepth").value = lorebookData.scan_depth;
+    renderLorebookEntries(lorebookData.entries || []);
+    closeEntryEditor();
+  }
+
+  function closeLorebook() {
+    document.getElementById("lorebookPanel").style.display = "none";
+    lorebookCardId = null;
+    lorebookData = null;
+  }
+
+  function renderLorebookEntries(entries) {
+    const container = document.getElementById("lorebookEntries");
+    while (container.firstChild) container.removeChild(container.firstChild);
+    if (!entries.length) {
+      container.appendChild(el("div", {
+        textContent: "No entries yet. Click + Entry to add one.",
+        style: "color:#8b949e;font-size:0.85em;padding:8px 0",
+      }));
+      return;
+    }
+    for (const entry of entries) {
+      const row = el("div", {
+        style: "display:flex;align-items:center;gap:8px;padding:6px 0;border-bottom:1px solid #21262d",
+      });
+      const toggle = el("input", { type: "checkbox", checked: entry.enabled });
+      toggle.addEventListener("change", async () => {
+        await api("PUT", "/rp/lorebook/entries/" + entry.id, { ...entry, enabled: toggle.checked });
+      });
+      const keys = (entry.keys || []).join(", ");
+      const label = el("span", {
+        textContent: (entry.name || keys || "(no keys)") + (entry.constant ? " [always]" : ""),
+        style: "flex:1;font-size:0.85em;color:" + (entry.enabled ? "#c9d1d9" : "#484f58"),
+      });
+      const pos = el("span", {
+        textContent: entry.position === "before_char" ? "before" : "after",
+        style: "font-size:0.7em;color:#8b949e;background:#161b22;padding:2px 6px;border-radius:3px",
+      });
+      const editBtn = el("button", {
+        textContent: "Edit",
+        className: "btn-secondary",
+        style: "font-size:0.7em;padding:2px 6px",
+        onClick: () => openEntryEditor(entry),
+      });
+      const delBtn = el("button", {
+        textContent: "Del",
+        className: "btn-secondary delete",
+        style: "font-size:0.7em;padding:2px 6px",
+        onClick: () => {
+          confirmAction(delBtn, async () => {
+            await api("DELETE", "/rp/lorebook/entries/" + entry.id);
+            openLorebook(lorebookCardId, "");
+          });
+        },
+      });
+      row.appendChild(toggle);
+      row.appendChild(label);
+      row.appendChild(pos);
+      row.appendChild(editBtn);
+      row.appendChild(delBtn);
+      container.appendChild(row);
+    }
+  }
+
+  function openEntryEditor(entry) {
+    editingEntryId = entry ? entry.id : null;
+    const editor = document.getElementById("lorebookEntryEditor");
+    document.getElementById("lbeName").value = entry ? entry.name : "";
+    document.getElementById("lbeKeys").value = entry ? (entry.keys || []).join(", ") : "";
+    document.getElementById("lbeSecondaryKeys").value = entry ? (entry.secondary_keys || []).join(", ") : "";
+    document.getElementById("lbeContent").value = entry ? entry.content : "";
+    document.getElementById("lbeEnabled").checked = entry ? entry.enabled : true;
+    document.getElementById("lbeConstant").checked = entry ? entry.constant : false;
+    document.getElementById("lbeSelective").checked = entry ? entry.selective : false;
+    document.getElementById("lbePosition").value = entry ? entry.position : "after_char";
+    document.getElementById("lbeOrder").value = entry ? entry.insertion_order : 100;
+    editor.style.display = "block";
+  }
+
+  function closeEntryEditor() {
+    document.getElementById("lorebookEntryEditor").style.display = "none";
+    editingEntryId = null;
+  }
+
+  async function saveEntry() {
+    const data = {
+      name: document.getElementById("lbeName").value,
+      keys: document.getElementById("lbeKeys").value.split(",").map(s => s.trim()).filter(Boolean),
+      secondary_keys: document.getElementById("lbeSecondaryKeys").value.split(",").map(s => s.trim()).filter(Boolean),
+      content: document.getElementById("lbeContent").value,
+      enabled: document.getElementById("lbeEnabled").checked,
+      constant: document.getElementById("lbeConstant").checked,
+      selective: document.getElementById("lbeSelective").checked,
+      position: document.getElementById("lbePosition").value,
+      insertion_order: parseInt(document.getElementById("lbeOrder").value) || 100,
+    };
+    if (editingEntryId) {
+      await api("PUT", "/rp/lorebook/entries/" + editingEntryId, data);
+    } else {
+      await api("POST", "/rp/cards/" + lorebookCardId + "/lorebook/entries", data);
+    }
+    closeEntryEditor();
+    openLorebook(lorebookCardId, "");
+  }
+
+  async function saveLorebookSettings() {
+    if (!lorebookCardId) return;
+    await api("PUT", "/rp/cards/" + lorebookCardId + "/lorebook", {
+      enabled: document.getElementById("lorebookEnabled").checked,
+      scan_depth: parseInt(document.getElementById("lorebookScanDepth").value) || 10,
+    });
+  }
+
+  document.getElementById("lorebookClose").addEventListener("click", closeLorebook);
+  document.getElementById("lorebookAddEntry").addEventListener("click", () => openEntryEditor(null));
+  document.getElementById("lorebookSaveSettings").addEventListener("click", saveLorebookSettings);
+  document.getElementById("lbeSave").addEventListener("click", saveEntry);
+  document.getElementById("lbeCancel").addEventListener("click", closeEntryEditor);
+
   // Init
   // ---------------------------------------------------------------------------
   async function init() {

--- a/projects/rp/static/index.html
+++ b/projects/rp/static/index.html
@@ -990,6 +990,7 @@
           <div class="under-hood-tab" data-pane="user-prompt">User Prompt</div>
           <div class="under-hood-tab" data-pane="summary">Summary</div>
           <div class="under-hood-tab" data-pane="raw">Raw Response</div>
+          <div class="under-hood-tab" data-pane="lorebook">Lorebook</div>
         </div>
         <div class="under-hood-pane active" id="underHoodPrompt" data-pane="prompt">
           <div class="under-hood-content" id="underHoodPromptContent">No data yet.</div>
@@ -1002,6 +1003,9 @@
         </div>
         <div class="under-hood-pane" id="underHoodRaw" data-pane="raw">
           <div class="under-hood-content" id="underHoodContent">No data yet.</div>
+        </div>
+        <div class="under-hood-pane" id="underHoodLorebook" data-pane="lorebook">
+          <div class="under-hood-content" id="underHoodLorebookContent">No lorebook data yet.</div>
         </div>
       </div>
       <div class="chat-input-area" id="chatInputArea" style="display:none">
@@ -1100,6 +1104,41 @@
           </div>
         </div>
         <div class="cards-grid" id="cardsGrid"></div>
+        <div id="lorebookPanel" style="display:none;margin-top:16px;padding:16px;background:#0d1117;border:1px solid #30363d;border-radius:8px">
+          <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:12px">
+            <h3 id="lorebookTitle" style="font-size:0.95em;color:#f0f6fc;margin:0"></h3>
+            <div style="display:flex;gap:8px;align-items:center">
+              <label style="font-size:0.75em;color:#8b949e"><input type="checkbox" id="lorebookEnabled" checked> Enabled</label>
+              <label style="font-size:0.75em;color:#8b949e">Depth: <input id="lorebookScanDepth" type="number" min="1" max="50" value="10" style="width:48px;font-size:0.8em;background:#161b22;color:#c9d1d9;border:1px solid #30363d;border-radius:4px;padding:2px 4px"></label>
+              <button id="lorebookSaveSettings" class="btn-secondary" style="font-size:0.75em;padding:4px 8px">Save</button>
+              <button id="lorebookAddEntry" class="btn-primary" style="font-size:0.75em;padding:4px 8px">+ Entry</button>
+              <button id="lorebookClose" class="btn-secondary" style="font-size:0.75em;padding:4px 8px">Close</button>
+            </div>
+          </div>
+          <div id="lorebookEntries"></div>
+          <div id="lorebookEntryEditor" style="display:none;margin-top:12px;padding:12px;background:#161b22;border:1px solid #30363d;border-radius:6px">
+            <div style="display:grid;grid-template-columns:1fr 1fr;gap:8px;margin-bottom:8px">
+              <input id="lbeName" placeholder="Entry name" style="background:#0d1117;color:#c9d1d9;border:1px solid #30363d;border-radius:4px;padding:6px;font-size:0.85em">
+              <input id="lbeKeys" placeholder="Keywords (comma-separated)" style="background:#0d1117;color:#c9d1d9;border:1px solid #30363d;border-radius:4px;padding:6px;font-size:0.85em">
+            </div>
+            <input id="lbeSecondaryKeys" placeholder="Secondary keys (for selective matching)" style="width:100%;background:#0d1117;color:#c9d1d9;border:1px solid #30363d;border-radius:4px;padding:6px;font-size:0.85em;margin-bottom:8px;box-sizing:border-box">
+            <textarea id="lbeContent" placeholder="Content to inject when keywords match..." rows="4" style="width:100%;background:#0d1117;color:#c9d1d9;border:1px solid #30363d;border-radius:4px;padding:6px;font-family:inherit;font-size:0.85em;resize:vertical;box-sizing:border-box"></textarea>
+            <div style="display:flex;gap:12px;align-items:center;margin-top:8px">
+              <label style="font-size:0.75em;color:#8b949e"><input type="checkbox" id="lbeEnabled" checked> Enabled</label>
+              <label style="font-size:0.75em;color:#8b949e"><input type="checkbox" id="lbeConstant"> Always inject</label>
+              <label style="font-size:0.75em;color:#8b949e"><input type="checkbox" id="lbeSelective"> Selective</label>
+              <select id="lbePosition" style="font-size:0.75em;background:#0d1117;color:#c9d1d9;border:1px solid #30363d;border-radius:4px;padding:2px 4px">
+                <option value="after_char">After char</option>
+                <option value="before_char">Before char</option>
+              </select>
+              <label style="font-size:0.75em;color:#8b949e">Order: <input id="lbeOrder" type="number" value="100" style="width:48px;font-size:0.85em;background:#0d1117;color:#c9d1d9;border:1px solid #30363d;border-radius:4px;padding:2px 4px"></label>
+              <div style="margin-left:auto;display:flex;gap:6px">
+                <button id="lbeSave" class="btn-primary" style="font-size:0.75em;padding:4px 10px">Save</button>
+                <button id="lbeCancel" class="btn-secondary" style="font-size:0.75em;padding:4px 10px">Cancel</button>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
 

--- a/projects/rp/tests/test_lorebook.py
+++ b/projects/rp/tests/test_lorebook.py
@@ -1,0 +1,138 @@
+from projects.rp.lorebook import (
+    _keywords_match, match_entries, build_injection_text, extract_character_book,
+)
+
+
+def _entry(name="e", keys=None, content="info", enabled=True, constant=False,
+           selective=False, secondary_keys=None, position="after_char",
+           insertion_order=100):
+    return {
+        "name": name, "keys": keys or [], "content": content,
+        "enabled": enabled, "constant": constant, "selective": selective,
+        "secondary_keys": secondary_keys or [], "position": position,
+        "insertion_order": insertion_order,
+    }
+
+
+def _msgs(*texts):
+    return [{"role": "user", "content": t} for t in texts]
+
+
+class TestKeywordsMatch:
+    def test_basic_match(self):
+        assert _keywords_match("the tavern is dark", ["tavern"])
+
+    def test_case_insensitive(self):
+        assert _keywords_match("The TAVERN is dark", ["tavern"])
+
+    def test_no_match(self):
+        assert not _keywords_match("the inn is dark", ["tavern"])
+
+    def test_empty_keys(self):
+        assert not _keywords_match("anything", [])
+
+    def test_empty_key_string(self):
+        assert not _keywords_match("anything", [""])
+
+    def test_multiple_keys_any_match(self):
+        assert _keywords_match("the inn is dark", ["tavern", "inn"])
+
+
+class TestMatchEntries:
+    def test_keyword_match(self):
+        entries = [_entry("tavern", keys=["tavern"], content="A smoky tavern")]
+        result = match_entries(entries, _msgs("I enter the tavern"))
+        assert len(result) == 1
+        assert result[0]["name"] == "tavern"
+
+    def test_no_match(self):
+        entries = [_entry("tavern", keys=["tavern"])]
+        result = match_entries(entries, _msgs("I walk outside"))
+        assert result == []
+
+    def test_disabled_entry_skipped(self):
+        entries = [_entry("tavern", keys=["tavern"], enabled=False)]
+        result = match_entries(entries, _msgs("I enter the tavern"))
+        assert result == []
+
+    def test_empty_content_skipped(self):
+        entries = [_entry("tavern", keys=["tavern"], content="")]
+        result = match_entries(entries, _msgs("I enter the tavern"))
+        assert result == []
+
+    def test_constant_always_matches(self):
+        entries = [_entry("lore", keys=[], content="world facts", constant=True)]
+        result = match_entries(entries, _msgs("hello"))
+        assert len(result) == 1
+
+    def test_selective_needs_both_keys(self):
+        entries = [_entry("secret", keys=["tavern"], secondary_keys=["basement"],
+                          content="hidden room", selective=True)]
+        assert match_entries(entries, _msgs("I enter the tavern")) == []
+        assert len(match_entries(entries, _msgs("tavern basement"))) == 1
+
+    def test_selective_without_secondary_matches_primary_only(self):
+        entries = [_entry("x", keys=["tavern"], secondary_keys=[],
+                          content="info", selective=True)]
+        assert len(match_entries(entries, _msgs("tavern"))) == 1
+
+    def test_scan_depth_limits_window(self):
+        entries = [_entry("old", keys=["dragon"], content="dragon lore")]
+        msgs = _msgs("a dragon appears") + _msgs(*["filler"] * 15)
+        assert match_entries(entries, msgs, scan_depth=5) == []
+        assert len(match_entries(entries, msgs, scan_depth=20)) == 1
+
+    def test_sorted_by_insertion_order(self):
+        entries = [
+            _entry("b", keys=["x"], content="b", insertion_order=200),
+            _entry("a", keys=["x"], content="a", insertion_order=50),
+        ]
+        result = match_entries(entries, _msgs("x"))
+        assert [e["name"] for e in result] == ["a", "b"]
+
+
+class TestBuildInjectionText:
+    def test_after_char(self):
+        entries = [_entry(content="fact one"), _entry(content="fact two")]
+        before, after = build_injection_text(entries)
+        assert before == ""
+        assert "fact one" in after and "fact two" in after
+
+    def test_before_char(self):
+        entries = [_entry(content="preamble", position="before_char")]
+        before, after = build_injection_text(entries)
+        assert "preamble" in before
+        assert after == ""
+
+    def test_mixed_positions(self):
+        entries = [
+            _entry(content="before stuff", position="before_char"),
+            _entry(content="after stuff", position="after_char"),
+        ]
+        before, after = build_injection_text(entries)
+        assert "before stuff" in before
+        assert "after stuff" in after
+
+    def test_empty_content_skipped(self):
+        entries = [_entry(content=""), _entry(content="real")]
+        _, after = build_injection_text(entries)
+        assert after == "real"
+
+
+class TestExtractCharacterBook:
+    def test_extracts_from_v2(self):
+        card = {"data": {"name": "Test", "character_book": {"entries": [{"keys": ["x"]}]}}}
+        result = extract_character_book(card)
+        assert result is not None
+        assert len(result["entries"]) == 1
+
+    def test_returns_none_when_missing(self):
+        assert extract_character_book({"data": {"name": "Test"}}) is None
+
+    def test_returns_none_for_empty_book(self):
+        assert extract_character_book({"data": {"character_book": {}}}) is None
+
+    def test_handles_flat_data(self):
+        card = {"name": "Test", "character_book": {"entries": [{"keys": ["y"]}]}}
+        result = extract_character_book(card)
+        assert result is not None

--- a/projects/rp/tests/test_routes.py
+++ b/projects/rp/tests/test_routes.py
@@ -293,6 +293,17 @@ class FakeDB:
     async def set_cached_first_message(self, *args):
         pass
 
+    # -- Lorebook (stubs) --
+
+    async def get_lorebook_for_card(self, card_id: int):
+        return None
+
+    async def get_or_create_lorebook(self, card_id, **kw):
+        return None
+
+    async def get_lorebook_entries(self, lorebook_id):
+        return []
+
 
 # ---------------------------------------------------------------------------
 # Stub Ollama — extends conftest StubOllama with generate + chat_stream


### PR DESCRIPTION
## Summary
- Card-scoped lorebooks with keyword-triggered context injection into the system prompt
- Supports constant entries (always injected), selective matching (primary + secondary keys), configurable scan depth, before/after char positioning, insertion order sorting
- Auto-imports character_book from SillyTavern v2 card imports
- Full UI: lorebook panel on card tiles, entry editor, Under the Hood debug tab showing matched entries and token count
- Pipeline pre-hook integrates with existing budget system (lorebook tokens counted as system prompt overhead)

## Files
- `lorebook.py` — Core matching logic, pipeline hook, character_book extraction
- `schema.sql` — `rp_lorebooks` + `rp_lorebook_entries` tables
- `db.py` — 10 new CRUD functions for lorebooks and entries
- `models.py` — Pydantic models for lorebook API
- `routes.py` — 7 API endpoints + character_book import on card upload
- `pipeline.py` — `inject_lorebook` pre-hook registration
- `static/index.html` — Lorebook panel HTML + Under the Hood tab
- `static/app.js` — Lorebook UI (open/close panel, entry editor, debug display)
- `tests/test_lorebook.py` — 23 unit tests
- `tests/test_routes.py` — FakeDB lorebook stubs for integration tests

## Test plan
```bash
cd /mnt/d/prg/plum-rp-lorebook
source /mnt/d/prg/plum/projects/aiserver/.venv/bin/activate
# Run unit tests (512 pass)
python -m pytest projects/rp/tests/ -v
# Start server and verify UI
DATABASE_URL="postgresql://plum:Hunter69@localhost:5432/plum" python projects/aiserver/main.py &
# Import a card with character_book — verify lorebook auto-created
# Open lorebook panel on card — add entry with keyword
# Chat and mention the keyword — verify injection in Under the Hood > Lorebook tab
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)