### PR TITLE
fix(rp): make characters aware of other AI participants in multi-char

### DIFF
--- a/projects/rp/pipeline.py
+++ b/projects/rp/pipeline.py
@@ -271,6 +271,25 @@ def assemble_prompt(ctx: dict) -> dict:
     ctx["system_prompt"] = render_template(system_part, values)
     ctx["post_prompt"] = render_template(post_part, values) if post_part else ""
 
+    if is_multi:
+        other_names = []
+        for cc in char_cards:
+            cd = cc.get("card_data", {}).get("data", cc.get("card_data", {}))
+            n = cd.get("name", "")
+            if n and n != active_name:
+                other_names.append(n)
+        if other_names:
+            others_str = ", ".join(other_names)
+            ctx["system_prompt"] += (
+                f"\n\nOther characters present: {others_str}. "
+                f"Their messages appear as [{others_str}]: in the conversation. "
+                f"React to what they say and do — acknowledge their presence and actions."
+            )
+            ctx["post_prompt"] += (
+                f"\nAlso do NOT write for {others_str}. "
+                f"But DO react to and acknowledge {others_str}'s actions and dialogue."
+            )
+
     raw_items = _parse_style_items(style_part)
     ctx["_style_pool"] = [render_template(item, values) for item in raw_items]
 


### PR DESCRIPTION
## Summary
- System prompt only said "roleplay with {{user}} where you are {{char}}" — other AI characters weren't mentioned
- Characters like Amber would completely ignore Lesbot's messages even though they appeared in chat history
- Added "Other characters present: ..." to system prompt with instruction to react to their actions
- Extended post prompt's "don't write for" rule to cover other AI characters too

## Test plan
```bash
source projects/aiserver/.venv/bin/activate
python -m pytest projects/rp/tests/ -q  # 521 pass

# Manual: conv 173, send message — verify Amber acknowledges Lesbot's actions in her response
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)