### PR TITLE
feat(rp): multi-character conversation support

### DIFF
--- a/projects/rp/db.py
+++ b/projects/rp/db.py
@@ -189,7 +189,8 @@ async def list_conversations() -> list[dict]:
     rows = await pool.fetch(
         "SELECT c.id, c.user_card_id, c.ai_card_id, c.scenario_id, c.model, "
         "c.category, c.created_at::text, c.updated_at::text, "
-        "uc.name as user_name, ac.name as ai_name "
+        "uc.name as user_name, ac.name as ai_name, "
+        "(SELECT COUNT(*) FROM rp_conversation_characters cc WHERE cc.conversation_id = c.id) as character_count "
         "FROM rp_conversations c "
         "JOIN rp_character_cards uc ON c.user_card_id = uc.id "
         "JOIN rp_character_cards ac ON c.ai_card_id = ac.id "
@@ -252,6 +253,64 @@ async def delete_conversation(conv_id: int) -> bool:
     return result == "DELETE 1"
 
 
+# -- Conversation Characters --
+
+async def get_conversation_characters(conv_id: int) -> list[dict]:
+    pool = await get_pool()
+    rows = await pool.fetch(
+        "SELECT cc.id, cc.conversation_id, cc.card_id, cc.color, cc.generation_order, "
+        "cc.created_at::text, c.name as card_name "
+        "FROM rp_conversation_characters cc "
+        "JOIN rp_character_cards c ON cc.card_id = c.id "
+        "WHERE cc.conversation_id = $1 ORDER BY cc.generation_order",
+        conv_id,
+    )
+    return [dict(r) for r in rows]
+
+
+async def add_conversation_character(conv_id: int, card_id: int,
+                                      color: str = "", generation_order: int = 0) -> dict:
+    pool = await get_pool()
+    row = await pool.fetchrow(
+        "INSERT INTO rp_conversation_characters (conversation_id, card_id, color, generation_order) "
+        "VALUES ($1, $2, $3, $4) "
+        "ON CONFLICT (conversation_id, card_id) DO UPDATE SET color=EXCLUDED.color, generation_order=EXCLUDED.generation_order "
+        "RETURNING id, conversation_id, card_id, color, generation_order, created_at::text",
+        conv_id, card_id, color, generation_order,
+    )
+    return dict(row)
+
+
+async def remove_conversation_character(conv_id: int, card_id: int) -> bool:
+    pool = await get_pool()
+    result = await pool.execute(
+        "DELETE FROM rp_conversation_characters WHERE conversation_id = $1 AND card_id = $2",
+        conv_id, card_id,
+    )
+    return result == "DELETE 1"
+
+
+async def update_conversation_character(conv_id: int, card_id: int, **kwargs) -> dict | None:
+    pool = await get_pool()
+    sets = []
+    vals = [conv_id, card_id]
+    i = 3
+    for k in ("color", "generation_order"):
+        if k in kwargs:
+            sets.append(f"{k} = ${i}")
+            vals.append(kwargs[k])
+            i += 1
+    if not sets:
+        return None
+    row = await pool.fetchrow(
+        f"UPDATE rp_conversation_characters SET {', '.join(sets)} "
+        f"WHERE conversation_id = $1 AND card_id = $2 "
+        f"RETURNING id, conversation_id, card_id, color, generation_order, created_at::text",
+        *vals,
+    )
+    return dict(row) if row else None
+
+
 # -- Messages --
 
 async def delete_all_messages(conv_id: int):
@@ -264,7 +323,8 @@ async def get_messages(conv_id: int) -> list[dict]:
     rows = await pool.fetch(
         "SELECT id, conversation_id, role, content, raw_response, sequence, "
         "system_prompt, scene_state, post_prompt, budget_json, prompt_json, "
-        "created_at::text FROM rp_messages WHERE conversation_id = $1 ORDER BY sequence",
+        "character_card_id, created_at::text "
+        "FROM rp_messages WHERE conversation_id = $1 ORDER BY sequence",
         conv_id,
     )
     return [dict(r) for r in rows]
@@ -276,16 +336,19 @@ async def add_message(conv_id: int, role: str, content: str,
                       scene_state: str | None = None,
                       post_prompt: str | None = None,
                       budget_json: dict | None = None,
-                      prompt_json: list | None = None) -> dict:
+                      prompt_json: list | None = None,
+                      character_card_id: int | None = None) -> dict:
     pool = await get_pool()
     row = await pool.fetchrow(
         "INSERT INTO rp_messages (conversation_id, role, content, raw_response, "
-        "system_prompt, scene_state, post_prompt, budget_json, prompt_json, sequence) "
-        "VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, "
+        "system_prompt, scene_state, post_prompt, budget_json, prompt_json, character_card_id, sequence) "
+        "VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, "
         "(SELECT COALESCE(MAX(sequence), 0) + 1 FROM rp_messages WHERE conversation_id = $1)) "
         "RETURNING id, conversation_id, role, content, "
-        "raw_response, sequence, system_prompt, scene_state, post_prompt, budget_json, prompt_json, created_at::text",
+        "raw_response, sequence, system_prompt, scene_state, post_prompt, budget_json, prompt_json, "
+        "character_card_id, created_at::text",
         conv_id, role, content, raw_response, system_prompt, scene_state, post_prompt, budget_json, prompt_json,
+        character_card_id,
     )
     await pool.execute(
         "UPDATE rp_conversations SET updated_at = NOW() WHERE id = $1", conv_id

--- a/projects/rp/models.py
+++ b/projects/rp/models.py
@@ -35,6 +35,7 @@ class ScenarioResponse(BaseModel):
 class ConversationCreate(BaseModel):
     user_card_id: int
     ai_card_id: int
+    ai_card_ids: list[int] = []
     scenario_id: int | None = None
     model: str
 
@@ -60,6 +61,17 @@ class MessageResponse(BaseModel):
     content: str
     raw_response: dict | None
     sequence: int
+    character_card_id: int | None = None
+    created_at: str
+
+
+class ConversationCharacterResponse(BaseModel):
+    id: int
+    conversation_id: int
+    card_id: int
+    card_name: str = ""
+    color: str = ""
+    generation_order: int = 0
     created_at: str
 
 
@@ -67,6 +79,8 @@ class ConversationDetailResponse(BaseModel):
     conversation: ConversationResponse
     user_card: CardResponse
     ai_card: CardResponse
+    ai_cards: list[CardResponse] = []
+    characters: list[ConversationCharacterResponse] = []
     scenario: ScenarioResponse | None
     messages: list[MessageResponse]
 
@@ -151,3 +165,14 @@ class CompareRequest(BaseModel):
 class SelectCandidateRequest(BaseModel):
     candidate_id: int
     preference_tags: list[str] = []
+
+
+class AddCharacterRequest(BaseModel):
+    card_id: int
+    color: str = ""
+    generation_order: int = 0
+
+
+class UpdateCharacterRequest(BaseModel):
+    color: str | None = None
+    generation_order: int | None = None

--- a/projects/rp/pipeline.py
+++ b/projects/rp/pipeline.py
@@ -580,7 +580,13 @@ def _merge_overlapping(ngrams: list[str]) -> list[str]:
 def inject_avoid_list(ctx: dict) -> dict:
     """Scan recent assistant messages for repeated phrases, inject avoid list."""
     messages = ctx.get("messages", [])
-    recent_asst = [m["content"] for m in messages if m.get("role") == "assistant"]
+    active_card_id = ctx.get("_active_card", {}).get("id") if ctx.get("_multi_character") else None
+    if active_card_id:
+        recent_asst = [m["content"] for m in messages
+                       if m.get("role") == "assistant"
+                       and m.get("_character_card_id") == active_card_id]
+    else:
+        recent_asst = [m["content"] for m in messages if m.get("role") == "assistant"]
     if len(recent_asst) < AVOID_LIST_MIN_MESSAGES:
         return ctx
 

--- a/projects/rp/prompt_builder.py
+++ b/projects/rp/prompt_builder.py
@@ -124,6 +124,68 @@ def build_chat_messages(ctx: dict) -> list[dict]:
     return chat_messages
 
 
+def rewrite_history_for_character(messages: list[dict], active_card_id: int,
+                                   card_names: dict[int, str]) -> list[dict]:
+    """Rewrite message history so the active character sees itself as assistant.
+
+    - Messages from the active character stay as role=assistant
+    - Messages from the human user stay as role=user
+    - Messages from other AI characters become role=user with "[Name]: " prefix
+    """
+    rewritten = []
+    for m in messages:
+        char_id = m.get("character_card_id") or m.get("_character_card_id")
+        role = m["role"]
+        content = m["content"]
+
+        if role == "user" and char_id is None:
+            rewritten.append({"role": "user", "content": content})
+        elif char_id == active_card_id:
+            rewritten.append({"role": "assistant", "content": content})
+        elif char_id is not None:
+            name = card_names.get(char_id, "Character")
+            rewritten.append({"role": "user", "content": f"[{name}]: {content}"})
+        else:
+            rewritten.append({"role": role, "content": content})
+
+        for key in ("_sequence", "_id", "_character_card_id"):
+            if key in m:
+                rewritten[-1][key] = m[key]
+
+    return rewritten
+
+
+def build_multi_char_messages(ctx: dict, active_card_id: int,
+                               card_names: dict[int, str]) -> list[dict]:
+    """Build chat messages for one character in a multi-character conversation."""
+    chat_messages = [{"role": "system", "content": ctx["system_prompt"]}]
+
+    messages = rewrite_history_for_character(
+        list(ctx["messages"]), active_card_id, card_names)
+
+    authors_note = ctx.get("authors_note", "")
+    if authors_note:
+        depth = ctx.get("authors_note_depth", 4)
+        insert_idx = max(0, len(messages) - depth)
+        note_msg = {"role": "system", "content": f"[Author's Note: {authors_note}]"}
+        messages.insert(insert_idx, note_msg)
+
+    chat_messages.extend(messages)
+    if ctx.get("post_prompt"):
+        chat_messages.append({"role": "system", "content": ctx["post_prompt"]})
+
+    active_card = ctx.get("_active_card", ctx.get("ai_card", {}))
+    card_data = active_card.get("card_data", {}).get("data", active_card.get("card_data", {}))
+    ai_name = card_data.get("name", "Character")
+    pronouns = card_data.get("pronouns", "") or infer_pronouns(card_data.get("description", ""))
+    if pronouns:
+        anchor = f"{ai_name} [{pronouns}] "
+    else:
+        anchor = ai_name + " "
+    chat_messages.append({"role": "assistant", "content": anchor})
+    return chat_messages
+
+
 def budget_to_json(ctx: dict) -> dict | None:
     report = ctx.get("_budget_report")
     if not isinstance(report, BudgetReport):
@@ -152,6 +214,8 @@ async def build_pipeline_ctx(conv, messages, *, pipeline, template_path: Path):
         d["_sequence"] = m.get("sequence", 0)
         if "id" in m:
             d["_id"] = m["id"]
+        if m.get("character_card_id") is not None:
+            d["_character_card_id"] = m["character_card_id"]
         msg_dicts.append(d)
 
     ctx = {
@@ -165,6 +229,50 @@ async def build_pipeline_ctx(conv, messages, *, pipeline, template_path: Path):
         "prompt_template": prompt_template,
         "authors_note": conv.get("authors_note", ""),
         "authors_note_depth": conv.get("authors_note_depth", 4),
+    }
+
+    summary_row = await db.get_latest_summary(conv["id"])
+    if summary_row:
+        ctx["_summary"] = summary_row["summary"]
+        ctx["_summary_through_sequence"] = summary_row["through_sequence"]
+
+    return await pipeline.run_pre(ctx)
+
+
+async def build_pipeline_ctx_for_character(conv, messages, active_card, *,
+                                            pipeline, template_path: Path):
+    """Like build_pipeline_ctx but swaps ai_card to the active character's card."""
+    user_card = await db.get_card(conv["user_card_id"])
+    scenario = await db.get_scenario(conv["scenario_id"]) if conv["scenario_id"] else {}
+    scenario = scenario or {}
+
+    prompt_template = ""
+    if template_path.exists():
+        prompt_template = template_path.read_text()
+
+    msg_dicts = []
+    for m in messages:
+        d = {"role": m["role"], "content": m["content"]}
+        d["_sequence"] = m.get("sequence", 0)
+        if "id" in m:
+            d["_id"] = m["id"]
+        if m.get("character_card_id") is not None:
+            d["_character_card_id"] = m["character_card_id"]
+        msg_dicts.append(d)
+
+    ctx = {
+        "user_card": user_card,
+        "ai_card": active_card,
+        "_active_card": active_card,
+        "scenario": scenario,
+        "messages": msg_dicts,
+        "system_prompt": "",
+        "post_prompt": "",
+        "scene_state": conv.get("scene_state", ""),
+        "prompt_template": prompt_template,
+        "authors_note": conv.get("authors_note", ""),
+        "authors_note_depth": conv.get("authors_note_depth", 4),
+        "_multi_character": True,
     }
 
     summary_row = await db.get_latest_summary(conv["id"])

--- a/projects/rp/routes.py
+++ b/projects/rp/routes.py
@@ -11,8 +11,10 @@ from .cards import parse_card_png, export_card_png, extract_name
 from .models import (
     CardCreate, CardResponse, ScenarioCreate, ScenarioResponse,
     ConversationCreate, ConversationResponse, ConversationDetailResponse,
+    ConversationCharacterResponse,
     MessageResponse, SendMessageRequest, SavePartialRequest, EditMessageRequest,
     SceneStateRequest, AuthorsNoteRequest,
+    AddCharacterRequest, UpdateCharacterRequest,
 )
 from .pipeline import create_default_pipeline
 from .budget import BudgetError, allocate_injections
@@ -23,8 +25,9 @@ from .summarize import maybe_generate_summary
 from .prompt_builder import (
     get_ai_name, get_user_name, get_ai_personality, get_ai_pronouns,
     get_user_pronouns, get_user_description, build_chat_messages,
-    build_ollama_options, scale_num_predict, budget_to_json,
-    build_pipeline_ctx, budget_ctx,
+    build_multi_char_messages, build_ollama_options, scale_num_predict,
+    budget_to_json, build_pipeline_ctx, build_pipeline_ctx_for_character,
+    budget_ctx,
 )
 from .lorebook import extract_character_book
 from . import conv_log
@@ -386,14 +389,28 @@ def setup(app: FastAPI, ollama, resolve_model=None):
 
     @app.post("/rp/conversations", response_model=ConversationResponse)
     async def create_conversation(conv: ConversationCreate):
-        # Verify cards exist
         if not await db.get_card(conv.user_card_id):
             raise HTTPException(404, "User card not found")
         if not await db.get_card(conv.ai_card_id):
             raise HTTPException(404, "AI card not found")
+
+        all_ai_ids = [conv.ai_card_id] + [cid for cid in conv.ai_card_ids if cid != conv.ai_card_id]
+        for cid in all_ai_ids[1:]:
+            if not await db.get_card(cid):
+                raise HTTPException(404, f"AI card {cid} not found")
+
         result = await db.create_conversation(
             conv.user_card_id, conv.ai_card_id, conv.scenario_id, conv.model
         )
+
+        colors = ["#4a9eff", "#ff6b6b", "#51cf66", "#ffd43b", "#cc5de8", "#ff922b"]
+        for i, cid in enumerate(all_ai_ids):
+            await db.add_conversation_character(
+                result["id"], cid,
+                color=colors[i % len(colors)],
+                generation_order=i,
+            )
+
         ai_card = await db.get_card(conv.ai_card_id)
         user_card = await db.get_card(conv.user_card_id)
         scenario = await db.get_scenario(conv.scenario_id) if conv.scenario_id else None
@@ -402,8 +419,8 @@ def setup(app: FastAPI, ollama, resolve_model=None):
         first_mes = await _get_or_generate_first_message(result, ai_card, user_card, scenario, model)
 
         if first_mes:
-            await db.add_message(result["id"], "assistant", first_mes)
-            # Initial scene state from first message + scenario + card context
+            await db.add_message(result["id"], "assistant", first_mes,
+                                 character_card_id=conv.ai_card_id)
             ai_data = ai_card["card_data"].get("data", ai_card["card_data"])
             user_data = user_card["card_data"].get("data", user_card["card_data"])
             scenario_desc = (scenario or {}).get("description", "")
@@ -426,8 +443,15 @@ def setup(app: FastAPI, ollama, resolve_model=None):
             raise HTTPException(404, "Card referenced by conversation no longer exists")
         scenario = await db.get_scenario(conv["scenario_id"]) if conv["scenario_id"] else None
         messages = await db.get_messages(conv_id)
+        characters = await db.get_conversation_characters(conv_id)
+        ai_cards = []
+        for ch in characters:
+            card = await db.get_card(ch["card_id"])
+            if card:
+                ai_cards.append(card)
         return ConversationDetailResponse(
             conversation=conv, user_card=user_card, ai_card=ai_card,
+            ai_cards=ai_cards, characters=characters,
             scenario=scenario, messages=messages,
         )
 
@@ -436,6 +460,44 @@ def setup(app: FastAPI, ollama, resolve_model=None):
         if not await db.delete_conversation(conv_id):
             raise HTTPException(404, "Conversation not found")
         return {"ok": True}
+
+    @app.get("/rp/conversations/{conv_id}/characters",
+             response_model=list[ConversationCharacterResponse])
+    async def list_characters(conv_id: int):
+        conv = await db.get_conversation(conv_id)
+        if not conv:
+            raise HTTPException(404, "Conversation not found")
+        return await db.get_conversation_characters(conv_id)
+
+    @app.post("/rp/conversations/{conv_id}/characters",
+              response_model=ConversationCharacterResponse)
+    async def add_character(conv_id: int, req: AddCharacterRequest):
+        conv = await db.get_conversation(conv_id)
+        if not conv:
+            raise HTTPException(404, "Conversation not found")
+        if not await db.get_card(req.card_id):
+            raise HTTPException(404, "Card not found")
+        return await db.add_conversation_character(
+            conv_id, req.card_id, color=req.color, generation_order=req.generation_order)
+
+    @app.delete("/rp/conversations/{conv_id}/characters/{card_id}")
+    async def remove_character(conv_id: int, card_id: int):
+        if not await db.remove_conversation_character(conv_id, card_id):
+            raise HTTPException(404, "Character not in conversation")
+        return {"ok": True}
+
+    @app.put("/rp/conversations/{conv_id}/characters/{card_id}",
+             response_model=ConversationCharacterResponse)
+    async def update_character(conv_id: int, card_id: int, req: UpdateCharacterRequest):
+        kwargs = {}
+        if req.color is not None:
+            kwargs["color"] = req.color
+        if req.generation_order is not None:
+            kwargs["generation_order"] = req.generation_order
+        result = await db.update_conversation_character(conv_id, card_id, **kwargs)
+        if not result:
+            raise HTTPException(404, "Character not in conversation")
+        return result
 
     @app.post("/rp/conversations/{conv_id}/restart")
     async def restart_conversation(conv_id: int):
@@ -453,8 +515,8 @@ def setup(app: FastAPI, ollama, resolve_model=None):
         first_mes = await _get_or_generate_first_message(conv, ai_card, user_card, scenario, model)
 
         if first_mes:
-            await db.add_message(conv_id, "assistant", first_mes)
-            # Initial scene state from first message + scenario + card context
+            await db.add_message(conv_id, "assistant", first_mes,
+                                 character_card_id=conv["ai_card_id"])
             ai_data = ai_card["card_data"].get("data", ai_card["card_data"])
             user_data = user_card["card_data"].get("data", user_card["card_data"])
             scenario_desc = (scenario or {}).get("description", "")
@@ -608,7 +670,7 @@ def setup(app: FastAPI, ollama, resolve_model=None):
             first_mes = await _generate_first_message(conv, ai_card, user_card, scenario)
         except Exception as e:
             _log.warning("Failed to generate first message: %s", e)
-            return ""
+            return
 
         await db.set_cached_first_message(combo_hash, card_hash, scenario_hash, model, first_mes)
         _log.info("First message cached for combo %s", combo_hash)
@@ -806,6 +868,7 @@ def setup(app: FastAPI, ollama, resolve_model=None):
                     post_prompt=ctx.get("post_prompt", ""),
                     budget_json=budget_to_json(ctx),
                     prompt_json=chat_messages,
+                    character_card_id=conv.get("ai_card_id"),
                 )
             conv_log.log_response(conv_id, save_role, post_ctx["response"], raw)
             budget_report = ctx.get("_budget_report")
@@ -820,14 +883,87 @@ def setup(app: FastAPI, ollama, resolve_model=None):
         except Exception as e:
             yield json.dumps({"error": f"Failed to save response: {e}", "done": True}) + "\n"
 
+    async def _generate_for_character(conv_id, conv, char_card, card_names,
+                                      model, ollama_options, user_content):
+        """Generate one character's response in a multi-char conversation.
+
+        Yields NDJSON chunks. Saves the message to DB when done.
+        Returns the saved message text (or "" on error).
+        """
+        messages = await db.get_messages(conv_id)
+        ctx = await build_pipeline_ctx_for_character(
+            conv, messages, char_card,
+            pipeline=_pipeline, template_path=_template_path)
+
+        card_data = char_card.get("card_data", {}).get("data", char_card.get("card_data", {}))
+        char_name = card_data.get("name", "Character")
+        char_id = char_card["id"]
+
+        try:
+            await _budget_ctx(ctx, model, ollama_options)
+        except BudgetError as e:
+            yield json.dumps({"error": f"Budget error for {char_name}: {e}", "done": False}) + "\n"
+            return
+
+        opts = {**ollama_options, "num_ctx": ctx["_num_ctx"]}
+        chat_messages = build_multi_char_messages(ctx, char_id, card_names)
+        user_name = get_user_name(ctx)
+
+        tokens = []
+        raw = {}
+        try:
+            async for chunk in _ollama.chat_stream(
+                model=model, messages=chat_messages,
+                options=opts, stop=[f"{user_name}:", "\n\n\n"],
+            ):
+                yield json.dumps(chunk) + "\n"
+                if chunk.get("done"):
+                    raw = chunk
+                elif not chunk.get("thinking"):
+                    tokens.append(chunk["token"])
+        except Exception as e:
+            yield json.dumps({"error": str(e), "done": False}) + "\n"
+            return
+
+        response_text = "".join(tokens)
+        recent_asst = [m["content"] for m in ctx.get("messages", [])
+                       if m.get("role") == "assistant"
+                       and m.get("_character_card_id") == char_id][-6:]
+        post_ctx = {
+            "response": response_text, "ai_name": char_name,
+            "_char_pronouns": card_data.get("pronouns", ""),
+            "_user_name": get_user_name(ctx),
+            "_user_pronouns": get_user_pronouns(ctx),
+            "_recent_assistant_messages": recent_asst,
+        }
+        post_ctx = await _pipeline.run_post(post_ctx)
+        final_text = post_ctx["response"]
+
+        await db.add_message(
+            conv_id, "assistant", final_text, raw_response=raw,
+            system_prompt=ctx.get("system_prompt", ""),
+            scene_state=conv.get("scene_state", ""),
+            post_prompt=ctx.get("post_prompt", ""),
+            budget_json=budget_to_json(ctx),
+            prompt_json=chat_messages,
+            character_card_id=char_id,
+        )
+        conv_log.log_response(conv_id, "assistant", final_text, raw)
+
     @app.post("/rp/conversations/{conv_id}/message")
     async def send_message(conv_id: int, req: SendMessageRequest):
         conv = await db.get_conversation(conv_id)
         if not conv:
             raise HTTPException(404, "Conversation not found")
 
+        characters = await db.get_conversation_characters(conv_id)
+        is_multi = len(characters) > 1
+
         await db.add_message(conv_id, "user", req.content)
         conv_log.log_response(conv_id, "user", req.content)
+
+        if is_multi:
+            return await _send_multi_char_message(conv_id, conv, characters, req.content)
 
         messages = await db.get_messages(conv_id)
         ctx = await _build_pipeline_ctx(conv, messages)
@@ -979,9 +1115,9 @@ def setup(app: FastAPI, ollama, resolve_model=None):
                     post_prompt=ctx.get("post_prompt", ""),
                     budget_json=budget_to_json(ctx),
                     prompt_json=chat_messages,
+                    character_card_id=conv["ai_card_id"],
                 )
                 conv_log.log_response(conv_id, "assistant", post_ctx["response"], raw)
-                # Update scene state and maybe generate summary in background
                 budget_report = ctx.get("_budget_report")
                 msg_budget = budget_report.messages_budget if budget_report else 0
                 asyncio.create_task(_auto_update_scene_state(conv_id, model,
@@ -995,6 +1131,61 @@ def setup(app: FastAPI, ollama, resolve_model=None):
                 yield json.dumps({"error": f"Failed to save response: {e}", "done": True}) + "\n"
 
         return StreamingResponse(stream(), media_type="application/x-ndjson")
+
+    async def _send_multi_char_message(conv_id, conv, characters, user_content):
+        """Handle message in a multi-character conversation with round-robin generation."""
+        model = _resolve_model(conv["model"])
+        scenario = {}
+        if conv["scenario_id"]:
+            scenario = await db.get_scenario(conv["scenario_id"]) or {}
+        settings = scenario.get("settings", {})
+        ollama_options = scale_num_predict(
+            build_ollama_options(settings), user_content)
+
+        char_cards = {}
+        card_names = {}
+        for ch in characters:
+            card = await db.get_card(ch["card_id"])
+            if card:
+                char_cards[ch["card_id"]] = card
+                cdata = card.get("card_data", {}).get("data", card.get("card_data", {}))
+                card_names[ch["card_id"]] = cdata.get("name", "Character")
+
+        async def multi_stream():
+            yield json.dumps({"multi_character": True, "character_count": len(characters)}) + "\n"
+
+            for ch in characters:
+                card_id = ch["card_id"]
+                card = char_cards.get(card_id)
+                if not card:
+                    continue
+                name = card_names.get(card_id, "Character")
+
+                yield json.dumps({
+                    "character_start": {
+                        "card_id": card_id,
+                        "name": name,
+                        "color": ch.get("color", ""),
+                    }
+                }) + "\n"
+
+                async for chunk in _generate_for_character(
+                    conv_id, conv, card, card_names,
+                    model, ollama_options, user_content,
+                ):
+                    yield chunk
+
+                yield json.dumps({"character_done": {"card_id": card_id, "name": name}}) + "\n"
+
+            asyncio.create_task(_auto_update_scene_state(
+                conv_id, model,
+                card_names.get(characters[0]["card_id"], "Character"),
+                get_user_name({"user_card": char_cards.get(conv["user_card_id"], await db.get_card(conv["user_card_id"]))}),
+                "",
+                user_description=""))
+            yield json.dumps({"done": True}) + "\n"
+
+        return StreamingResponse(multi_stream(), media_type="application/x-ndjson")
 
     @app.post("/rp/conversations/{conv_id}/save-partial")
     async def save_partial(conv_id: int, req: SavePartialRequest):

--- a/projects/rp/schema.sql
+++ b/projects/rp/schema.sql
@@ -250,3 +250,25 @@ CREATE TABLE IF NOT EXISTS rp_lorebook_entries (
 
 CREATE INDEX IF NOT EXISTS idx_rp_lorebook_entries_book
     ON rp_lorebook_entries(lorebook_id, insertion_order);
+
+-- Migration: track which character authored each message (multi-character conversations)
+DO $$ BEGIN
+    ALTER TABLE rp_messages ADD COLUMN character_card_id INTEGER REFERENCES rp_character_cards(id) ON DELETE SET NULL;
+EXCEPTION WHEN duplicate_column THEN NULL;
+END $$;
+
+CREATE INDEX IF NOT EXISTS idx_rp_messages_character ON rp_messages(character_card_id);
+
+-- Junction table: which AI characters participate in a conversation
+CREATE TABLE IF NOT EXISTS rp_conversation_characters (
+    id              SERIAL PRIMARY KEY,
+    conversation_id INTEGER NOT NULL REFERENCES rp_conversations(id) ON DELETE CASCADE,
+    card_id         INTEGER NOT NULL REFERENCES rp_character_cards(id) ON DELETE CASCADE,
+    color           TEXT NOT NULL DEFAULT '',
+    generation_order INTEGER NOT NULL DEFAULT 0,
+    created_at      TIMESTAMPTZ DEFAULT NOW(),
+    UNIQUE(conversation_id, card_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_rp_conv_chars
+    ON rp_conversation_characters(conversation_id, generation_order);

--- a/projects/rp/static/app.js
+++ b/projects/rp/static/app.js
@@ -268,7 +268,11 @@
       item.appendChild(avatar);
 
       const info = el("div", { className: "conv-info" });
-      const name = el("div", { className: "conv-name", textContent: "Conv #" + c.id });
+      var convLabel = "Conv #" + c.id;
+      if (c.character_count && c.character_count > 1) {
+        convLabel += " [" + c.character_count + " chars]";
+      }
+      const name = el("div", { className: "conv-name", textContent: convLabel });
       const date = el("div", { className: "conv-date", textContent: timeAgo(c.updated_at) });
       info.appendChild(name);
       info.appendChild(date);
@@ -325,13 +329,33 @@
   }
 
   function renderChat(detail) {
-    const { conversation, user_card, ai_card, scenario, messages } = detail;
+    const { conversation, user_card, ai_card, ai_cards, characters, scenario, messages } = detail;
+
+    var charMap = {};
+    if (characters && characters.length > 0) {
+      for (var ci = 0; ci < characters.length; ci++) {
+        charMap[characters[ci].card_id] = characters[ci];
+      }
+    }
+    var cardMap = {};
+    if (ai_cards && ai_cards.length > 0) {
+      for (var ci = 0; ci < ai_cards.length; ci++) {
+        cardMap[ai_cards[ci].id] = ai_cards[ci];
+      }
+    }
+    cardMap[ai_card.id] = ai_card;
+    var isMultiChar = characters && characters.length > 1;
 
     // Header
     $("chatHeader").style.display = "";
     setAvatarSrc($("chatHeaderAvatar"), ai_card.id, ai_card.has_avatar);
     const aiData = ai_card.card_data.data || ai_card.card_data;
-    $("chatHeaderName").textContent = aiData.name || ai_card.name;
+    var headerName = aiData.name || ai_card.name;
+    if (isMultiChar) {
+      var charNames = characters.map(function (ch) { return ch.card_name || "?"; });
+      headerName = charNames.join(", ");
+    }
+    $("chatHeaderName").textContent = headerName;
     $("chatHeaderModel").textContent = conversation.model + (scenario ? " | " + scenario.name : "");
 
     // Messages
@@ -350,7 +374,16 @@
     }
 
     for (var i = 0; i < messages.length; i++) {
-      appendMessageBubble(container, messages[i], user_card, ai_card, i);
+      var msg = messages[i];
+      var msgCard = ai_card;
+      var msgChar = null;
+      if (msg.character_card_id && cardMap[msg.character_card_id]) {
+        msgCard = cardMap[msg.character_card_id];
+      }
+      if (msg.character_card_id && charMap[msg.character_card_id]) {
+        msgChar = charMap[msg.character_card_id];
+      }
+      appendMessageBubble(container, msg, user_card, msgCard, i, isMultiChar ? msgChar : null);
     }
 
     // Scroll to bottom
@@ -395,7 +428,7 @@
     });
   }
 
-  function appendMessageBubble(container, msg, userCard, aiCard, msgIndex) {
+  function appendMessageBubble(container, msg, userCard, aiCard, msgIndex, charInfo) {
     const isUser = msg.role === "user";
     const wrapper = el("div", { className: "message " + msg.role });
 
@@ -408,6 +441,20 @@
     wrapper.appendChild(avatar);
 
     const col = el("div");
+
+    if (charInfo && !isUser) {
+      var nameData = aiCard.card_data.data || aiCard.card_data;
+      var charLabel = el("div", {
+        className: "char-name-label",
+        textContent: nameData.name || aiCard.name,
+      });
+      if (charInfo.color) {
+        charLabel.style.color = charInfo.color;
+        wrapper.style.borderLeft = "3px solid " + charInfo.color;
+      }
+      col.appendChild(charLabel);
+    }
+
     const bubble = el("div", { className: "message-bubble" });
     renderDialogue(bubble, msg.content, msg.role);
     col.appendChild(bubble);
@@ -591,26 +638,70 @@
       opts.body = JSON.stringify(body);
     }
 
-    // Create message bubble for streaming — role may be overridden by auto_role from server
     var streamRole = forceRole || "assistant";
-    const wrapper = el("div", { className: "message " + streamRole });
-    const avatar = el("img", { className: "message-avatar", alt: "" });
-    if (currentConvDetail) {
-      var card = streamRole === "user" ? currentConvDetail.user_card : currentConvDetail.ai_card;
-      setAvatarSrc(avatar, card.id, card.has_avatar);
-    }
-    wrapper.appendChild(avatar);
-
-    const col = el("div");
-    let thinkingSection = null;
-    let thinkingContent = null;
-    let hasThinking = false;
+    var isMultiChar = false;
+    var wrapper, avatar, col, bubble, thinkingSection, thinkingContent, hasThinking;
     let hadError = false;
 
-    const bubble = el("div", { className: "message-bubble streaming-cursor" });
-    col.appendChild(bubble);
-    wrapper.appendChild(col);
-    container.appendChild(wrapper);
+    function createBubble(charStart) {
+      wrapper = el("div", { className: "message assistant" });
+      avatar = el("img", { className: "message-avatar", alt: "" });
+      col = el("div");
+      thinkingSection = null;
+      thinkingContent = null;
+      hasThinking = false;
+
+      if (charStart) {
+        var charCard = null;
+        if (currentConvDetail && currentConvDetail.ai_cards) {
+          for (var ci = 0; ci < currentConvDetail.ai_cards.length; ci++) {
+            if (currentConvDetail.ai_cards[ci].id === charStart.card_id) {
+              charCard = currentConvDetail.ai_cards[ci];
+              break;
+            }
+          }
+        }
+        if (!charCard && currentConvDetail) charCard = currentConvDetail.ai_card;
+        if (charCard) setAvatarSrc(avatar, charCard.id, charCard.has_avatar);
+        var nameLabel = el("div", {
+          className: "char-name-label",
+          textContent: charStart.name || "Character",
+        });
+        if (charStart.color) {
+          nameLabel.style.color = charStart.color;
+          wrapper.style.borderLeft = "3px solid " + charStart.color;
+        }
+        col.appendChild(nameLabel);
+      } else {
+        if (currentConvDetail) {
+          var card = streamRole === "user" ? currentConvDetail.user_card : currentConvDetail.ai_card;
+          setAvatarSrc(avatar, card.id, card.has_avatar);
+        }
+        wrapper.className = "message " + streamRole;
+      }
+
+      wrapper.appendChild(avatar);
+      bubble = el("div", { className: "message-bubble streaming-cursor" });
+      col.appendChild(bubble);
+      wrapper.appendChild(col);
+      container.appendChild(wrapper);
+    }
+
+    function finalizeBubble() {
+      if (!bubble) return;
+      bubble.classList.remove("streaming-cursor");
+      var fullText = bubble.textContent;
+      if (fullText) {
+        bubble.textContent = "";
+        renderDialogue(bubble, fullText, "assistant");
+      }
+      if (thinkingContent) {
+        var toggle = thinkingSection.querySelector(".msg-thinking-toggle");
+        if (toggle) toggle.textContent = "Hide thinking";
+      }
+    }
+
+    createBubble(null);
 
     try {
       const resp = await fetch(url, opts);
@@ -630,6 +721,22 @@
           if (!line.trim()) continue;
           const chunk = JSON.parse(line);
 
+          if (chunk.multi_character) {
+            isMultiChar = true;
+            wrapper.remove();
+            continue;
+          }
+
+          if (chunk.character_start) {
+            createBubble(chunk.character_start);
+            continue;
+          }
+
+          if (chunk.character_done) {
+            finalizeBubble();
+            continue;
+          }
+
           if (chunk.debug_prompt !== undefined) {
             $("underHoodPromptContent").textContent = chunk.debug_prompt || "(empty)";
             $("underHoodUserPromptContent").textContent = chunk.debug_user_prompt || "(empty)";
@@ -647,8 +754,7 @@
             } else {
               $("underHoodLorebookContent").textContent = "No lorebook entries matched.";
             }
-            // Update bubble side if auto_role differs
-            if (chunk.auto_role && chunk.auto_role !== streamRole) {
+            if (chunk.auto_role && chunk.auto_role !== streamRole && !isMultiChar) {
               streamRole = chunk.auto_role;
               wrapper.className = "message " + streamRole;
               if (currentConvDetail) {
@@ -661,19 +767,20 @@
 
           if (chunk.error) {
             hadError = true;
-            bubble.classList.remove("streaming-cursor");
-            const errSpan = el("span", {
-              style: { color: "#f85149" },
-              textContent: "Error: " + chunk.error,
-            });
-            bubble.appendChild(errSpan);
-            break;
+            if (bubble) {
+              bubble.classList.remove("streaming-cursor");
+              const errSpan = el("span", {
+                style: { color: "#f85149" },
+                textContent: "Error: " + chunk.error,
+              });
+              bubble.appendChild(errSpan);
+            }
+            if (chunk.done !== false) break;
+            continue;
           }
 
-          // Queue status messages
           if (chunk.status) {
-            if (chunk.status === "preempted") {
-              // Clear partial text — generation will restart
+            if (chunk.status === "preempted" && bubble) {
               bubble.textContent = "";
               if (thinkingContent) thinkingContent.textContent = "";
             }
@@ -697,24 +804,14 @@
               thinkingSection.appendChild(toggle);
               thinkingContent = el("div", { className: "msg-thinking-content" });
               thinkingSection.appendChild(thinkingContent);
-              // Insert thinking before the bubble
               col.insertBefore(thinkingSection, bubble);
             }
             thinkingContent.textContent += chunk.token;
           } else if (chunk.done) {
-            bubble.classList.remove("streaming-cursor");
-            // Re-render with dialogue coloring
-            var fullText = bubble.textContent;
-            bubble.textContent = "";
-            renderDialogue(bubble, fullText, streamRole);
-            if (thinkingContent) {
-              const toggle = thinkingSection.querySelector(".msg-thinking-toggle");
-              toggle.textContent = "Hide thinking";
-            }
-            // Update under-the-hood
+            if (!isMultiChar) finalizeBubble();
             $("underHoodContent").textContent = JSON.stringify(chunk, null, 2);
           } else {
-            bubble.textContent += chunk.token;
+            if (bubble) bubble.textContent += chunk.token;
           }
 
           var atBottom = container.scrollHeight - container.scrollTop - container.clientHeight < 60;
@@ -723,8 +820,7 @@
       }
     } catch (e) {
       if (e.name === "AbortError") {
-        // Stop was pressed — save whatever we have so far
-        var partialText = bubble.textContent.trim();
+        var partialText = bubble ? bubble.textContent.trim() : "";
         if (partialText && currentConvId) {
           try {
             await fetch("/rp/conversations/" + currentConvId + "/save-partial", {
@@ -734,18 +830,22 @@
             });
           } catch (_) {}
         }
-        bubble.classList.remove("streaming-cursor");
-        if (partialText) {
-          bubble.textContent = "";
-          renderDialogue(bubble, partialText, streamRole);
+        if (bubble) {
+          bubble.classList.remove("streaming-cursor");
+          if (partialText) {
+            bubble.textContent = "";
+            renderDialogue(bubble, partialText, streamRole);
+          }
         }
       } else {
         hadError = true;
-        bubble.classList.remove("streaming-cursor");
-        bubble.textContent += "\n[Stream error: " + e.message + "]";
+        if (bubble) {
+          bubble.classList.remove("streaming-cursor");
+          bubble.textContent += "\n[Stream error: " + e.message + "]";
+        }
       }
     } finally {
-      bubble.classList.remove("streaming-cursor");
+      if (bubble) bubble.classList.remove("streaming-cursor");
       abortController = null;
     }
     return hadError;
@@ -1069,11 +1169,13 @@
     // Populate selects
     const userSelect = $("modalUserCard");
     const aiSelect = $("modalAiCard");
+    const extraAiSelect = $("modalExtraAiCards");
     const scenarioSelect = $("modalScenario");
     const modelSelect = $("modalModel");
 
     userSelect.textContent = "";
     aiSelect.textContent = "";
+    extraAiSelect.textContent = "";
 
     for (const card of allCards) {
       const cardData = card.card_data.data || card.card_data;
@@ -1090,6 +1192,11 @@
       opt2.textContent = label;
       if (last && card.id === last.ai_card_id) opt2.selected = true;
       aiSelect.appendChild(opt2);
+
+      const opt3 = document.createElement("option");
+      opt3.value = card.id;
+      opt3.textContent = label;
+      extraAiSelect.appendChild(opt3);
     }
 
     // Scenarios
@@ -1124,12 +1231,18 @@
     const scenarioId = $("modalScenario").value ? parseInt($("modalScenario").value) : null;
     const model = $("modalModel").value;
 
+    var extraAiIds = [];
+    var extraOpts = $("modalExtraAiCards").selectedOptions;
+    for (var i = 0; i < extraOpts.length; i++) {
+      var eid = parseInt(extraOpts[i].value);
+      if (eid !== aiCardId) extraAiIds.push(eid);
+    }
+
     if (!userCardId || !aiCardId || !model) {
       alert("Please select all required fields.");
       return;
     }
 
-    // Show a timer while waiting for first message generation
     $("newChatModal").classList.remove("open");
     switchView("chat");
     var timerStart = Date.now();
@@ -1147,6 +1260,7 @@
       const conv = await api("POST", "/rp/conversations", {
         user_card_id: userCardId,
         ai_card_id: aiCardId,
+        ai_card_ids: extraAiIds,
         scenario_id: scenarioId,
         model: model,
       });

--- a/projects/rp/static/index.html
+++ b/projects/rp/static/index.html
@@ -261,6 +261,13 @@
   }
   .message.user .message-number { text-align: left; }
 
+  .char-name-label {
+    font-size: 0.75em;
+    font-weight: 600;
+    margin-bottom: 3px;
+    padding-left: 2px;
+  }
+
   /* Thinking section in messages */
   .msg-thinking {
     margin-bottom: 8px;
@@ -1215,8 +1222,12 @@
         <select id="modalUserCard"></select>
       </div>
       <div class="form-group">
-        <label for="modalAiCard">AI Character</label>
+        <label for="modalAiCard">AI Character (primary)</label>
         <select id="modalAiCard"></select>
+      </div>
+      <div class="form-group">
+        <label for="modalExtraAiCards">Additional AI Characters (multi-select, optional)</label>
+        <select id="modalExtraAiCards" multiple style="height:80px"></select>
       </div>
       <div class="form-group">
         <label for="modalScenario">Scenario (optional)</label>

--- a/projects/rp/tests/test_routes.py
+++ b/projects/rp/tests/test_routes.py
@@ -33,8 +33,9 @@ class FakeDB:
         self.messages: dict[int, dict] = {}
         self.eval_sets: dict[int, dict] = {}
         self.eval_candidates: dict[int, dict] = {}
+        self.conv_characters: list[dict] = []
         self._next = {"card": 1, "scenario": 1, "conv": 1, "msg": 1,
-                       "eval_set": 1, "eval_cand": 1}
+                       "eval_set": 1, "eval_cand": 1, "conv_char": 1}
 
     def _now(self) -> str:
         return datetime.now(timezone.utc).isoformat()
@@ -139,7 +140,13 @@ class FakeDB:
     # -- Conversations --
 
     async def list_conversations(self) -> list[dict]:
-        return sorted(self.conversations.values(), key=lambda c: c["id"])
+        result = []
+        for c in sorted(self.conversations.values(), key=lambda c: c["id"]):
+            cc = dict(c)
+            cc["character_count"] = len([ch for ch in self.conv_characters
+                                          if ch["conversation_id"] == c["id"]])
+            result.append(cc)
+        return result
 
     async def create_conversation(self, user_card_id: int, ai_card_id: int,
                                   scenario_id: int | None,
@@ -150,7 +157,8 @@ class FakeDB:
             "id": cid, "user_card_id": user_card_id,
             "ai_card_id": ai_card_id, "scenario_id": scenario_id,
             "model": model, "scene_state": "", "scene_state_msg_id": None,
-            "category": "user", "created_at": now, "updated_at": now,
+            "category": "user", "authors_note": "", "authors_note_depth": 4,
+            "created_at": now, "updated_at": now,
         }
         self.conversations[cid] = conv
         return conv
@@ -167,6 +175,37 @@ class FakeDB:
             if v["conversation_id"] != conv_id
         }
         return True
+
+    async def get_conversation_characters(self, conv_id: int) -> list[dict]:
+        return [c for c in self.conv_characters if c["conversation_id"] == conv_id]
+
+    async def add_conversation_character(self, conv_id: int, card_id: int,
+                                          color: str = "", generation_order: int = 0) -> dict:
+        cid = self._id("conv_char")
+        entry = {
+            "id": cid, "conversation_id": conv_id, "card_id": card_id,
+            "color": color, "generation_order": generation_order,
+            "card_name": "", "created_at": self._now(),
+        }
+        card = self.cards.get(card_id)
+        if card:
+            cd = card.get("card_data", {}).get("data", card.get("card_data", {}))
+            entry["card_name"] = cd.get("name", card.get("name", ""))
+        self.conv_characters.append(entry)
+        return entry
+
+    async def remove_conversation_character(self, conv_id: int, card_id: int) -> bool:
+        before = len(self.conv_characters)
+        self.conv_characters = [c for c in self.conv_characters
+                                 if not (c["conversation_id"] == conv_id and c["card_id"] == card_id)]
+        return len(self.conv_characters) < before
+
+    async def update_conversation_character(self, conv_id: int, card_id: int, **kwargs) -> dict | None:
+        for c in self.conv_characters:
+            if c["conversation_id"] == conv_id and c["card_id"] == card_id:
+                c.update(kwargs)
+                return c
+        return None
 
     async def delete_all_messages(self, conv_id: int):
         self.messages = {
@@ -196,7 +235,8 @@ class FakeDB:
                           raw_response=None, system_prompt: str | None = None,
                           scene_state: str | None = None,
                           post_prompt: str | None = None,
-                          budget_json=None, prompt_json=None) -> dict:
+                          budget_json=None, prompt_json=None,
+                          character_card_id: int | None = None) -> dict:
         mid = self._id("msg")
         existing = [m for m in self.messages.values()
                     if m["conversation_id"] == conv_id]
@@ -204,7 +244,8 @@ class FakeDB:
         msg = {
             "id": mid, "conversation_id": conv_id, "role": role,
             "content": content, "raw_response": raw_response,
-            "sequence": seq, "created_at": self._now(),
+            "sequence": seq, "character_card_id": character_card_id,
+            "created_at": self._now(),
         }
         self.messages[mid] = msg
         return msg


### PR DESCRIPTION
## Summary

- Conversations can have multiple AI characters who respond in round-robin order after each user message
- Each character gets its own pipeline context with history rewritten from its perspective — other AI characters appear as `role=user` messages with `[Name]: ` prefixes, preserving the `user`/`assistant` binary that Ollama requires
- Stream protocol uses `character_start`/`character_done` NDJSON delimiters so the frontend creates separate color-coded bubbles per character
- Fully backward compatible: single-character conversations are completely unchanged

### Changes
- **schema.sql**: `rp_conversation_characters` junction table, `character_card_id` column on `rp_messages`
- **db.py**: CRUD for conversation characters, `character_card_id` in message queries
- **models.py**: `ConversationCharacterResponse`, `AddCharacterRequest`, `ai_card_ids` on `ConversationCreate`
- **prompt_builder.py**: `rewrite_history_for_character()`, `build_multi_char_messages()`, `build_pipeline_ctx_for_character()`
- **pipeline.py**: `inject_avoid_list` filters by active character in multi-char mode
- **routes.py**: Character management endpoints, `_generate_for_character()` async generator, `_send_multi_char_message()` round-robin orchestrator
- **app.js**: Multi-char stream handling, character name/color labels, multi-select in creation modal
- **test_routes.py**: FakeDB updated with character CRUD

## Test plan

```bash
cd /mnt/d/prg/plum-feat-multi-character
# Run all tests
/mnt/d/prg/plum/projects/aiserver/.venv/bin/python -m pytest projects/rp/tests/ -x -q

# Manual test: create a multi-character conversation
# 1. Open http://localhost:8080/rp/
# 2. Click New Chat, select primary AI card, hold Ctrl to select additional cards
# 3. Send a message — all characters respond in order with colored name labels
# 4. Verify single-character conversations still work normally
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)