### PR TITLE
fix(rp): deduplicate avoid-list sub-phrases

### DIFF
--- a/projects/rp/pipeline.py
+++ b/projects/rp/pipeline.py
@@ -615,7 +615,7 @@ AVOID_LIST_NGRAM = 4
 AVOID_LIST_SHORT_NGRAM = 3
 AVOID_LIST_MIN_OCCURRENCES = 2
 AVOID_LIST_MAX_PHRASES = 12
-AVOID_LIST_MIN_MESSAGES = 2
+AVOID_LIST_MIN_MESSAGES = 3
 
 DIALECT_PATTERNS = re.compile(
     r"\b(whaddya|whatcha|lookit|gonna|wanna|gotta|kinda|sorta|lemme|dunno)"
@@ -628,7 +628,7 @@ DIALECT_PATTERNS = re.compile(
 
 
 def _merge_overlapping(ngrams: list[str]) -> list[str]:
-    """Merge overlapping ngrams into longer phrases."""
+    """Merge overlapping ngrams into longer phrases, then drop sub-phrases."""
     merged: list[str] = []
     used: set[int] = set()
     for i, ng in enumerate(ngrams):
@@ -650,7 +650,12 @@ def _merge_overlapping(ngrams: list[str]) -> list[str]:
             if not found:
                 break
         merged.append(chain)
-    return merged
+    deduped: list[str] = []
+    for phrase in merged:
+        if any(phrase != other and phrase in other for other in merged):
+            continue
+        deduped.append(phrase)
+    return deduped
 
 
 def _detect_dialect(messages: list[str]) -> list[str]:

--- a/projects/rp/tests/test_avoid_list.py
+++ b/projects/rp/tests/test_avoid_list.py
@@ -11,13 +11,22 @@ def _ctx_with_assistant_messages(messages: list[str]) -> dict:
 
 
 class TestAvoidListThreshold:
-    def test_kicks_in_after_two_messages(self):
+    def test_kicks_in_after_three_messages(self):
+        ctx = _ctx_with_assistant_messages([
+            "Her tongue darted out to wet suddenly dry lips as she shifted.",
+            "Her tongue darted out to wet suddenly dry lips nervously.",
+            "Her tongue darted out to wet suddenly dry lips again.",
+        ])
+        result = inject_avoid_list(ctx)
+        assert result.get("_avoid_list"), "Should detect repeats after 3 messages"
+
+    def test_no_injection_with_two_messages(self):
         ctx = _ctx_with_assistant_messages([
             "Her tongue darted out to wet suddenly dry lips as she shifted.",
             "Her tongue darted out to wet suddenly dry lips nervously.",
         ])
         result = inject_avoid_list(ctx)
-        assert result.get("_avoid_list"), "Should detect repeats after 2 messages"
+        assert not result.get("_avoid_list")
 
     def test_no_injection_with_one_message(self):
         ctx = _ctx_with_assistant_messages([
@@ -46,6 +55,18 @@ class TestShortNgrams:
         assert result.get("_avoid_list")
         joined = " ".join(result["_avoid_list"])
         assert "hazel eyes" in joined
+
+    def test_subsumes_shorter_phrases(self):
+        ctx = _ctx_with_assistant_messages([
+            "She swallowed hard and looked away from the door.",
+            "She swallowed hard and tried to breathe.",
+            "She swallowed hard and clenched her fists.",
+        ])
+        result = inject_avoid_list(ctx)
+        phrases = result.get("_avoid_list", [])
+        assert any("swallowed hard" in p for p in phrases)
+        assert not any(p == "she swallowed" for p in phrases), \
+            "Sub-phrase 'she swallowed' should be subsumed by 'she swallowed hard'"
 
 
 class TestDialectDetection:
@@ -84,6 +105,7 @@ class TestCombined:
         ctx = _ctx_with_assistant_messages([
             "Her tongue darted out to wet suddenly dry lips. Gonna be fun, ain't it?",
             "Her tongue darted out to wet suddenly dry lips. Whatcha thinkin'?",
+            "Her tongue darted out to wet suddenly dry lips. Gonna try again.",
         ])
         result = inject_avoid_list(ctx)
         assert result.get("_avoid_list")


### PR DESCRIPTION
## Summary
- 3-gram detection (PR #198) produces overlapping sub-phrases: `she swallowed hard` + `she swallowed` + `swallowed hard` all survive as separate avoid-list entries
- This floods the post-prompt with redundant "don't say X" constraints, over-constraining the model into flat, generic prose (conv 180 regression vs conv 171)
- `_merge_overlapping` now drops phrases that are substrings of longer phrases already in the list
- `AVOID_LIST_MIN_MESSAGES` raised from 2 → 3 to avoid activating before enough signal accumulates

## Test plan
```bash
source projects/aiserver/.venv/bin/activate
pytest projects/rp/tests/ -q
# 523 passed

# Restart server, start new Drowned Rat conv with Amber on mn-12b
# Verify avoid list has distinct phrases, not redundant sub-phrases
# Compare writing quality against conv 171 benchmark
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)