### PR TITLE
fix(rp): preserve scenario character names in auto-reply swap

### DIFF
--- a/projects/rp/pipeline.py
+++ b/projects/rp/pipeline.py
@@ -233,7 +233,11 @@ def assemble_prompt(ctx: dict) -> dict:
     user_name = user_data.get("name", "User")
 
     scenario_text = scenario.get("description", "")
-    if is_multi and scenario_text:
+    scenario_names = ctx.get("_scenario_names")
+    if scenario_text and scenario_names:
+        scenario_text = scenario_text.replace("{{char}}", scenario_names["char"])
+        scenario_text = scenario_text.replace("{{user}}", scenario_names["user"])
+    elif is_multi and scenario_text:
         scenario_text = scenario_text.replace("{{char}}", primary_name)
         scenario_text = scenario_text.replace("{{user}}", user_name)
 

--- a/projects/rp/prompt_builder.py
+++ b/projects/rp/prompt_builder.py
@@ -230,6 +230,8 @@ async def build_pipeline_ctx(conv, messages, *, pipeline, template_path: Path):
         "authors_note": conv.get("authors_note", ""),
         "authors_note_depth": conv.get("authors_note_depth", 4),
     }
+    if conv.get("_scenario_names"):
+        ctx["_scenario_names"] = conv["_scenario_names"]
 
     summary_row = await db.get_latest_summary(conv["id"])
     if summary_row:

--- a/projects/rp/routes.py
+++ b/projects/rp/routes.py
@@ -1354,18 +1354,24 @@ def setup(app: FastAPI, ollama, resolve_model=None):
                 conv_id, conv, characters, last_user_content)
 
         if generating_as_user:
+            orig_ai_card = await db.get_card(conv["ai_card_id"])
+            orig_ai_data = orig_ai_card["card_data"].get("data", orig_ai_card["card_data"])
+            orig_user_card = await db.get_card(conv["user_card_id"])
+            orig_user_data = orig_user_card["card_data"].get("data", orig_user_card["card_data"])
             swapped_conv = dict(conv)
             swapped_conv["user_card_id"] = conv["ai_card_id"]
             swapped_conv["ai_card_id"] = conv["user_card_id"]
+            swapped_conv["_scenario_names"] = {
+                "char": orig_ai_data.get("name", "Character"),
+                "user": orig_user_data.get("name", "User"),
+            }
             swapped_messages = []
             for m in messages:
                 sm = dict(m)
                 sm["role"] = "assistant" if m["role"] == "user" else "user"
                 swapped_messages.append(sm)
             ctx = await _build_pipeline_ctx(swapped_conv, swapped_messages)
-            user_card = await db.get_card(conv["user_card_id"])
-            user_data = user_card["card_data"].get("data", user_card["card_data"])
-            user_name_str = user_data.get("name", "User")
+            user_name_str = orig_user_data.get("name", "User")
             ai_char_names = []
             for ch in characters:
                 card = await db.get_card(ch["card_id"])
@@ -1389,7 +1395,7 @@ def setup(app: FastAPI, ollama, resolve_model=None):
         if generating_as_user:
             model = _resolve_model("qwen3:14b")
             ollama_options = {
-                "temperature": 0.7, "num_predict": 128, "think": False,
+                "temperature": 0.7, "num_predict": 256, "think": False,
                 "repeat_penalty": 1.15, "repeat_last_n": 256,
             }
         else:


### PR DESCRIPTION
## Summary
- **Scenario name bleeding**: When auto-reply swaps cards for user-side generation, `{{char}}`/`{{user}}` in the scenario text resolved to swapped names. This made the model think Valentina walked through the rain (Amber's backstory). Now passes original names via `_scenario_names` so `assemble_prompt` pre-expands the scenario text correctly.
- **Truncated user messages**: Restores `num_predict` to 256 (was 128, causing mid-thought cutoffs). Repeat penalty prevents the loops that motivated the reduction.

## Test plan
```bash
cd /mnt/d/prg/plum-fix-auto-reply
source /mnt/d/prg/plum/projects/aiserver/.venv/bin/activate
python -m pytest projects/rp/tests/ -x -q

# Manual: start a new conv with scenario that uses {{char}}/{{user}}
# Run auto mode, verify user messages reference correct character details
# Verify user messages are not truncated mid-thought
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)