### PR TITLE
fix(rp): consume NDJSON stream in eval judge, fix lorebook PUT partial update

### DIFF
--- a/projects/rp/eval/cli.py
+++ b/projects/rp/eval/cli.py
@@ -129,13 +129,15 @@ async def _warmup_model(aiserver_url: str, model: str):
     try:
         import httpx
         async with httpx.AsyncClient() as client:
-            await client.post(
-                f"{aiserver_url}/chat",
+            async with client.stream(
+                "POST", f"{aiserver_url}/chat",
                 json={"model": model, "messages": [
                     {"role": "user", "content": "hi"}
-                ], "stream": False, "priority": 5},
-                timeout=600.0,
-            )
+                ], "priority": 5},
+                timeout=httpx.Timeout(600.0, connect=30.0),
+            ) as resp:
+                async for _ in resp.aiter_lines():
+                    pass
     except Exception:
         pass
     print(f" {time.time() - t_load:.1f}s\n")

--- a/projects/rp/eval/engine.py
+++ b/projects/rp/eval/engine.py
@@ -4,6 +4,7 @@ Uses G-Eval pattern: chain-of-thought rubric in the system prompt, content to ev
 in the user message, structured score output parsed from the judge's response.
 """
 
+import json
 import re
 import tomllib
 from dataclasses import dataclass
@@ -228,23 +229,31 @@ async def judge(
     ]
 
     async with httpx.AsyncClient() as client:
-        resp = await client.post(
+        async with client.stream(
+            "POST",
             f"{aiserver_url}/chat",
             json={
                 "model": model,
                 "messages": messages,
-                "stream": False,
                 "priority": 10,
                 "options": {"temperature": 0.3, "num_predict": 4096, "think": True},
             },
-            timeout=1800.0,
-        )
-        if resp.status_code != 200:
-            raise RuntimeError(f"aiserver {resp.status_code}: {resp.text[:300]}")
-        data = resp.json()
-        if "error" in data:
-            raise RuntimeError(f"aiserver error: {data['error']}")
-        raw_output = data["message"]["content"]
+            timeout=httpx.Timeout(1800.0, connect=30.0),
+        ) as resp:
+            if resp.status_code != 200:
+                body = await resp.aread()
+                raise RuntimeError(f"aiserver {resp.status_code}: {body[:300]}")
+            tokens = []
+            async for line in resp.aiter_lines():
+                if not line.strip():
+                    continue
+                chunk = json.loads(line)
+                if "error" in chunk:
+                    raise RuntimeError(f"aiserver error: {chunk['error']}")
+                tok = chunk.get("token", "")
+                if tok and not chunk.get("thinking", False):
+                    tokens.append(tok)
+            raw_output = "".join(tokens)
 
     scores = parse_scores(raw_output, rubric)
     weighted_avg = compute_weighted_average(scores, rubric)

--- a/projects/rp/routes.py
+++ b/projects/rp/routes.py
@@ -211,7 +211,7 @@ def setup(app: FastAPI, ollama, resolve_model=None):
 
     @app.put("/rp/lorebook/entries/{entry_id}", response_model=LorebookEntryResponse)
     async def update_entry(entry_id: int, req: LorebookEntryCreate):
-        result = await db.update_lorebook_entry(entry_id, **req.model_dump())
+        result = await db.update_lorebook_entry(entry_id, **req.model_dump(exclude_unset=True))
         if not result:
             raise HTTPException(404, "Entry not found")
         return result


### PR DESCRIPTION
## Summary
- Eval engine and warmup now consume the NDJSON stream from `/chat` instead of expecting a non-streaming JSON response (which caused the judge to hang indefinitely)
- Lorebook entry PUT endpoint uses `exclude_unset=True` so partial updates don't wipe unset fields

## Test plan
```bash
cd /mnt/d/prg/plum-fix-eval-streaming
source /mnt/d/prg/plum/projects/aiserver/.venv/bin/activate
python -m pytest projects/rp/tests/ -v
# Then run eval:
DATABASE_URL="postgresql://plum:Hunter69@localhost:5432/plum" python -m projects.rp.eval message --conv-id 147 --judge-model qwen3.6:35b --save
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)