### PR TITLE
fix(rp): prevent cross-message repetition in auto-reply

### DIFF
--- a/projects/rp/routes.py
+++ b/projects/rp/routes.py
@@ -1475,6 +1475,13 @@ def setup(app: FastAPI, ollama, resolve_model=None):
                 "Use first person for actions (e.g. 'I walk over') and direct speech for dialogue.\n"
                 "Be reactive to what just happened — don't repeat or restart the scene."
             )
+            recent_user = [m["content"][:150] for m in messages if m["role"] == "user"][-3:]
+            if recent_user:
+                ctx["post_prompt"] += (
+                    "\n\nYou already wrote these — write something COMPLETELY DIFFERENT "
+                    "(different actions, different words, advance the scene):\n"
+                    + "\n---\n".join(recent_user)
+                )
             scene_state = ctx.get("scene_state", "")
             if scene_state.strip():
                 ctx["post_prompt"] += "\n\n[Current Scene State — do NOT contradict this]\n" + scene_state.strip()


### PR DESCRIPTION
## Summary
- Injects last 3 auto-generated user messages (truncated to 150 chars) into the post prompt as "don't repeat" examples
- Addresses conv 168 where Valentina's auto-reply user messages converged to near-identical text across turns
- `repeat_penalty` only works within a single generation; this fix handles cross-message repetition at the prompt level

## Test plan
```bash
source projects/aiserver/.venv/bin/activate
python -m pytest projects/rp/tests/ -q  # 512 pass

# Manual: open conv 168, run auto-reply 5+ turns, verify user messages don't repeat
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)