### PR TITLE
fix(rp): prevent AI-side cross-message opening line repetition

### DIFF
--- a/projects/rp/pipeline.py
+++ b/projects/rp/pipeline.py
@@ -67,6 +67,14 @@ def expand_variables(ctx: dict) -> dict:
     if ctx.get("post_prompt"):
         ctx["post_prompt"] = replace(ctx["post_prompt"])
 
+    recent_asst = [m["content"][:80] for m in ctx.get("messages", [])
+                   if m.get("role") == "assistant"][-3:]
+    if len(recent_asst) >= 2:
+        ctx["post_prompt"] += (
+            "\n\nDo NOT open with the same action, gesture, or phrase as your recent messages. "
+            "Vary your opening line:\n" + "\n".join(f"- {s}..." for s in recent_asst)
+        )
+
     # Inject scene state into post prompt so it's close to generation.
     # Guard: if scene state references a different character (e.g. stale data
     # from a card that was overwritten), discard it to prevent identity bleed.


### PR DESCRIPTION
## Summary
- Injects last 3 assistant message openings (80 chars) into the post prompt as "vary your opening" examples
- Addresses conv 171 where Amber repeated "Fuck, Val! Warn a girl next time!" across 4 consecutive messages
- Placed in `pipeline.py` `expand_variables` so it applies to all AI generation paths universally
- Only activates when there are 2+ recent assistant messages (no effect on conversation starts)
- No overlap with PR #194 (user-side) since auto-reply user path overwrites post_prompt entirely

## Test plan
```bash
source projects/aiserver/.venv/bin/activate
python -m pytest projects/rp/tests/ -q  # 512 pass

# Manual: continue conv 171 or similar, verify AI doesn't repeat opening lines
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)