### PR TITLE
fix(rp): tighten avoid-list for dialect + repetition

### DIFF
--- a/projects/rp/pipeline.py
+++ b/projects/rp/pipeline.py
@@ -590,9 +590,19 @@ def detect_pov(ctx: dict) -> dict:
 
 
 AVOID_LIST_NGRAM = 4
+AVOID_LIST_SHORT_NGRAM = 3
 AVOID_LIST_MIN_OCCURRENCES = 2
 AVOID_LIST_MAX_PHRASES = 12
-AVOID_LIST_MIN_MESSAGES = 4
+AVOID_LIST_MIN_MESSAGES = 2
+
+DIALECT_PATTERNS = re.compile(
+    r"\b(whaddya|whatcha|lookit|gonna|wanna|gotta|kinda|sorta|lemme|dunno)"
+    r"(?:\b|(?=\s|$))"
+    r"|\b(ain't|y'know|ya'll|somethin'|anythin'|nothin'|everythin'"
+    r"|doin'|goin'|thinkin'|feelin'|sayin'|tryin'|comin'|runnin')"
+    r"(?=\s|[.,!?;:\"]|$)",
+    re.IGNORECASE,
+)
 
 
 def _merge_overlapping(ngrams: list[str]) -> list[str]:
@@ -621,8 +631,19 @@ def _merge_overlapping(ngrams: list[str]) -> list[str]:
     return merged
 
 
+def _detect_dialect(messages: list[str]) -> list[str]:
+    """Find dialect words used across messages."""
+    from collections import Counter
+    counts: Counter[str] = Counter()
+    for msg in messages:
+        found = set(m.group(0).lower() for m in DIALECT_PATTERNS.finditer(msg))
+        for word in found:
+            counts[word] += 1
+    return sorted(w for w, c in counts.items() if c >= 1)
+
+
 def inject_avoid_list(ctx: dict) -> dict:
-    """Scan recent assistant messages for repeated phrases, inject avoid list."""
+    """Scan recent assistant messages for repeated phrases and dialect, inject avoid list."""
     messages = ctx.get("messages", [])
     active_card_id = ctx.get("_active_card", {}).get("id") if ctx.get("_multi_character") else None
     if active_card_id:
@@ -631,34 +652,49 @@ def inject_avoid_list(ctx: dict) -> dict:
                        and m.get("_character_card_id") == active_card_id]
     else:
         recent_asst = [m["content"] for m in messages if m.get("role") == "assistant"]
-    if len(recent_asst) < AVOID_LIST_MIN_MESSAGES:
+
+    phrases: list[str] = []
+    dialect_words: list[str] = []
+
+    if len(recent_asst) >= AVOID_LIST_MIN_MESSAGES:
+        window = recent_asst[-6:]
+
+        from collections import Counter
+        ngram_counts: Counter[str] = Counter()
+        for msg in window:
+            seen: set[str] = set()
+            for n in (AVOID_LIST_NGRAM, AVOID_LIST_SHORT_NGRAM):
+                for ng in _extract_ngrams(msg, n):
+                    if ng not in seen:
+                        ngram_counts[ng] += 1
+                        seen.add(ng)
+
+        overused = sorted(
+            [ng for ng, count in ngram_counts.items()
+             if count >= AVOID_LIST_MIN_OCCURRENCES],
+            key=lambda ng: -ngram_counts[ng],
+        )
+        phrases = _merge_overlapping(overused)[:AVOID_LIST_MAX_PHRASES]
+
+    if recent_asst:
+        dialect_words = _detect_dialect(recent_asst[-3:])
+
+    if not phrases and not dialect_words:
         return ctx
 
-    window = recent_asst[-6:]
+    parts: list[str] = []
+    if phrases:
+        parts.append("Do NOT reuse these phrases (find fresh alternatives):\n- " + "\n- ".join(phrases))
+    if dialect_words:
+        parts.append("Do NOT use dialect spelling or phonetic contractions (write standard English instead):\n- " + ", ".join(dialect_words))
 
-    from collections import Counter
-    ngram_counts: Counter[str] = Counter()
-    for msg in window:
-        seen: set[str] = set()
-        for ng in _extract_ngrams(msg, AVOID_LIST_NGRAM):
-            if ng not in seen:
-                ngram_counts[ng] += 1
-                seen.add(ng)
-
-    overused = sorted(
-        [ng for ng, count in ngram_counts.items()
-         if count >= AVOID_LIST_MIN_OCCURRENCES],
-        key=lambda ng: -ngram_counts[ng],
-    )
-
-    if not overused:
-        return ctx
-
-    phrases = _merge_overlapping(overused)[:AVOID_LIST_MAX_PHRASES]
-    avoid_block = "\n\nDo NOT reuse these phrases (find fresh alternatives):\n- " + "\n- ".join(phrases)
-    ctx["post_prompt"] += avoid_block
+    ctx["post_prompt"] += "\n\n" + "\n\n".join(parts)
     ctx["_avoid_list"] = phrases
-    _log.info("Injected avoid list: %d phrases", len(phrases))
+    ctx["_dialect_violations"] = dialect_words
+    if phrases:
+        _log.info("Injected avoid list: %d phrases", len(phrases))
+    if dialect_words:
+        _log.info("Injected dialect avoid: %s", dialect_words)
     return ctx
 
 

--- a/projects/rp/tests/test_avoid_list.py
+++ b/projects/rp/tests/test_avoid_list.py
@@ -1,0 +1,92 @@
+"""Tests for inject_avoid_list: phrase repetition + dialect detection."""
+
+from projects.rp.pipeline import inject_avoid_list, _detect_dialect
+
+
+def _ctx_with_assistant_messages(messages: list[str]) -> dict:
+    return {
+        "messages": [{"role": "assistant", "content": m} for m in messages],
+        "post_prompt": "",
+    }
+
+
+class TestAvoidListThreshold:
+    def test_kicks_in_after_two_messages(self):
+        ctx = _ctx_with_assistant_messages([
+            "Her tongue darted out to wet suddenly dry lips as she shifted.",
+            "Her tongue darted out to wet suddenly dry lips nervously.",
+        ])
+        result = inject_avoid_list(ctx)
+        assert result.get("_avoid_list"), "Should detect repeats after 2 messages"
+
+    def test_no_injection_with_one_message(self):
+        ctx = _ctx_with_assistant_messages([
+            "Her tongue darted out to wet suddenly dry lips as she shifted.",
+        ])
+        result = inject_avoid_list(ctx)
+        assert not result.get("_avoid_list")
+
+    def test_no_injection_when_no_repeats(self):
+        ctx = _ctx_with_assistant_messages([
+            "She walked to the window and looked outside.",
+            "The coffee was cold but she drank it anyway.",
+        ])
+        result = inject_avoid_list(ctx)
+        assert not result.get("_avoid_list")
+
+
+class TestShortNgrams:
+    def test_catches_three_word_repeats(self):
+        ctx = _ctx_with_assistant_messages([
+            "Her hazel eyes widened as she looked at him.",
+            "Her hazel eyes sparkled with mischief.",
+            "Her hazel eyes narrowed suspiciously.",
+        ])
+        result = inject_avoid_list(ctx)
+        assert result.get("_avoid_list")
+        joined = " ".join(result["_avoid_list"])
+        assert "hazel eyes" in joined
+
+
+class TestDialectDetection:
+    def test_detects_dialect_in_single_message(self):
+        ctx = _ctx_with_assistant_messages([
+            "Whaddya say, newbie? Gonna show me whatcha got?",
+        ])
+        result = inject_avoid_list(ctx)
+        assert result.get("_dialect_violations")
+        assert "whaddya" in result["_dialect_violations"]
+        assert "gonna" in result["_dialect_violations"]
+
+    def test_dialect_injected_into_post_prompt(self):
+        ctx = _ctx_with_assistant_messages([
+            "Well ain't that somethin'. Gonna be a wild ride, y'know?",
+        ])
+        result = inject_avoid_list(ctx)
+        assert "dialect" in result["post_prompt"].lower() or "phonetic" in result["post_prompt"].lower()
+
+    def test_no_dialect_for_clean_text(self):
+        ctx = _ctx_with_assistant_messages([
+            "She smiled and turned to face the window.",
+        ])
+        result = inject_avoid_list(ctx)
+        assert not result.get("_dialect_violations")
+
+    def test_detect_dialect_helper(self):
+        words = _detect_dialect(["Gonna be thinkin' about whatcha said"])
+        assert "gonna" in words
+        assert "thinkin'" in words
+        assert "whatcha" in words
+
+
+class TestCombined:
+    def test_both_phrases_and_dialect(self):
+        ctx = _ctx_with_assistant_messages([
+            "Her tongue darted out to wet suddenly dry lips. Gonna be fun, ain't it?",
+            "Her tongue darted out to wet suddenly dry lips. Whatcha thinkin'?",
+        ])
+        result = inject_avoid_list(ctx)
+        assert result.get("_avoid_list")
+        assert result.get("_dialect_violations")
+        assert "Do NOT reuse" in result["post_prompt"]
+        assert "dialect" in result["post_prompt"].lower() or "phonetic" in result["post_prompt"].lower()


### PR DESCRIPTION
## Summary
- Avoid-list pre-hook now activates after **2** assistant messages (was 4) — catches repetition before patterns set in
- Added **3-gram detection** alongside existing 4-grams — catches short repeats like "hazel eyes widening"
- Added **dialect detection** — flags phonetic contractions (gonna, whaddya, thinkin', ain't, etc.) from the first assistant message and injects "write standard English" into the post-prompt
- Dialect and phrase avoidance are separate blocks in the post-prompt

## Context
Analysis of Amber conversations with mag-mell showed dialect appearing in 0-100% of messages per conversation, stochastically. Once the model writes dialect in early messages, it self-reinforces. The old avoid-list needed 4 messages before activating — too late.

## Test plan
```bash
cd /mnt/d/prg/plum-rp-avoid-list
/mnt/d/prg/plum/projects/aiserver/.venv/bin/python -m pytest projects/rp/tests/test_avoid_list.py -v
/mnt/d/prg/plum/projects/aiserver/.venv/bin/python -m pytest projects/rp/tests/ -q
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)