### PR TITLE
fix(rp): list required dimension keys in eval judge prompt

### DIFF
--- a/projects/rp/eval/engine.py
+++ b/projects/rp/eval/engine.py
@@ -89,20 +89,21 @@ def build_judge_prompt(rubric: Rubric, context: dict) -> tuple[str, str]:
         )
     dimensions_text = "\n\n".join(dim_blocks)
 
+    dim_keys = "\n".join(f"[{dim.key}]" for dim in rubric.dimensions)
+
     system_prompt = (
         f"You are an expert evaluator of roleplay writing quality.\n"
         f"Evaluate the content below on {len(rubric.dimensions)} dimensions.\n"
         f"Scale: {rubric.scale_min} (worst) to {rubric.scale_max} (best).\n\n"
-        f"For each dimension, reason step-by-step about the criteria, "
-        f"then assign a score.\n\n"
-        f"Output format — one block per dimension, in this exact order:\n\n"
+        f"IMPORTANT: You are EVALUATING the writing, not continuing it. "
+        f"Do NOT write fiction or continue the story.\n\n"
+        f"Output EXACTLY {len(rubric.dimensions)} blocks using THESE "
+        f"dimension keys (no other keys):\n\n"
+        f"{dim_keys}\n\n"
+        f"Format for each block:\n\n"
         f"[dimension_key]\n"
         f"Score: N\n"
-        f"Explanation: Your reasoning in 1-2 sentences.\n\n"
-        f"Evaluate ALL dimensions listed below. Do not skip any.\n\n"
-        f"IMPORTANT: You are EVALUATING the writing, not continuing it. "
-        f"Output ONLY the score blocks above. "
-        f"Do NOT write fiction or continue the story.\n\n"
+        f"Explanation: 1-2 sentences.\n\n"
         f"=== EVALUATION CRITERIA ===\n\n{dimensions_text}"
     )
 


### PR DESCRIPTION
## Summary
- Explicitly list all 7 `[dimension_key]` blocks at the top of the judge system prompt
- The model was inventing its own dimensions (`character_voice`, `continuation_quality`, `tone`) because it only saw the keys embedded within the long criteria text
- With keys listed upfront, test shows 7/7 dimensions parse consistently

## Test plan
```bash
# Unit tests
python -m pytest projects/rp/tests/ -x -q

# Live test (needs running aiserver + qwen3.6:35b)
DATABASE_URL='...' python -m projects.rp.eval message --conv-id 102 --judge-model qwen3.6:35b --limit 2
# Should see 7/7 dimensions per message
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)