### PR TITLE
fix(rp): replace multi-select with 3 dropdown selects

### DIFF
--- a/projects/rp/static/app.js
+++ b/projects/rp/static/app.js
@@ -1169,13 +1169,19 @@
     // Populate selects
     const userSelect = $("modalUserCard");
     const aiSelect = $("modalAiCard");
-    const extraAiSelect = $("modalExtraAiCards");
+    const extraSelects = [$("modalAiCard2"), $("modalAiCard3"), $("modalAiCard4")];
     const scenarioSelect = $("modalScenario");
     const modelSelect = $("modalModel");
 
     userSelect.textContent = "";
     aiSelect.textContent = "";
-    extraAiSelect.textContent = "";
+    for (var ei = 0; ei < extraSelects.length; ei++) {
+      extraSelects[ei].textContent = "";
+      var noneOpt = document.createElement("option");
+      noneOpt.value = "";
+      noneOpt.textContent = "— None —";
+      extraSelects[ei].appendChild(noneOpt);
+    }
 
     for (const card of allCards) {
       const cardData = card.card_data.data || card.card_data;
@@ -1193,10 +1199,12 @@
       if (last && card.id === last.ai_card_id) opt2.selected = true;
       aiSelect.appendChild(opt2);
 
-      const opt3 = document.createElement("option");
-      opt3.value = card.id;
-      opt3.textContent = label;
-      extraAiSelect.appendChild(opt3);
+      for (var ei = 0; ei < extraSelects.length; ei++) {
+        var opt3 = document.createElement("option");
+        opt3.value = card.id;
+        opt3.textContent = label;
+        extraSelects[ei].appendChild(opt3);
+      }
     }
 
     // Scenarios
@@ -1232,11 +1240,13 @@
     const model = $("modalModel").value;
 
     var extraAiIds = [];
-    var extraOpts = $("modalExtraAiCards").selectedOptions;
-    for (var i = 0; i < extraOpts.length; i++) {
-      var eid = parseInt(extraOpts[i].value);
-      if (eid !== aiCardId) extraAiIds.push(eid);
-    }
+    ["modalAiCard2", "modalAiCard3", "modalAiCard4"].forEach(function (selId) {
+      var val = $(selId).value;
+      if (val) {
+        var eid = parseInt(val);
+        if (eid !== aiCardId && extraAiIds.indexOf(eid) === -1) extraAiIds.push(eid);
+      }
+    });
 
     if (!userCardId || !aiCardId || !model) {
       alert("Please select all required fields.");

--- a/projects/rp/static/index.html
+++ b/projects/rp/static/index.html
@@ -1226,8 +1226,16 @@
         <select id="modalAiCard"></select>
       </div>
       <div class="form-group">
-        <label for="modalExtraAiCards">Additional AI Characters (multi-select, optional)</label>
-        <select id="modalExtraAiCards" multiple style="height:80px"></select>
+        <label for="modalAiCard2">AI Character 2 (optional)</label>
+        <select id="modalAiCard2"></select>
+      </div>
+      <div class="form-group">
+        <label for="modalAiCard3">AI Character 3 (optional)</label>
+        <select id="modalAiCard3"></select>
+      </div>
+      <div class="form-group">
+        <label for="modalAiCard4">AI Character 4 (optional)</label>
+        <select id="modalAiCard4"></select>
       </div>
       <div class="form-group">
         <label for="modalScenario">Scenario (optional)</label>


### PR DESCRIPTION
## Summary

- Replace the HTML `<select multiple>` (which required Ctrl+click) with 3 standard dropdown selects for additional AI characters
- Each dropdown has a "— None —" default, deduplicates against the primary card

🤖 Generated with [Claude Code](https://claude.com/claude-code)