### PR TITLE
fix(rp): preserve paragraph breaks in pronoun enforcement

### DIFF
--- a/projects/rp/pipeline.py
+++ b/projects/rp/pipeline.py
@@ -322,7 +322,10 @@ def _fix_character_pronouns(response: str, char_name: str, pronouns: str) -> tup
     if not mapping or not char_name:
         return response, 0
 
-    sentences = re.split(r'(?<=[.!?…"])\s+', response)
+    parts = re.split(r'(?<=[.!?…"])(\s+)', response)
+    sentences = parts[0::2]
+    separators = parts[1::2]
+
     fixed = []
     name_recent = False
     corrections = 0
@@ -344,7 +347,12 @@ def _fix_character_pronouns(response: str, char_name: str, pronouns: str) -> tup
         elif re.search(r'\b[A-Z][a-z]+\b', sent) and not has_name:
             name_recent = False
 
-    return " ".join(fixed), corrections
+    result = []
+    for i, sent in enumerate(fixed):
+        result.append(sent)
+        if i < len(separators):
+            result.append(separators[i])
+    return "".join(result), corrections
 
 
 def enforce_pronouns(ctx: dict) -> dict:


### PR DESCRIPTION
## Summary
- `enforce_pronouns` post-hook was destroying paragraph breaks by splitting on `\s+` (which includes `\n\n`) then rejoining with `" ".join()`
- Fix uses a capturing group in the split regex to preserve original whitespace separators

## Test plan
```bash
cd /mnt/d/prg/plum-fix-pronoun-newlines
source projects/aiserver/.venv/bin/activate
python -m pytest projects/rp/tests/ -x -q
# Chat in RP UI and verify multi-paragraph responses retain line breaks
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)