### PR TITLE
fix(rp): keep {{char}} as primary character in multi-char mode

### DIFF
--- a/projects/rp/pipeline.py
+++ b/projects/rp/pipeline.py
@@ -33,19 +33,26 @@ class Pipeline:
 # -- Built-in pre-processing hooks --
 
 def expand_variables(ctx: dict) -> dict:
-    """Replace ${user}, ${char}, ${scenario} in all text fields."""
+    """Replace ${user}, ${char}, ${active_char}, ${char2-4}, ${scenario} in all text fields."""
     user_card = ctx.get("user_card", {})
     ai_card = ctx.get("ai_card", {})
+    active_card = ctx.get("_active_card", ai_card)
     scenario = ctx.get("scenario", {})
 
     user_data = user_card.get("card_data", {}).get("data", user_card.get("card_data", {}))
     ai_data = ai_card.get("card_data", {}).get("data", ai_card.get("card_data", {}))
+    active_data = active_card.get("card_data", {}).get("data", active_card.get("card_data", {}))
 
     replacements = {
         "${user}": user_data.get("name", "User"),
         "${char}": ai_data.get("name", "Character"),
+        "${active_char}": active_data.get("name", ai_data.get("name", "Character")),
         "${scenario}": scenario.get("description", ""),
     }
+
+    for i, cc in enumerate(ctx.get("_char_cards", [])[1:], start=2):
+        cd = cc.get("card_data", {}).get("data", cc.get("card_data", {}))
+        replacements[f"${{char{i}}}"] = cd.get("name", f"Character{i}")
 
     def replace(text: str) -> str:
         for var, val in replacements.items():
@@ -61,9 +68,10 @@ def expand_variables(ctx: dict) -> dict:
     # from a card that was overwritten), discard it to prevent identity bleed.
     scene_state = ctx.get("scene_state", "")
     if scene_state.strip():
-        ai_name = ai_data.get("name", "")
+        ai_name = active_data.get("name", ai_data.get("name", ""))
+        primary_name = ai_data.get("name", "")
         user_name = user_data.get("name", "")
-        if ai_name and ai_name not in scene_state:
+        if primary_name and primary_name not in scene_state:
             _log.warning("Scene state discarded — references unknown character "
                          "(expected %r, state: %s)", ai_name, scene_state[:120])
             ctx["scene_state"] = ""
@@ -204,24 +212,35 @@ def _match_scene_condition(category: str, keywords: list[str],
 def assemble_prompt(ctx: dict) -> dict:
     """Build system_prompt, post_prompt, and style pool from template + card data."""
     ai_card = ctx.get("ai_card", {})
+    active_card = ctx.get("_active_card", ai_card)
     scenario = ctx.get("scenario", {})
     user_card = ctx.get("user_card", {})
     ai_data = ai_card.get("card_data", {}).get("data", ai_card.get("card_data", {}))
+    active_data = active_card.get("card_data", {}).get("data", active_card.get("card_data", {}))
     user_data = user_card.get("card_data", {}).get("data", user_card.get("card_data", {}))
+
+    is_multi = ctx.get("_multi_character", False)
+    desc_data = active_data if is_multi else ai_data
 
     template = ctx.get("prompt_template", "") or DEFAULT_PROMPT_TEMPLATE
 
     values = {
         "scenario": scenario.get("description", ""),
-        "description": ai_data.get("description", ""),
-        "personality": ai_data.get("personality", ""),
-        "mes_example": ai_data.get("mes_example", ""),
+        "description": desc_data.get("description", ""),
+        "personality": desc_data.get("personality", ""),
+        "mes_example": desc_data.get("mes_example", ""),
         "char": ai_data.get("name", "Character"),
+        "active_char": active_data.get("name", ai_data.get("name", "Character")),
         "user": user_data.get("name", "User"),
         "user_description": user_data.get("description", ""),
         "user_pronouns": user_data.get("pronouns", "") or infer_pronouns(user_data.get("description", "")),
-        "char_pronouns": ai_data.get("pronouns", "") or infer_pronouns(ai_data.get("description", "")),
+        "char_pronouns": desc_data.get("pronouns", "") or infer_pronouns(desc_data.get("description", "")),
     }
+
+    char_cards = ctx.get("_char_cards", [])
+    for i, cc in enumerate(char_cards[1:], start=2):
+        cd = cc.get("card_data", {}).get("data", cc.get("card_data", {}))
+        values[f"char{i}"] = cd.get("name", f"Character{i}")
 
     system_part, post_part, style_part, scene_style_part = _split_template(template)
     ctx["system_prompt"] = render_template(system_part, values)

--- a/projects/rp/prompt_builder.py
+++ b/projects/rp/prompt_builder.py
@@ -240,9 +240,11 @@ async def build_pipeline_ctx(conv, messages, *, pipeline, template_path: Path):
 
 
 async def build_pipeline_ctx_for_character(conv, messages, active_card, *,
-                                            pipeline, template_path: Path):
-    """Like build_pipeline_ctx but swaps ai_card to the active character's card."""
+                                            pipeline, template_path: Path,
+                                            all_char_cards: list[dict] | None = None):
+    """Like build_pipeline_ctx but uses the primary card for {{char}} and active card for generation."""
     user_card = await db.get_card(conv["user_card_id"])
+    primary_card = await db.get_card(conv["ai_card_id"])
     scenario = await db.get_scenario(conv["scenario_id"]) if conv["scenario_id"] else {}
     scenario = scenario or {}
 
@@ -262,8 +264,9 @@ async def build_pipeline_ctx_for_character(conv, messages, active_card, *,
 
     ctx = {
         "user_card": user_card,
-        "ai_card": active_card,
+        "ai_card": primary_card,
         "_active_card": active_card,
+        "_char_cards": all_char_cards or [primary_card],
         "scenario": scenario,
         "messages": msg_dicts,
         "system_prompt": "",

--- a/projects/rp/routes.py
+++ b/projects/rp/routes.py
@@ -884,16 +884,17 @@ def setup(app: FastAPI, ollama, resolve_model=None):
             yield json.dumps({"error": f"Failed to save response: {e}", "done": True}) + "\n"
 
     async def _generate_for_character(conv_id, conv, char_card, card_names,
-                                      model, ollama_options, user_content):
+                                      model, ollama_options, user_content,
+                                      all_char_cards=None):
         """Generate one character's response in a multi-char conversation.
 
         Yields NDJSON chunks. Saves the message to DB when done.
-        Returns the saved message text (or "" on error).
         """
         messages = await db.get_messages(conv_id)
         ctx = await build_pipeline_ctx_for_character(
             conv, messages, char_card,
-            pipeline=_pipeline, template_path=_template_path)
+            pipeline=_pipeline, template_path=_template_path,
+            all_char_cards=all_char_cards)
 
         card_data = char_card.get("card_data", {}).get("data", char_card.get("card_data", {}))
         char_name = card_data.get("name", "Character")
@@ -1151,6 +1152,8 @@ def setup(app: FastAPI, ollama, resolve_model=None):
                 cdata = card.get("card_data", {}).get("data", card.get("card_data", {}))
                 card_names[ch["card_id"]] = cdata.get("name", "Character")
 
+        all_cards_ordered = [char_cards[ch["card_id"]] for ch in characters if ch["card_id"] in char_cards]
+
         async def multi_stream():
             yield json.dumps({"multi_character": True, "character_count": len(characters)}) + "\n"
 
@@ -1172,6 +1175,7 @@ def setup(app: FastAPI, ollama, resolve_model=None):
                 async for chunk in _generate_for_character(
                     conv_id, conv, card, card_names,
                     model, ollama_options, user_content,
+                    all_char_cards=all_cards_ordered,
                 ):
                     yield chunk
 


### PR DESCRIPTION
## Summary
- `{{char}}` now always resolves to the primary AI character (conversation's `ai_card_id`), not the currently-generating character
- Added `{{char2}}`-`{{char4}}` and `${char2}`-`${char4}` template variables for additional characters
- Added `{{active_char}}`/`${active_char}` for the character currently generating
- `_active_card` carries the generating character's card; `ai_card` stays as primary throughout pipeline

## Test plan
- [x] All 512 tests pass
- [ ] Start a multi-char conversation (e.g. Amber primary + Riley secondary)
- [ ] Verify `{{char}}` in scenario/system prompt resolves to Amber for both characters
- [ ] Verify Riley's personality/description is used when generating Riley's response

🤖 Generated with [Claude Code](https://claude.com/claude-code)