### PR TITLE
fix(rp): remove pronoun bracket from priming anchor

### DIFF
--- a/projects/rp/prompt_builder.py
+++ b/projects/rp/prompt_builder.py
@@ -115,12 +115,7 @@ def build_chat_messages(ctx: dict) -> list[dict]:
     if ctx.get("post_prompt"):
         chat_messages.append({"role": "system", "content": ctx["post_prompt"]})
     ai_name = get_ai_name(ctx)
-    pronouns = get_ai_pronouns(ctx)
-    if pronouns:
-        anchor = f"{ai_name} [{pronouns}] "
-    else:
-        anchor = ai_name + " "
-    chat_messages.append({"role": "assistant", "content": anchor})
+    chat_messages.append({"role": "assistant", "content": ai_name + " "})
     return chat_messages
 
 
@@ -177,12 +172,7 @@ def build_multi_char_messages(ctx: dict, active_card_id: int,
     active_card = ctx.get("_active_card", ctx.get("ai_card", {}))
     card_data = active_card.get("card_data", {}).get("data", active_card.get("card_data", {}))
     ai_name = card_data.get("name", "Character")
-    pronouns = card_data.get("pronouns", "") or infer_pronouns(card_data.get("description", ""))
-    if pronouns:
-        anchor = f"{ai_name} [{pronouns}] "
-    else:
-        anchor = ai_name + " "
-    chat_messages.append({"role": "assistant", "content": anchor})
+    chat_messages.append({"role": "assistant", "content": ai_name + " "})
     return chat_messages
 
 

--- a/projects/rp/tests/test_prompt_builder.py
+++ b/projects/rp/tests/test_prompt_builder.py
@@ -172,25 +172,25 @@ class TestGetAiPronouns:
 
 
 class TestBuildChatMessagesWithPronouns:
-    def test_includes_pronouns_in_anchor(self):
+    def test_anchor_is_name_only(self):
         ctx = _ctx(ai_name="Kasa", ai_pronouns="she/her")
         msgs = build_chat_messages(ctx)
-        assert msgs[-1]["content"] == "Kasa [she/her] "
+        assert msgs[-1]["content"] == "Kasa "
 
     def test_no_pronouns_plain_anchor(self):
         ctx = _ctx(ai_name="Kasa")
         msgs = build_chat_messages(ctx)
         assert msgs[-1]["content"] == "Kasa "
 
-    def test_he_him_pronouns(self):
+    def test_anchor_ignores_pronouns(self):
         ctx = _ctx(ai_name="Marcus", ai_pronouns="he/him")
         msgs = build_chat_messages(ctx)
-        assert msgs[-1]["content"] == "Marcus [he/him] "
+        assert msgs[-1]["content"] == "Marcus "
 
-    def test_they_them_pronouns(self):
+    def test_they_them_anchor_is_name_only(self):
         ctx = _ctx(ai_name="River", ai_pronouns="they/them")
         msgs = build_chat_messages(ctx)
-        assert msgs[-1]["content"] == "River [they/them] "
+        assert msgs[-1]["content"] == "River "
 
 
 class TestBudgetToJson:


### PR DESCRIPTION
## Summary
- Priming anchor `Name [she/her]` triggers card-format completion in Skyfall-31B (and likely other RP finetunes trained on SillyTavern card data)
- Model dumps character description ("22, bratty-sweet, neurodivergent...") instead of writing roleplay
- Once a card dump enters message history it creates a death spiral of repeated dumps and verbatim repetition (conv 178, messages 5986-6000)
- Pronouns are already in the system prompt — the anchor bracket was redundant
- Simplified anchor to just `Name ` in both single-char and multi-char paths

## Test plan
```bash
source projects/aiserver/.venv/bin/activate
pytest projects/rp/tests/ -q
# 521 passed

# Restart server, open conv 178 or new conversation with Skyfall-31B
# Verify responses start with narrative, not character descriptions
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)