### PR TITLE
fix(rp): remove frequency_penalty that causes rambling

### DIFF
--- a/projects/rp/prompt_builder.py
+++ b/projects/rp/prompt_builder.py
@@ -23,7 +23,6 @@ CHAT_DEFAULTS = {
     "temperature": 1.1,
     "repeat_penalty": 1.08,
     "repeat_last_n": 512,
-    "frequency_penalty": 0.1,
     "min_p": 0.1,
 }
 


### PR DESCRIPTION
## Summary
- `frequency_penalty: 0.1` (added in #169) compounds over conversation length — common function words get increasingly penalized, producing incoherent run-on text by message ~10+
- Removing it; `repeat_penalty: 1.08` with `repeat_last_n: 512` is sufficient for anti-repetition

## Test plan
```bash
cd /mnt/d/prg/plum-fix-frequency-penalty
source projects/aiserver/.venv/bin/activate
python -m pytest projects/rp/tests/ -x -q
# Chat 15+ messages in RP UI — verify prose stays coherent with articles and connectors intact
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)