### PR TITLE
fix(rp): harder anti-repetition for auto-reply user generation

### DIFF
--- a/projects/rp/pipeline.py
+++ b/projects/rp/pipeline.py
@@ -67,8 +67,11 @@ def expand_variables(ctx: dict) -> dict:
     if ctx.get("post_prompt"):
         ctx["post_prompt"] = replace(ctx["post_prompt"])
 
+    active_card_id = ctx.get("_active_card", {}).get("id") if is_multi else None
     recent_asst = [m["content"][:80] for m in ctx.get("messages", [])
-                   if m.get("role") == "assistant"][-3:]
+                   if m.get("role") == "assistant"
+                   and (active_card_id is None
+                        or m.get("_character_card_id") == active_card_id)][-3:]
     if len(recent_asst) >= 2:
         ctx["post_prompt"] += (
             "\n\nDo NOT open with the same action, gesture, or phrase as your recent messages. "

--- a/projects/rp/routes.py
+++ b/projects/rp/routes.py
@@ -1490,9 +1490,14 @@ def setup(app: FastAPI, ollama, resolve_model=None):
 
         if generating_as_user:
             model = _resolve_model("qwen3:14b")
+            recent_user_texts = [m["content"] for m in messages if m["role"] == "user"][-3:]
+            has_repetition = (len(recent_user_texts) >= 2
+                              and recent_user_texts[-1][:80] == recent_user_texts[-2][:80])
             ollama_options = {
-                "temperature": 0.7, "num_predict": 256, "think": False,
-                "repeat_penalty": 1.15, "repeat_last_n": 256,
+                "temperature": 1.1 if has_repetition else 0.7,
+                "num_predict": 256, "think": False,
+                "repeat_penalty": 1.3 if has_repetition else 1.15,
+                "repeat_last_n": 512 if has_repetition else 256,
             }
         else:
             model = _resolve_model(conv["model"])


### PR DESCRIPTION
## Summary
- **Multi-char filter**: Anti-repetition examples now filter by active character card ID, so each character only sees its own openings as "don't repeat" examples (not other characters')
- **Temperature escalation**: When last 2 auto-generated user messages share the same opening, bump temperature (0.7→1.1), repeat_penalty (1.15→1.3), repeat_last_n (256→512) to break the loop
- Addresses conv 173 where Valentina generated "I take a slow step forward, my boots scuffing the floor again..." verbatim 9 times in a row — the prompt-level instruction alone wasn't enough for mn-12b

## Test plan
```bash
source projects/aiserver/.venv/bin/activate
python -m pytest projects/rp/tests/ -q  # 521 pass

# Manual: auto-reply in multi-char conv, verify user messages vary
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)