### PR TITLE
fix(rp): turn selector was silently broken — think inside options

### DIFF
--- a/projects/rp/routes.py
+++ b/projects/rp/routes.py
@@ -1178,7 +1178,8 @@ def setup(app: FastAPI, ollama, resolve_model=None):
                     {"role": "system", "content": system},
                     {"role": "user", "content": prompt_text},
                 ],
-                options={"temperature": 0.3, "num_predict": 64, "think": False},
+                think=False,
+                options={"temperature": 0.3, "num_predict": 64},
             )
             raw_text = result.get("message", {}).get("content", "").strip()
             start = raw_text.find("[")


### PR DESCRIPTION
## Summary
- `_select_turn_order` passed `think: False` inside the `options` dict to `_ollama.chat()`
- `OllamaClient.chat()` takes `think` as a separate keyword arg — it doesn't pop it from options like `chat_stream()` and `generate_stream()` do
- Ollama silently ignored `think` inside options → qwen3 defaulted to thinking → 64-token budget consumed by thinking → empty content → fallback to default order every time
- Fix: pass `think=False` as keyword arg

## Test plan
```bash
source projects/aiserver/.venv/bin/activate
python -m pytest projects/rp/tests/ -q  # 512 pass

# Manual: send message in multi-char conv, check /tmp/aiserver.log for "Turn selector:" entries
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)